### PR TITLE
Fix builds on some windows machines

### DIFF
--- a/legacy/common.gypi
+++ b/legacy/common.gypi
@@ -68,9 +68,6 @@
             'EnableIntrinsicFunctions': 'true',
             'RuntimeTypeInfo': 'false',
             'ExceptionHandling': '0',
-            'AdditionalOptions': [
-              '/MP', # compile across multiple CPUs
-            ],
           },
           'VCLibrarianTool': {
             'AdditionalOptions': [


### PR DESCRIPTION
The /MP option causes lockups on some multi-core windows boxes during the build process
