### PR TITLE
Added help to the Windows install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ You will also need to install:
     * Windows XP/Vista/7:
       * Microsoft Visual Studio C++ 2010 ([Express][msvc2010] version works well)
       * For 64-bit builds of node and native modules you will _**also**_ need the [Windows 7 64-bit SDK][win7sdk]
+        * If the install fails, try uninstalling any C++ 2010 x64&x86 Redistributable that you have installed first.
       * If you get errors that the 64-bit compilers are not installed you may also need the [compiler update for the Windows SDK 7.1]
     * Windows 8:
       * Microsoft Visual Studio C++ 2012 for Windows Desktop ([Express][msvc2012] version works well)


### PR DESCRIPTION
When attempting to install the Windows 7.1 SDK it may error without reason. This can be caused by having prior C++ 2010 redistributables installed. Uninstalling these redistributables will allow the Windows 7.1 SDK to install successfully.

References:
http://support.microsoft.com/kb/2717426
http://stackoverflow.com/questions/1901279/windows-7-sdk-installation-failure
