### PR TITLE
Recognize OpenBSD in GetFlavor

### DIFF
--- a/legacy/tools/gyp/pylib/gyp/common.py
+++ b/legacy/tools/gyp/pylib/gyp/common.py
@@ -355,6 +355,7 @@ def GetFlavor(params):
     'sunos5': 'solaris',
     'freebsd7': 'freebsd',
     'freebsd8': 'freebsd',
+    'openbsd5': 'openbsd',
   }
   flavor = flavors.get(sys.platform, 'linux')
   return params.get('flavor', flavor)


### PR DESCRIPTION
Without this change, OpenBSD is recognized as linux, which
breaks node-fibers installation on OpenBSD.
