### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ You will also need to install:
     * [Python][windows-python] ([`v2.7.3`][windows-python-v2.7.3] recommended, `v3.x.x` is not supported)
     * Microsoft Visual C++ ([Express][msvc] version works well)
       * For 64-bit builds of node and native modules you will _also_ need the [Windows 7 64-bit SDK][win7sdk]
+        * If you get errors that the 64 bit compilers are not installed you may also need the [compiler update for the Windows SDK 7.1]
 
 How to Use
 ----------
@@ -150,3 +151,4 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 [windows-python-v2.7.3]: http://www.python.org/download/releases/2.7.3#download
 [msvc]: http://www.microsoft.com/visualstudio/en-us/products/2010-editions/visual-cpp-express
 [win7sdk]: http://www.microsoft.com/download/en/details.aspx?displayLang=en&id=8279
+[compiler update for the Windows SDK 7.1]: http://www.microsoft.com/en-us/download/details.aspx?id=4422


### PR DESCRIPTION
There is a known issue with the Windows SDK and Visual Studio. It seems that when both are installed users may be missing the 64 bit compilers which will make using node-gyp for 64 bit really frustrating. It took me quite a bit of googling to find the information about this issue, as it didn't come up when searching for the various error messages and such. I've added a note to the readme to make it easier for people to find the compiler update and get node-gyp working properly on 64 bit systems with this common issue. :D

see the kb article: http://support.microsoft.com/?kbid=2519277 for some details. I had Visual Studio 2010 and 2012 fully updated before getting the SDK, the article describes a different scenario which leads to the same problem.
