### PR TITLE
Allow user to change the binding.gyp filename to something more useful 

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -331,9 +331,13 @@ function configure (gyp, argv, callback) {
     // tell make to write its output into the same dir
     argv.push('-Goutput_dir=.')
 
-    // enforce use of the "binding.gyp" file
-    argv.unshift('binding.gyp')
-
+    // Don't enforce use of the "binding.gyp" file, but let the user specify their own .gyp file via the -binding parameter
+    if ('binding' in gyp.opts) {
+      argv.unshift(gyp.opts.binding);
+    }
+    else {
+      argv.unshift('binding.gyp')
+    }
     // execute `gyp` from the current target nodedir
     argv.unshift(gyp_script)
 

--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -84,6 +84,7 @@ proto.configDefs = {
   , nodedir: String   // 'configure'
   , loglevel: String  // everywhere
   , python: String    // 'configure'
+  , binding: String   // 'configure'
 }
 
 /**


### PR DESCRIPTION
I've added a --binding variable to the options.  When present this will specify the .gyp filename for the project.

Just makes is simpler in many cases where we have plenty of gyp files.
