### PR TITLE
cp -a flag is not portable

### DIFF
--- a/gyp/pylib/gyp/generator/make.py
+++ b/gyp/pylib/gyp/generator/make.py
@@ -372,7 +372,7 @@ cmd_touch = touch $@
 
 quiet_cmd_copy = COPY $@
 # send stderr to /dev/null to ignore messages when linking directories.
-cmd_copy = rm -rf "$@" && cp -af "$<" "$@"
+cmd_copy = rm -rf "$@" && cp -RpPf "$<" "$@"
 
 %(link_commands)s
 """

--- a/gyp/pylib/gyp/generator/ninja.py
+++ b/gyp/pylib/gyp/generator/ninja.py
@@ -2020,7 +2020,7 @@ def GenerateOutputForConfig(target_list, target_dicts, data, params,
     master_ninja.rule(
       'copy',
       description='COPY $in $out',
-      command='rm -rf $out && cp -af $in $out')
+      command='rm -rf $out && cp -RpPf $in $out')
   master_ninja.newline()
 
   all_targets = set()


### PR DESCRIPTION
at least it's not on OpenBSD. probably somewhere else as well.