### PR TITLE
win: enable delay-load hook by default

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -1,7 +1,7 @@
 {
   'target_defaults': {
     'type': 'loadable_module',
-    'win_delay_load_hook': 'false',
+    'win_delay_load_hook': 'true',
     'product_prefix': '',
 
     'include_dirs': [


### PR DESCRIPTION
Enables the following commit by default:
52ceec3a6d15de3a8f385f43dbe5ecf5456ad07a

See also:
https://github.com/nodejs/node/commit/3bda6cbfa4a9bb073790d53bc14e85b6e575bbe5


Seeing if we can get this in, even into a major, to land in npm, so that we don't need to keep patching it in io.js/node.

I talked with @othiym23 a bit last Friday and he seemed to think it wasn't major-worthy. In io.js we wated to do it in a major.

@TooTallNate what are your thoughts on this?

cc @nodejs/tsc?