### PR TITLE
add check for gmake on openbsd

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -11,13 +11,15 @@ var fs = require('graceful-fs')
   , which = require('which')
   , mkdirp = require('./util/mkdirp')
   , win = process.platform == 'win32'
+  , openbsd = process.platform == 'openbsd
 
 exports.usage = 'Invokes `' + (win ? 'msbuild' : 'make') + '` and builds the module'
 
 function build (gyp, argv, callback) {
 
   gyp.verbose('build args', argv)
-  var command = win ? 'msbuild' : 'make'
+  var builder = openbsd ? 'gmake' : 'make'
+  var command = win ? 'msbuild' : builder
     , buildDir = path.resolve('build')
     , configPath = path.resolve(buildDir, 'config.gypi')
     , buildType


### PR DESCRIPTION
OpenBSD's make doesn't have a -C option, this adds a check for openbsd and sets make to gmake.

Perhaps it would be good to check ~/.npmrc ( maybe /etc/npmrc would be even more awesome ) for a "make" option? 
