### PR TITLE
nopt: allow version 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fstream": "0",
     "minimatch": "0",
     "mkdirp": "0",
-    "nopt": "2",
+    "nopt": "2 || 3",
     "npmlog": "0",
     "osenv": "0",
     "request": "2",


### PR DESCRIPTION
No longer parse numeric args.  Technically a breaking change, but not breaking
for node-gyp, because it doesn't accept any numeric args anyway.
