### PR TITLE
Update repository URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Some additional resources for addons and writing `gyp` files:
  * ["Hello World" node addon example](https://github.com/joyent/node/tree/master/test/addons/hello-world)
  * [gyp user documentation](https://chromium.googlesource.com/external/gyp/+/master/docs/UserDocumentation.md)
  * [gyp input format reference](https://chromium.googlesource.com/external/gyp/+/master/docs/InputFormatReference.md)
- * [*"binding.gyp" files out in the wild* wiki page](https://github.com/TooTallNate/node-gyp/wiki/%22binding.gyp%22-files-out-in-the-wild)
+ * [*"binding.gyp" files out in the wild* wiki page](https://github.com/nodejs/node-gyp/wiki/%22binding.gyp%22-files-out-in-the-wild)
 
 
 Commands

--- a/bin/node-gyp.js
+++ b/bin/node-gyp.js
@@ -125,7 +125,7 @@ function issueMessage () {
   errorMessage()
   log.error('', [ 'This is a bug in `node-gyp`.'
                 , 'Try to update node-gyp and file an Issue if it does not help:'
-                , '    <https://github.com/TooTallNate/node-gyp/issues>'
+                , '    <https://github.com/nodejs/node-gyp/issues>'
                 ].join('\n'))
 }
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -142,7 +142,7 @@ function install (gyp, argv, callback) {
     }
     try {
       // The "request" constructor can throw sometimes apparently :(
-      // See: https://github.com/TooTallNate/node-gyp/issues/114
+      // See: https://github.com/nodejs/node-gyp/issues/114
       req = request(requestOpts)
     } catch (e) {
       cb(e)

--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -48,7 +48,7 @@ function Gyp () {
 
   // set the dir where node-gyp dev files get installed
   // TODO: make this *more* configurable?
-  //       see: https://github.com/TooTallNate/node-gyp/issues/21
+  //       see: https://github.com/nodejs/node-gyp/issues/21
   var homeDir = process.env.HOME || process.env.USERPROFILE
   if (!homeDir) {
     throw new Error(

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)",
   "repository": {
     "type": "git",
-    "url": "git://github.com/TooTallNate/node-gyp.git"
+    "url": "git://github.com/nodejs/node-gyp.git"
   },
   "preferGlobal": true,
   "bin": "./bin/node-gyp.js",


### PR DESCRIPTION
The project was moved from https://github.com/TooTallNate/node-gyp to
https://github.com/nodejs/node-gyp.  Update a handful of links that
still pointed to the old location.

R=@thefourtheye?