### PR TITLE
Fixes #65, Build failure when builddir contains spaces.

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -1,3 +1,4 @@
+
 module.exports = exports = configure
 
 /**
@@ -174,7 +175,7 @@ function configure (gyp, argv, callback) {
 
     var config = process.config || {}
       , defaults = config.target_defaults
-      , variablesa = config.variables
+      , variables = config.variables
 
     // default "config.variables"
     if (!variables) variables = config.variables = {}


### PR DESCRIPTION
Fixes https://github.com/TooTallNate/node-gyp/issues/65 
