### PR TITLE
issue #65: fix some shell escaping for building in a dir with spaces

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -387,12 +387,16 @@ function configure (gyp, argv, callback) {
       output_dir = buildDir
     }
 
-    argv.push('-I', addon_gypi)
-    argv.push('-I', common_gypi)
+    function shellEscape(str) {
+      return str.replace(/(["\s'$`\\])/g, '\\$1');
+    };
+
+    argv.push('-I', shellEscape(addon_gypi))
+    argv.push('-I', shellEscape(common_gypi))
     argv.push('-Dlibrary=shared_library')
     argv.push('-Dvisibility=default')
-    argv.push('-Dnode_root_dir=' + nodeDir)
-    argv.push('-Dmodule_root_dir=' + process.cwd())
+    argv.push('-Dnode_root_dir=' + shellEscape(nodeDir))
+    argv.push('-Dmodule_root_dir=' + shellEscape(process.cwd()))
     argv.push('--depth=.')
 
     // tell gyp to write the Makefile/Solution files into output_dir


### PR DESCRIPTION
When I manually patch my "NODE_PREFIX/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js" with this patch, then at least https://github.com/chrisa/node-dtrace-provider/issues/25 (and hence https://github.com/trentm/node-bunyan/issues/58) is fixed.
