### PR TITLE
Support http_proxy environment variables and the --proxy= switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Commands
  * `clean` - Removes any generated project files and the `out` dir
  * `configure` - Generates project build files for the current platform
  * `copy` - Copies a compiled bindings to an appropriate dir for runtime detection
- * `install` - Installs node development files for the given version
+ * `install` - Installs node development files for the given version.  Respects http_proxy/HTTP_PROXY and --proxy=<proxyurl> when downloading.
  * `list` - Lists the currently installed node development file versions
  * `remove` - Removes a node development files for a given version
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,7 +1,7 @@
 
 module.exports = exports = install
 
-exports.usage = 'Install node development files for the specified node version'
+exports.usage = 'Install node development files for the specified node version.  Respects http_proxy/HTTP_PROXY and --proxy=<proxyurl> when downloading.'
 
 /**
  * Module dependencies.
@@ -96,7 +96,14 @@ function install (gyp, argv, callback) {
 
     gyp.info('downloading:', tarballUrl)
 
-    request(tarballUrl, downloadError)
+    var requestOpts = { uri: tarballUrl };
+    var proxyUrl = gyp.opts.proxy || process.env.http_proxy || process.env.HTTP_PROXY;
+    if (proxyUrl) {
+      gyp.verbose('using proxy:', proxyUrl);
+      requestOpts.proxy = proxyUrl;
+    }
+
+    request(requestOpts, downloadError)
       .pipe(zlib.createGunzip())
       .pipe(parser)
     parser.on('entry', onEntry)

--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -63,6 +63,7 @@ proto.configDefs = {
   , ensure: Boolean  // 'install'
   , verbose: Boolean // everywhere
   , solution: String // 'build' (windows only)
+  , proxy: String // 'install'
 }
 
 proto.shorthands = {}


### PR DESCRIPTION
Both the 'install' and 'configure' commands support the --proxy
switch.
