### PR TITLE
fix install: add iojs support

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -39,8 +39,15 @@ function install (gyp, argv, callback) {
     }
   }
 
-  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'https://nodejs.org/dist'
+  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl
 
+  if (!distUrl) {
+    if (semver.satisfies(version, '>=1.0.0')) {
+      distUrl = 'https://iojs.org/dist'
+    } else {
+      distUrl = 'https://nodejs.org/dist'
+    }
+  }
 
   // Determine which node dev files version we are installing
   var versionStr = argv[0] || gyp.opts.target || process.version


### PR DESCRIPTION
Add `iojs` support: when version `>=1.0.0` download dist from url `https://iojs.org`.

```js
gyp WARN install got an error, rolling back install
gyp ERR! configure error
gyp ERR! stack Error: 404 response downloading https://nodejs.org/dist/v2.4.0/node-v2.4.0.tar.gz
gyp ERR! stack     at Request.<anonymous> (/home/coderaiser/.nvm/versions/io.js/v2.4.0/lib/node_modules/npm/node_modules/node-gyp/lib/install.js:251:14)
gyp ERR! stack     at emitOne (events.js:82:20)
gyp ERR! stack     at Request.emit (events.js:169:7)
gyp ERR! stack     at Request.onRequestResponse (/home/coderaiser/.nvm/versions/io.js/v2.4.0/lib/node_modules/npm/node_modules/request/request.js:985:10)
gyp ERR! stack     at emitOne (events.js:77:13)
gyp ERR! stack     at ClientRequest.emit (events.js:169:7)
gyp ERR! stack     at HTTPParser.parserOnIncomingClient (_http_client.js:415:21)
gyp ERR! stack     at HTTPParser.parserOnHeadersComplete (_http_common.js:88:23)
gyp ERR! stack     at TLSSocket.socketOnData (_http_client.js:305:20)
gyp ERR! stack     at emitOne (events.js:77:13)
```