### PR TITLE
not parallel processing gyp file

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -1,4 +1,3 @@
-
 module.exports = exports = configure
 
 /**
@@ -311,6 +310,7 @@ function configure (gyp, argv, callback) {
     argv.push('-Dnode_root_dir=' + nodeDir)
     argv.push('-Dmodule_root_dir=' + process.cwd())
     argv.push('--depth=.')
+    argv.push('--no-parallel')
 
     // tell gyp to write the Makefile/Solution files into output_dir
     argv.push('--generator-output', output_dir)


### PR DESCRIPTION
I'm working on a old platforms,when I run `node-gyp configure`,node-gyp report one error of python 

> ImportError: This platform lacks a functioning sem_open implementation, therefore, the required synchronization primitives needed will not function, see issue 3770.

check this : http://bugs.python.org/issue3770

I suggest not parallel processing because usually we don't have so manay files to parse.

github.com/joyent/node had closed the issue of the same problem,see :

https://github.com/joyent/node/issues/6640
