### PR TITLE
fixing ansi path related issues

### DIFF
--- a/gyp/pylib/gyp/easy_xml.py
+++ b/gyp/pylib/gyp/easy_xml.py
@@ -4,6 +4,7 @@
 
 import re
 import os
+import locale
 
 
 def XmlToString(content, encoding='utf-8', pretty=False):
@@ -119,7 +120,8 @@ def WriteXmlIfChanged(content, path, encoding='utf-8', pretty=False,
   try:
     xml_string = xml_string.encode(encoding)
   except Exception:
-    xml_string = unicode(xml_string, 'latin-1').encode(encoding)
+    ansi_locale = locale.getdefaultlocale()
+    xml_string = unicode(xml_string, ansi_locale[1]).encode(encoding)
 
   # Get the old content
   try:


### PR DESCRIPTION
As I've already mentioned, paths passed to vcbuild/msbuild are still encoded incorrectly on non-Latin editions of Windows. Here's a more flexible solution that, hopefully, will fix ANSI→UTF encoding issues on Windows 2000 and higher.

Fixes: #297