### PR TITLE
configure: prevent ANSI escape codes in stdout of Python version check

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -91,7 +91,7 @@ function configure (gyp, argv, callback) {
   }
 
   function checkPythonVersion () {
-    execFile(python, ['-c', 'import platform; print(platform.python_version());'], function (err, stdout) {
+    execFile(python, ['-c', 'import platform; print(platform.python_version());'], {env:{'TERM':'dumb'}}, function (err, stdout) {
       if (err) {
         return callback(err)
       }


### PR DESCRIPTION
Fixes Python version checking with some shells/terminals outputting ANSI escape codes by adding execFile() options `{env:{'TERM':'dumb'}}`:

Before:

> gyp verb check python version 'python -c 
> "import platform; print(platform.python_version());" returned: **"\u001b[?1034h2.7.2\n"**
> gyp ERR! configure error 
> gyp ERR! stack Error: Python executable "python" is v2.7.2, which is not supported by gyp. 
> gyp ERR! stack You can pass the --python switch to point to Python >= v2.5.0 & < 3.0.0.

After:

> gyp verb check python version 'python -c 
> "import platform; print(platform.python_version());"' returned: **"2.7.2\n"**
