### PR TITLE
Make linking 64-bit addons with VCExpress 2010 + Windows 7.1 SDK work out of the box

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -13,7 +13,10 @@ var fs = require('graceful-fs')
   , semver = require('semver')
   , mkdirp = require('mkdirp')
   , exec = require('child_process').exec
+  , spawn = require('child_process').spawn
   , win = process.platform == 'win32'
+  , hasVCExpress = false
+  , hasWin71SDK = false
 
 exports.usage = 'Generates ' + (win ? 'MSVC project files' : 'a Makefile') + ' for the current module'
 
@@ -24,7 +27,18 @@ function configure (gyp, argv, callback) {
     , configPath
     , nodeDir
 
-  checkPython()
+  if (win) {
+    checkVCExpress(function () {
+      if (hasVCExpress) {
+        checkWin71SDK(function () {
+          checkPython()
+        })
+      } else {
+        checkPython()
+      }
+    })
+  } else
+    checkPython()
 
   // Make sure that Python is in the $PATH
   function checkPython () {
@@ -100,6 +114,33 @@ function configure (gyp, argv, callback) {
     callback(new Error('Python executable "' + python
           + '" is v' + badVersion + ', which is not supported by gyp.\n'
           + 'You can pass the --python switch to point to Python >= v2.5.0 & < 3.0.0.'))
+  }
+
+  function checkWin71SDK(cb) {
+    spawn('reg', ['query', 'HKLM\\Software\\Microsoft\\Microsoft SDKs\\Windows\\v7.1', '/v', 'InstallationFolder'])
+         .on('exit', function (code) {
+           hasWin71SDK = (code === 0)
+           cb()
+         })
+  }
+
+  function checkVCExpress64(cb) {
+    var cp = spawn('cmd', ['/C', '%WINDIR%\\SysWOW64\\reg', 'query', 'HKLM\\Software\\Microsoft\\VCExpress\\10.0\\Setup\\VC', '/v', 'ProductDir'])
+    cp.on('exit', function (code) {
+      hasVCExpress = (code === 0)
+      cb()
+    })
+  }
+
+  function checkVCExpress(cb) {
+    spawn('reg', ['query', 'HKLM\\Software\\Microsoft\\VCExpress\\10.0\\Setup\\VC', '/v', 'ProductDir'])
+         .on('exit', function (code) {
+           if (code !== 0) {
+             checkVCExpress64(cb)
+           } else {
+             cb()
+           }
+         })
   }
 
   function getNodeDir () {
@@ -203,6 +244,11 @@ function configure (gyp, argv, callback) {
 
     // set the target_arch variable
     variables.target_arch = gyp.opts.arch || process.arch || 'ia32'
+
+    // set the toolset for 64-bit VCExpress users
+    if (win && variables.target_arch === 'x64' && hasVCExpress && hasWin71SDK) {
+      defaults.msbuild_toolset = 'Windows7.1SDK'
+    }
 
     // set the node development directory
     variables.nodedir = nodeDir


### PR DESCRIPTION
This allows you to link 64-bit addons under node-gyp in any command prompt and not just the Windows 7.1 SDK command prompt.

Fixes #112
