### PR TITLE
add -j N alias for build

### DIFF
--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -97,6 +97,7 @@ proto.shorthands = {
     release: '--no-debug'
   , C: '--directory'
   , debug: '--debug'
+  , j: '--jobs'
   , silly: '--loglevel=silly'
   , verbose: '--loglevel=verbose'
 }


### PR DESCRIPTION
this way one could add short jobs alias, similar to make(1):
$ node-gyp build -j 1

unfortunately it's not exactly the same as make, as -j1 is not
understood by nopt i guess
