### PR TITLE
Handle when both VS2010 and VS2012 Express are installed

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -37,7 +37,9 @@ function configure (gyp, argv, callback) {
     checkVCExpress(function () {
       if (hasVCExpress || hasVC2012Express) {
         checkWinSDK(function () {
-          checkPython()
+          checkVSPrompt(function() {
+            checkPython()
+          })
         })
       } else {
         checkPython()
@@ -125,6 +127,22 @@ function configure (gyp, argv, callback) {
           'You can pass the --python switch to point to Python >= v2.5.0 & < 3.0.0.'))
   }
 
+  function checkVSPrompt(cb) {
+    // in the event that they have both installed, see if they are using a particular command prompt
+    if (hasVCExpress && hasVC2012Express) {
+      if (process.env["VisualStudioVersion"] === "11.0") {
+        // they are using the VS 2012 command prompt, unset the VS 2010 variables
+        hasVCExpress = false
+        hasWin71SDK = false
+      } else {
+        // otherwise, unset the VS 2012 variables
+        hasVC2012Express = false
+        hasWin8SDK = false
+      }
+    }
+    cb()
+  }
+
   function checkWinSDK(cb) {
     checkWin71SDK(function() {
       checkWin8SDK(cb)
@@ -178,6 +196,7 @@ function configure (gyp, argv, callback) {
   function checkVCExpress(cb) {
     spawn('reg', ['query', 'HKLM\\Software\\Microsoft\\VCExpress\\10.0\\Setup\\VC', '/v', 'ProductDir'])
          .on('exit', function (code) {
+           hasVCExpress = (code === 0)
            if (code !== 0) {
              checkVCExpress64(cb)
            } else {


### PR DESCRIPTION
When both versions are present, attempt to use the command prompt to
determine which one should be set.

The command prompt for VS2012 set the environment variable to:

VisualStudioVersion=11.0

This environment variable is absent in the VS2010 command prompts.

Also, presumably the checkVCExpress function not setting hasVCExpress
was an oversight.
