### PR TITLE
Make sure gyp_main imports the correct library

### DIFF
--- a/gyp/gyp_main.py
+++ b/gyp/gyp_main.py
@@ -5,14 +5,11 @@
 # found in the LICENSE file.
 
 import sys
+import os.path
 
-# TODO(mark): sys.path manipulation is some temporary testing stuff.
-try:
-  import gyp
-except ImportError, e:
-  import os.path
-  sys.path.append(os.path.join(os.path.dirname(sys.argv[0]), 'pylib'))
-  import gyp
+# ensure that we always import the version this file shipped with
+sys.path.insert(0, os.path.join(os.path.dirname(sys.argv[0]), 'pylib'))
+import gyp
 
 if __name__ == '__main__':
   sys.exit(gyp.script_main())


### PR DESCRIPTION
Python does not understand the concept of `node_modules` so it will import the first version that it finds on the `sys.path`. This can be either a much older or a much newer node package than the one we are using currently.
