### PR TITLE
Fix build on Windows 2003 Server with MSVC 2008

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -42,7 +42,7 @@
           '-luuid.lib',
           '-lodbc32.lib',
           '-lDelayImp.lib',
-          '-l<(node_root_dir)/$(Configuration)/node.lib'
+          '-l"<(node_root_dir)/$(ConfigurationName)/node.lib"'
         ],
         # warning C4251: 'node::ObjectWrap::handle_' : class 'v8::Persistent<T>'
         # needs to have dll-interface to be used by clients of class 'node::ObjectWrap'


### PR DESCRIPTION
I suggest this as a fix for the #386.

Use quotation marks to encapsulate the path to node.lib.
Use ConfigurationName instead of Configuration for the
variable getting the Debug/Release directory.
