### PR TITLE
Generated Makefile fails on OpenBSD 5.3

### DIFF
--- a/gyp/pylib/gyp/generator/make.py
+++ b/gyp/pylib/gyp/generator/make.py
@@ -351,7 +351,7 @@ cmd_touch = touch $@
 
 quiet_cmd_copy = COPY $@
 # send stderr to /dev/null to ignore messages when linking directories.
-cmd_copy = rm -rf "$@" && cp -af "$<" "$@"
+cmd_copy = rm -rf "$@" && cp -pPRf "$<" "$@"
 
 %(link_commands)s
 """


### PR DESCRIPTION
While trying to install node-sqlite3 via `npm install sqlite3` I got this error:

```
  COPY Release/sqlite3.a
cp: unknown option -- a
usage: cp [-fip] [-R [-H | -L | -P]]
       cp [-fip] [-R [-H | -L | -P]]
gmake: *** [Release/sqlite3.a] Error 1
```

Turns out the archive flag isn't available in the cp binary on OpenBSD, but it looks like it's just a shortcut for -pPR.
