### PR TITLE
Avoid copying around node.lib on Windows

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -42,7 +42,7 @@
           '-luuid.lib',
           '-lodbc32.lib',
           '-lDelayImp.lib',
-          '-l"<(node_root_dir)/$(ConfigurationName)/node.lib"'
+          '-l"<(node_root_dir)/$(Platform)/node.lib"'
         ],
         # warning C4251: 'node::ObjectWrap::handle_' : class 'v8::Persistent<T>'
         # needs to have dll-interface to be used by clients of class 'node::ObjectWrap'

--- a/lib/build.js
+++ b/lib/build.js
@@ -108,7 +108,7 @@ function build (gyp, argv, callback) {
         return
       }
       log.verbose('`which` succeeded for `' + command + '`', execPath)
-      copyNodeLib()
+      doBuild()
     })
   }
 
@@ -166,34 +166,9 @@ function build (gyp, argv, callback) {
             return
           }
           command = msbuildPath
-          copyNodeLib()
+          doBuild()
         })
       })()
-    })
-  }
-
-  /**
-   * Copies the node.lib file for the current target architecture into the
-   * current proper dev dir location.
-   */
-
-  function copyNodeLib () {
-    if (!win || !copyDevLib) return doBuild()
-
-    var buildDir = path.resolve(nodeDir, buildType)
-      , archNodeLibPath = path.resolve(nodeDir, arch, 'node.lib')
-      , buildNodeLibPath = path.resolve(buildDir, 'node.lib')
-
-    mkdirp(buildDir, function (err, isNew) {
-      if (err) return callback(err)
-      log.verbose('"' + buildType + '" dir needed to be created?', isNew)
-      var rs = fs.createReadStream(archNodeLibPath)
-        , ws = fs.createWriteStream(buildNodeLibPath)
-      log.verbose('copying "node.lib" for ' + arch, buildNodeLibPath)
-      rs.pipe(ws)
-      rs.on('error', callback)
-      ws.on('error', callback)
-      rs.on('end', doBuild)
     })
   }
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -344,7 +344,7 @@ function install (gyp, argv, callback) {
 
       function downloadNodeLib (done) {
         log.verbose('on Windows; need to download `node.lib`...')
-        var dir32 = path.resolve(devDir, 'ia32')
+        var dir32 = path.resolve(devDir, 'Win32')
           , dir64 = path.resolve(devDir, 'x64')
           , nodeLibPath32 = path.resolve(dir32, 'node.lib')
           , nodeLibPath64 = path.resolve(dir64, 'node.lib')


### PR DESCRIPTION
Imagine a Jenkins build server, where node-gyp chooses a dev dir of say `C:\Users\jenkins\.node-gyp\0.10.29\`. The build server runs multiple build jobs in parallel, each with disjoint working directories, but sharing global state such as the node-gyp dev dir. Some of these build jobs are using node-gyp to build 32-bit binaries, and some are using node-gyp to build 64-bit binaries. Sometimes the following scenario could previously occur:
  1. Job A step 1: Copy `C:\Users\jenkins\.node-gyp\0.10.29\ia32\node.lib` to `C:\Users\jenkins\.node-gyp\0.10.29\Release\node.lib`
  2. Job B step 1: Copy `C:\Users\jenkins\.node-gyp\0.10.29\x64\node.lib` to `C:\Users\jenkins\.node-gyp\0.10.29\Release\node.lib`
  3. Job B step 2: Successfully build and link a 64-bit binary.
  4. Job A step 2: Attempt to build and link a 32-bit binary, but fail because `C:\Users\jenkins\.node-gyp\0.10.29\Release\node.lib` is of the wrong architecture.

This commit avoids the above scenario by making the dev dir immutable, and making the generated vcxproj files refer directly to the node.lib file for the appropriate architecture.
<hr>
This is rather similar to #443 / #450.