### PR TITLE
 Add disturl as alias for dist-url.

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -38,7 +38,7 @@ function install (gyp, argv, callback) {
     }
   }
 
-  var distUrl = gyp.opts['dist-url'] || 'http://nodejs.org/dist'
+  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'http://nodejs.org/dist'
 
 
   // Determine which node dev files version we are installing


### PR DESCRIPTION
There is no way to set `dist-url` by environment variable because of the `-` in it. Adding `disturl` as alias would solve the problem.
