### PR TITLE
Build binaries that can load in electron by default.

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -48,7 +48,7 @@
             'msvs_settings': {
               'VCLinkerTool': {
                 'DelayLoadDLLs': [ 'iojs.exe', 'node.exe', 'node.dll' ],
-                # Don't print a linker warning when no imports from either .exe
+                # Don't print a linker warning when no imports from delay loaded binary
                 # are used.
                 'AdditionalOptions': [ '/ignore:4199' ],
               },

--- a/addon.gypi
+++ b/addon.gypi
@@ -42,6 +42,9 @@
             'sources': [
               '<(node_gyp_dir)/src/win_delay_load_hook.c',
             ],
+            'libraries': [
+              '-lShlwapi.lib'
+            ],
             'msvs_settings': {
               'VCLinkerTool': {
                 'DelayLoadDLLs': [ 'iojs.exe', 'node.exe', 'node.dll' ],

--- a/addon.gypi
+++ b/addon.gypi
@@ -36,7 +36,7 @@
         # If the addon specifies `'win_delay_load_hook': 'true'` in its
         # binding.gyp, link a delay-load hook into the DLL. This hook ensures
         # that the addon will work regardless of whether the node/iojs binary
-        # is named node.exe, iojs.exe, or something else.
+        # is named node.exe, iojs.exe, or node.dll.
         'conditions': [
           [ 'OS=="win"', {
             'sources': [
@@ -44,7 +44,7 @@
             ],
             'msvs_settings': {
               'VCLinkerTool': {
-                'DelayLoadDLLs': [ 'iojs.exe', 'node.exe' ],
+                'DelayLoadDLLs': [ 'iojs.exe', 'node.exe', 'node.dll' ],
                 # Don't print a linker warning when no imports from either .exe
                 # are used.
                 'AdditionalOptions': [ '/ignore:4199' ],

--- a/addon.gypi
+++ b/addon.gypi
@@ -36,7 +36,7 @@
         # If the addon specifies `'win_delay_load_hook': 'true'` in its
         # binding.gyp, link a delay-load hook into the DLL. This hook ensures
         # that the addon will work regardless of whether the node/iojs binary
-        # is named node.exe, iojs.exe, or node.dll.
+        # is named node.exe, iojs.exe, node.dll or something else.
         'conditions': [
           [ 'OS=="win"', {
             'sources': [

--- a/src/win_delay_load_hook.c
+++ b/src/win_delay_load_hook.c
@@ -21,10 +21,16 @@ static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
     return NULL;
 
   if (_stricmp(info->szDll, "iojs.exe") != 0 &&
-      _stricmp(info->szDll, "node.exe") != 0)
+      _stricmp(info->szDll, "node.exe") != 0 &&
+      _stricmp(info->szDll, "node.dll") != 0)
     return NULL;
 
-  m = GetModuleHandle(NULL);
+  m = GetModuleHandle("node.dll");
+  if (m == NULL) 
+  {
+    m = GetModuleHandle(NULL);
+  }
+
   return (FARPROC) m;
 }
 

--- a/src/win_delay_load_hook.c
+++ b/src/win_delay_load_hook.c
@@ -11,12 +11,12 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-
+#include <Shlwapi.h>
 #include <delayimp.h>
 #include <string.h>
 
 static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
-  HMODULE m;
+
   if (event != dliNotePreLoadLibrary)
     return NULL;
 
@@ -25,13 +25,34 @@ static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
       _stricmp(info->szDll, "node.dll") != 0)
     return NULL;
 
-  m = GetModuleHandle("node.dll");
-  if (m == NULL) 
-  {
-    m = GetModuleHandle(NULL);
+  // Get a handle to the current process executable.
+  HMODULE processModule = GetModuleHandle(NULL);
+
+  // Get the path to the executable.
+  TCHAR processPath[_MAX_PATH];
+  GetModuleFileName(processModule, processPath, _MAX_PATH);
+
+  // Get the name of the current executable.
+  LPSTR processName = PathFindFileName(&processPath[0]);
+
+  // If the current process is node or iojs, then just return the proccess module.
+  if (_stricmp(processName, "node.exe") == 0 ||
+      _stricmp(processName, "iojs.exe") == 0) {
+    return (FARPROC)processModule;
   }
 
-  return (FARPROC) m;
+  // If it is another process, attempt to load 'node.dll' from the same directory.
+  PathRemoveFileSpec(&processPath[0]);
+  PathAppend(&processPath[0], "node.dll");
+
+  HMODULE nodeDllModule = GetModuleHandle(&processPath[0]);
+  if(nodeDllModule != NULL) {
+    // This application has a node.dll in the same directory as the executable, use that.
+    return (FARPROC)nodeDllModule;
+  }
+
+  // Fallback to the current executable, which must statically link to node.lib.
+  return (FARPROC)processModule;
 }
 
 PfnDliHook __pfnDliNotifyHook2 = load_exe_hook;

--- a/src/win_delay_load_hook.c
+++ b/src/win_delay_load_hook.c
@@ -33,7 +33,7 @@ static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
   GetModuleFileName(processModule, processPath, _MAX_PATH);
 
   // Get the name of the current executable.
-  LPSTR processName = PathFindFileName(&processPath[0]);
+  LPSTR processName = PathFindFileName(processPath);
 
   // If the current process is node or iojs, then just return the proccess module.
   if (_stricmp(processName, "node.exe") == 0 ||
@@ -42,10 +42,10 @@ static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
   }
 
   // If it is another process, attempt to load 'node.dll' from the same directory.
-  PathRemoveFileSpec(&processPath[0]);
-  PathAppend(&processPath[0], "node.dll");
+  PathRemoveFileSpec(processPath);
+  PathAppend(processPath, "node.dll");
 
-  HMODULE nodeDllModule = GetModuleHandle(&processPath[0]);
+  HMODULE nodeDllModule = GetModuleHandle(processPath);
   if(nodeDllModule != NULL) {
     // This application has a node.dll in the same directory as the executable, use that.
     return (FARPROC)nodeDllModule;


### PR DESCRIPTION
Attempt to load node.dll first, if its not found then link to the
running process under the assumption that it is node/iojs or has
statically linked to node. This adds support for electron or any
other app that dynamically links to node.

With this PR, node does not need to ship a "node.dll" but if 3rd party apps want to embed node they can build their own node.dll and will have automatic support from node-gyp.