### PR TITLE
Fix for 'make' failure when process.env.JOBS is '0'

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -222,8 +222,9 @@ function build (gyp, argv, callback) {
       var p = arch === 'x64' ? 'x64' : 'Win32'
       argv.push('/p:Configuration=' + buildType + ';Platform=' + p)
       if (jobs) {
-        if (!isNaN(parseInt(jobs, 10))) {
-          argv.push('/m:' + parseInt(jobs, 10))
+        var j = parseInt(jobs, 10)
+        if (!isNaN(j) && j > 0) {
+          argv.push('/m:' + j)
         } else if (jobs.toUpperCase() === 'MAX') {
           argv.push('/m:' + require('os').cpus().length)
         }
@@ -234,9 +235,10 @@ function build (gyp, argv, callback) {
       argv.push('-C')
       argv.push('build')
       if (jobs) {
-        if (!isNaN(parseInt(jobs, 10))) {
+        var j = parseInt(jobs, 10)
+        if (!isNaN(j) && j > 0) {
           argv.push('--jobs')
-          argv.push(parseInt(jobs, 10))
+          argv.push(j)
         } else if (jobs.toUpperCase() === 'MAX') {
           argv.push('--jobs')
           argv.push(require('os').cpus().length)


### PR DESCRIPTION
If you use the environment variable `JOBS` which are set '0' for other purpose, `node-gpy rebuild` will fail to execute `make`. Because the `-j` option of `make` require a non-zero positive integer.

Here is a simple repro:

```
$ JOBS=0 npm install nightmare
...
> weak@0.3.3 install /home/kui/tmp/nm/node_modules/nightmare/node_modules/phantom/node_modules/dnode/node_modules/weak
> node-gyp rebuild

make: the `-j' option requires a positive integral argument
Usage: make [options] [target] ...
Options:
  -b, -m                      Ignored for compatibility.
  -B, --always-make           Unconditionally make all targets.
  -C DIRECTORY, --directory=DIRECTORY
                              Change to DIRECTORY before doing anything.
  -d                          Print lots of debugging information.
..
```
