### PR TITLE
Prefer "python2" over "python" for running gyp, because gyp does not work with Python 3

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -17,7 +17,7 @@ exports.usage = 'Generates ' + (win ? 'MSVC project files' : 'a Makefile') + ' f
 
 function configure (gyp, argv, callback) {
 
-  var python = process.env.PYTHON || gyp.opts.python || 'python'
+  var python = process.env.PYTHON || gyp.opts.python || 'python2' || 'python'
     , buildDir = path.resolve('build')
     , configPath
     , nodeDir


### PR DESCRIPTION
Fixes GH-64

```
$ which python
/Users/marca/dev/git-repos/node-gyp/py32.venv/bin/python
$ python -V
Python 3.2.3
$ git checkout master
Switched to branch 'master'
$ rm -rf ~/.node-gyp
$ pwd
/Users/marca/dev/git-repos/node-gyp/example_node_modules/ws
$ ../../bin/node-gyp.js configure
...
  File "/Users/marca/.node-gyp/0.6.18/tools/gyp_addon", line 40
    print 'Error running GYP'
                            ^
SyntaxError: invalid syntax
...
$ git checkout prefer-python2 
Switched to branch 'prefer-python2'
$ PAGER=cat git log -n 1
commit 8acc137d9fb8e20dd061fdcf0649ba7fa12e9267
Author: Marc Abramowitz <marc@marc-abramowitz.com>
Date:   Wed Jun 6 13:44:30 2012 -0700

    Prefer "python2" over "python" for running gyp, because gyp does not
    work with Python 3.

    Fixes GH-64
$ rm -rf ~/.node-gyp
$ ../../bin/node-gyp.js configure
info it worked if it ends with ok 
info downloading: http://nodejs.org/dist/v0.6.18/node-v0.6.18.tar.gz 
spawn python2 [ '/Users/marca/.node-gyp/0.6.18/tools/gyp_addon',
  'binding.gyp',
  '-I/Users/marca/dev/git-repos/node-gyp/example_node_modules/ws/build/config.gypi',
  '-f',
  'make' ]
info done ok
```
