### PR TITLE
Allow use of build file other than 'binding.gyp'

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -332,7 +332,9 @@ function configure (gyp, argv, callback) {
     argv.push('-Goutput_dir=.')
 
     // enforce use of the "binding.gyp" file
-    argv.unshift('binding.gyp')
+    var bindingFile = gyp.opts.bindingfile || 'binding.gyp';
+    log.verbose('gyp', "using binding file '" + bindingFile + "'")
+    argv.unshift(bindingFile)
 
     // execute `gyp` from the current target nodedir
     argv.unshift(gyp_script)

--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -86,6 +86,7 @@ proto.configDefs = {
   , python: String    // 'configure'
   , 'dist-url': String // 'install'
   , jobs: String      // 'build'
+  , bindingfile: String // 'binding.gyp'
 }
 
 /**
@@ -98,6 +99,7 @@ proto.shorthands = {
   , debug: '--debug'
   , silly: '--loglevel=silly'
   , verbose: '--loglevel=verbose'
+  , F: '--bindingfile'
 }
 
 /**


### PR DESCRIPTION
I added the command line argument "--bindingfile=file" (or "-F [file]" shorthand) to use a build file other than binding.gyp.  (I would have used "-f" to be like make but it seemed like -f was already being used.)
