### PR TITLE
Generator: make: Add support for out-of-tree builds

### DIFF
--- a/gyp/pylib/gyp/generator/make.py
+++ b/gyp/pylib/gyp/generator/make.py
@@ -1944,11 +1944,21 @@ def GenerateOutput(target_list, target_dicts, data, params):
     base_path = gyp.common.RelativePath(os.path.dirname(build_file),
                                         options.depth)
     # We write the file in the base_path directory.
-    output_file = os.path.join(options.depth, base_path, base_name)
+    if not os.path.abspath(build_file).startswith(os.getcwd()):
+      output_path = gyp.common.RelativePath(os.path.dirname(build_file),
+       options.toplevel_dir)
+      output_file = os.path.join(output_path, base_name)
+      gyp.DebugOutput(gyp.DEBUG_GENERAL, "toplevel='%s', output_path='%s'"
+       % (options.toplevel_dir, output_path))
+    else:
+      output_file = os.path.join(options.depth, base_path, base_name)
+    
     if options.generator_output:
       output_file = os.path.join(options.generator_output, output_file)
     base_path = gyp.common.RelativePath(os.path.dirname(build_file),
                                         options.toplevel_dir)
+    gyp.DebugOutput(gyp.DEBUG_GENERAL, "('%s', '%s') = '%s', '%s'"
+     % (build_file, base_name, base_path, output_file))
     return base_path, output_file
 
   # TODO:  search for the first non-'Default' target.  This can go
@@ -1966,12 +1976,21 @@ def GenerateOutput(target_list, target_dicts, data, params):
 
   srcdir = '.'
   makefile_name = 'Makefile' + options.suffix
-  makefile_path = os.path.join(options.toplevel_dir, makefile_name)
+  makefile_path = os.path.abspath(os.path.join(builddir_name, makefile_name))
   if options.generator_output:
     global srcdir_prefix
     makefile_path = os.path.join(options.generator_output, makefile_path)
-    srcdir = gyp.common.RelativePath(srcdir, options.generator_output)
+    if options.toplevel_dir:
+      srcdir = options.toplevel_dir
+    else:
+      srcdir = gyp.common.RelativePath(srcdir, options.generator_output)
     srcdir_prefix = '$(srcdir)/'
+
+  gyp.DebugOutput(gyp.DEBUG_GENERAL,
+   "\n builddir=name'%s'\n makefile_path='%s'\n options.generator_output='%s'\n"
+   " srcdir='%s'\n srcdir_prefix='%s'"
+   % (builddir_name, makefile_path, options.generator_output 
+    if options.generator_output else '', srcdir, srcdir_prefix))
 
   flock_command= 'flock'
   header_params = {


### PR DESCRIPTION
This change allows enables node (and other projects) to configure automatically
for out-of-tree builds. See node issue #4773.

When building to some directory that is not inside the source directory
root the extensive use of relative paths, sometimes anchored to toplevel_dir
a.k.a. the source directory root, prevents clean and automatic detection and
self-configuration.

These changes ensure that the top-level Makefile is written to the build
directory rather than the source tree, and that .mk files are created in the
correct relative paths inside the build directory (usually starting in ./out/).

If the build and source directories are the same the original behaviour
continues.

The Make variable 'srcdir' is set to an absolute path in the emitted
makefiles. Portable makefiles simply need to use $(srcdir) prefixed to relevant
paths.

Signed-off-by: TJ tj@khiasmos.org
