### PR TITLE
Changed clean to only delete node-gyp object files

### DIFF
--- a/lib/clean.js
+++ b/lib/clean.js
@@ -14,7 +14,7 @@ var log = require('npmlog')
 function clean (gyp, argv, callback) {
 
   // Remove the 'build' dir
-  var buildDir = 'build'
+  var buildDir = 'build/*.node'
 
   log.verbose('clean', 'removing "%s" directory', buildDir)
   rm(buildDir, callback)


### PR DESCRIPTION
With this change, node-gyp only deletes object files it created. Resolves a conflict if node-gyp shares a build directory with anything else. This is the simplest possible way to solve this, though it relies on the convention that node-gyp and only node-gyp object files will have the suffix *.node.