### PR TITLE
Fixes for loading wrong libpython.so when having multiple python installation.

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -73,7 +73,7 @@ function configure (gyp, argv, callback) {
   }
 
   function checkPythonVersion () {
-    var env = { TERM: 'dumb', PATH: process.env.PATH };
+    var env = { TERM: 'dumb', PATH: process.env.PATH, LD_LIBRARY_PATH: process.env.LD_LIBRARY_PATH };
     execFile(python, ['-c', 'import platform; print(platform.python_version());'], { env: env }, function (err, stdout) {
       if (err) {
         return callback(err)


### PR DESCRIPTION
I have two python installations on my Linux box: one is 2.7.3 (system) and the other is my own compilation of  2.7.5, if LD_LIBRARY_PATH is not set it will show errors about MAXREPEAT when running 2.7.5 executable with 2.7.3 libpython.so .
