### PR TITLE
normalise versions for target == this comparison

### DIFF
--- a/lib/process-release.js
+++ b/lib/process-release.js
@@ -11,9 +11,9 @@ var semver = require('semver')
 // `process.version` and `process.release` where it exists.
 function processRelease (argv, gyp, defaultVersion, defaultRelease) {
   var version = argv[0] || gyp.opts.target || defaultVersion
-    , isDefaultVersion = version === defaultVersion
     , versionSemver = semver.parse(version)
     , overrideDistUrl = gyp.opts['dist-url'] || gyp.opts.disturl
+    , isDefaultVersion
     , isIojs
     , name
     , distBaseUrl
@@ -27,6 +27,9 @@ function processRelease (argv, gyp, defaultVersion, defaultRelease) {
   }
   // flatten version into String
   version = versionSemver.version
+
+  // defaultVersion should come from process.version so ought to be valid semver
+  isDefaultVersion = version === semver.parse(defaultVersion).version
 
   // can't use process.release if we're using --target=x.y.z
   if (!isDefaultVersion)

--- a/test/test-process-release.js
+++ b/test/test-process-release.js
@@ -368,3 +368,56 @@ test('test process release - process.release ~ frankenstein@4.1.23 --dist-url=ht
   })
 })
 
+test('test process release - process.release ~ node@4.0.0-rc.4', function (t) {
+  t.plan(2)
+
+  var release = processRelease([], { opts: {} }, 'v4.0.0-rc.4', {
+    name: 'node',
+    headersUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/node-v4.0.0-rc.4-headers.tar.gz'
+  })
+
+  t.equal(release.semver.version, '4.0.0-rc.4')
+  delete release.semver
+
+  t.deepEqual(release, {
+    version: '4.0.0-rc.4',
+    name: 'node',
+    baseUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/',
+    tarballUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/node-v4.0.0-rc.4-headers.tar.gz',
+    shasumsUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/SHASUMS256.txt',
+    versionDir: '4.0.0-rc.4',
+    libUrl32: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x86/node.lib',
+    libUrl64: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x64/node.lib',
+    libPath32: 'win-x86/node.lib',
+    libPath64: 'win-x64/node.lib'
+  })
+})
+
+
+test('test process release - process.release ~ node@4.0.0-rc.4 passed as argv[0]', function (t) {
+  t.plan(2)
+
+  // note the missing 'v' on the arg, it should normalise when checking
+  // whether we're on the default or not
+  var release = processRelease([ '4.0.0-rc.4' ], { opts: {} }, 'v4.0.0-rc.4', {
+    name: 'node',
+    headersUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/node-v4.0.0-rc.4-headers.tar.gz'
+  })
+
+  t.equal(release.semver.version, '4.0.0-rc.4')
+  delete release.semver
+
+  t.deepEqual(release, {
+    version: '4.0.0-rc.4',
+    name: 'node',
+    baseUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/',
+    tarballUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/node-v4.0.0-rc.4-headers.tar.gz',
+    shasumsUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/SHASUMS256.txt',
+    versionDir: '4.0.0-rc.4',
+    libUrl32: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x86/node.lib',
+    libUrl64: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x64/node.lib',
+    libPath32: 'win-x86/node.lib',
+    libPath64: 'win-x64/node.lib'
+  })
+})
+


### PR DESCRIPTION
For the `node-gyp rebuild` case, everything is calculated fine for `configure` but then when it gets to `install` it's passing in an `argv[0]` with the version number and the `v` is stripped from that version but we are comparing with `process.version` which has a `v` so the naive comparison says it's not the same version and therefore we are not targetting the "default".

The solution here is to simply normalise `process.version` and match it to the already normalised target version so the comparison is fair.

Reported [here](https://github.com/nodejs/node/issues/2522#issuecomment-138447618) for 4.0.0-rc.4