### PR TITLE
Use stdio instead of customFds

### DIFF
--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -180,8 +180,8 @@ proto.parseArgv = function parseOpts (argv) {
 
 proto.spawn = function spawn (command, args, opts) {
   if (!opts) opts = {}
-  if (!opts.silent && !opts.customFds) {
-    opts.customFds = [ 0, 1, 2 ]
+  if (!opts.silent && !opts.stdio) {
+    opts.stdio = [ 0, 1, 2 ]
   }
   var cp = child_process.spawn(command, args, opts)
   log.info('spawn', command)


### PR DESCRIPTION
This fixes the noisy deprecation warnings when node-gyp is used with >= node v0.11.14. Apparently the `stdio` option has been around and `customFds` has been deprecated since node v0.5.11 (https://github.com/joyent/node/commit/245469587c7a6326d1b55bdf6c6d6650d72bfa22).
- refs joyent/node#8492

Would love to see this land since for node-pre-gyp I test expected stdout and stderr and therefore this deprecation warning breaks my tests against node v0.11.14: https://travis-ci.org/mapbox/node-pre-gyp/builds/40707288
