### PR TITLE
Allow glob@4

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "bin": "./bin/node-gyp.js",
   "main": "./lib/node-gyp.js",
   "dependencies": {
-    "glob": "3",
+    "glob": "3 || 4",
     "graceful-fs": "2",
     "fstream": "0",
     "minimatch": "0",


### PR DESCRIPTION
There are no actual breaking changes in glob 4.

The only breaking change is that it requires a new version of npm,
because it uses the ^ syntax to specify its dependency.

This is not a problem for node-gyp, because new versions of node-gyp
will generally come along with new versions of node and/or npm.
