### PR TITLE
adds vs2012-full check support to "node-gyp configure"

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -146,12 +146,36 @@ function configure (gyp, argv, callback) {
       cb()
     })
   }
+    
+  function checkVC201264(cb) {
+    var cp = spawn('reg', ['query', 'HKLM\\SOFTWARE\\Wow6432Node\\Microsoft\\VisualStudio\\11.0\\Setup\\VC', '/v', 'ProductDir'])
+    cp.on('exit', function (code) {
+      hasVC2012Express = (code === 0)
+      cb()
+    })
+  }
+  
+  function checkVC2012(cb) {
+    var cp = spawn('reg', ['query', 'HKLM\\SOFTWARE\\Microsoft\\VisualStudio\\11.0\\Setup\\VC', '/v', 'ProductDir'])
+    cp.on('exit', function (code) {
+      hasVC2012Express = (code === 0)
+      if (code !== 0) {
+        checkVC201264(cb)
+      } else {
+        cb()
+      }
+    })
+  }
 
   function checkVC2012Express64(cb) {
     var cp = spawn('reg', ['query', 'HKLM\\SOFTWARE\\Wow6432Node\\Microsoft\\VCExpress\\11.0\\Setup\\VC', '/v', 'ProductDir'])
     cp.on('exit', function (code) {
-      hasVC2012Express = (code === 0)
-      cb()
+        hasVC2012Express = (code === 0)
+        if (code !== 0) {
+            checkVC2012(cb)
+        } else {
+            cb()
+        }
     })
   }
 


### PR DESCRIPTION
Being an owner of vs2012 (pro edition) I prefer not to install any express editions (which would cause issues if I did) 
So I've added two functions to check for vs2012 (full) 32bit and 64bit.
