### PR TITLE
Make Python prefer bundled files

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -327,6 +327,9 @@ function configure (gyp, argv, callback) {
     // execute `gyp` from the current target nodedir
     argv.unshift(gyp_script)
 
+    // make sure python uses files that came with this particular node package
+    process.env.PYTHONPATH = path.resolve(__dirname, '..', 'gyp', 'pylib')
+
     var cp = gyp.spawn(python, argv)
     cp.on('exit', onCpExit)
   }


### PR DESCRIPTION
As Python has no concept of node packages, it will load whatever comes first in `sys.path`. Here we help Python by making sure files bundled in this node package are the preferred path when looking for imports.
