### PR TITLE
dep: Update graceful-fs dependency to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "fstream": "^1.0.0",
     "glob": "3 || 4",
-    "graceful-fs": "3",
+    "graceful-fs": "^4.1.2",
     "minimatch": "1",
     "mkdirp": "^0.5.0",
     "nopt": "2 || 3",


### PR DESCRIPTION
graceful-fs used to monkey-patch node's core fs module.
This has been fixed in the version 4.

This might also fix https://github.com/nodejs/node/pull/2714#issuecomment-138092313