### PR TITLE
Add the 'gyp' log heading

### DIFF
--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -28,6 +28,9 @@ var fs = require('graceful-fs')
       , 'rm': 'remove'
     }
 
+// differentiate node-gyp's logs from npm's
+log.heading = 'gyp'
+
 /**
  * The `gyp` function.
  */


### PR DESCRIPTION
This makes gyp logs dovetail into the npm logs in a bit more slick manner.
