### PR TITLE
VS2012Express support on windows 8

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -27,13 +27,15 @@ function configure (gyp, argv, callback) {
     , hasVCExpress = false
     , hasVC2012Express = false
     , hasWin71SDK = false
+    , hasWin8SDK = false
     , configPath
     , nodeDir
 
+
   if (win) {
     checkVCExpress(function () {
-      if (hasVCExpress) {
-        checkWin71SDK(function () {
+      if (hasVCExpress || hasVC2012Express) {
+        checkWinSDK(function () {
           checkPython()
         })
       } else {
@@ -116,12 +118,26 @@ function configure (gyp, argv, callback) {
           + 'You can pass the --python switch to point to Python >= v2.5.0 & < 3.0.0.'))
   }
 
+  function checkWinSDK(cb) {
+    checkWin71SDK(function() {
+      checkWin8SDK(cb);
+    })
+  }
+
   function checkWin71SDK(cb) {
     spawn('reg', ['query', 'HKLM\\Software\\Microsoft\\Microsoft SDKs\\Windows\\v7.1', '/v', 'InstallationFolder'])
          .on('exit', function (code) {
            hasWin71SDK = (code === 0)
            cb()
          })
+  }
+
+  function checkWin8SDK(cb) {
+    var cp = spawn('reg', ['query', 'HKLM\\Software\\Microsoft\\Windows Kits\\Installed Products', '/f', 'Windows Software Development Kit x86', '/reg:32'])
+    cp.on('exit', function (code) {
+      hasWin8SDK = (code === 0)
+      cb()
+    })
   }
 
   function checkVC2012Express64(cb) {
@@ -264,7 +280,7 @@ function configure (gyp, argv, callback) {
 
     // set the toolset for VCExpress users
     if (win) {
-      if (hasVC2012Express) {
+      if (hasVC2012Express && hasWin8SDK) {
         defaults.msbuild_toolset = 'v110'
       } else if (hasVCExpress && hasWin71SDK) {
         defaults.msbuild_toolset = 'Windows7.1SDK'


### PR DESCRIPTION
I run across this problem while compiling node-expat https://github.com/astro/node-expat/issues/50, now is compiling well.

The [VS2012 Express](http://www.microsoft.com/visualstudio/eng/downloads#d-2012-express) installs windows 8 SDK, so no need to manual install it.

Can you add this info on the readme?

btw, I thing is also possible to add support for VC2010.

Thank you.
