### PR TITLE
Search for includes also in the node directory

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -5,6 +5,7 @@
     'product_prefix': '',
 
     'include_dirs': [
+      '<(node_root_dir)',
       '<(node_root_dir)/include/node',
       '<(node_root_dir)/src',
       '<(node_root_dir)/deps/uv/include',


### PR DESCRIPTION
FreeBSD installs all headers and .gypi files
in the /usr/local/include/node directory.

I am using `--nodedir=/usr/local/include/node`
to compile the addons against various node/iojs
versions, including pre-releases.

I can't set `--nodedir` just to `/usr/local`,
because then `gypi` files will not be found.

Output of `(cd /usr/local/include/node && find *)`:

    android-ifaddrs.h
    ares.h
    ares_version.h
    common.gypi
    config.gypi
    libplatform
    libplatform/libplatform.h
    nameser.h
    node.h
    node_buffer.h
    node_internals.h
    node_object_wrap.h
    node_version.h
    openssl
    openssl/aes.h
    openssl/archs
    openssl/archs/BSD-x86
    openssl/archs/BSD-x86/opensslconf.h
    openssl/archs/BSD-x86_64
    openssl/archs/BSD-x86_64/opensslconf.h
    openssl/archs/VC-WIN32
    openssl/archs/VC-WIN32/opensslconf.h
    openssl/archs/VC-WIN64A
    openssl/archs/VC-WIN64A/opensslconf.h
    openssl/archs/darwin-i386-cc
    openssl/archs/darwin-i386-cc/opensslconf.h
    openssl/archs/darwin64-x86_64-cc
    openssl/archs/darwin64-x86_64-cc/opensslconf.h
    openssl/archs/linux-aarch64
    openssl/archs/linux-aarch64/opensslconf.h
    openssl/archs/linux-armv4
    openssl/archs/linux-armv4/opensslconf.h
    openssl/archs/linux-elf
    openssl/archs/linux-elf/opensslconf.h
    openssl/archs/linux-ppc
    openssl/archs/linux-ppc/opensslconf.h
    openssl/archs/linux-ppc64
    openssl/archs/linux-ppc64/opensslconf.h
    openssl/archs/linux-x32
    openssl/archs/linux-x32/opensslconf.h
    openssl/archs/linux-x86_64
    openssl/archs/linux-x86_64/opensslconf.h
    openssl/archs/solaris-x86-gcc
    openssl/archs/solaris-x86-gcc/opensslconf.h
    openssl/archs/solaris64-x86_64-gcc
    openssl/archs/solaris64-x86_64-gcc/opensslconf.h
    openssl/asn1.h
    openssl/asn1_mac.h
    openssl/asn1t.h
    openssl/bio.h
    openssl/blowfish.h
    openssl/bn.h
    openssl/buffer.h
    openssl/camellia.h
    openssl/cast.h
    openssl/cmac.h
    openssl/cms.h
    openssl/comp.h
    openssl/conf.h
    openssl/conf_api.h
    openssl/crypto.h
    openssl/des.h
    openssl/des_old.h
    openssl/dh.h
    openssl/dsa.h
    openssl/dso.h
    openssl/dtls1.h
    openssl/e_os2.h
    openssl/ebcdic.h
    openssl/ec.h
    openssl/ecdh.h
    openssl/ecdsa.h
    openssl/engine.h
    openssl/err.h
    openssl/evp.h
    openssl/hmac.h
    openssl/idea.h
    openssl/krb5_asn.h
    openssl/kssl.h
    openssl/lhash.h
    openssl/md4.h
    openssl/md5.h
    openssl/mdc2.h
    openssl/modes.h
    openssl/obj_mac.h
    openssl/objects.h
    openssl/ocsp.h
    openssl/opensslconf.h
    openssl/opensslv.h
    openssl/ossl_typ.h
    openssl/pem.h
    openssl/pem2.h
    openssl/pkcs12.h
    openssl/pkcs7.h
    openssl/pqueue.h
    openssl/rand.h
    openssl/rc2.h
    openssl/rc4.h
    openssl/ripemd.h
    openssl/rsa.h
    openssl/safestack.h
    openssl/seed.h
    openssl/sha.h
    openssl/srp.h
    openssl/srtp.h
    openssl/ssl.h
    openssl/ssl2.h
    openssl/ssl23.h
    openssl/ssl3.h
    openssl/stack.h
    openssl/symhacks.h
    openssl/tls1.h
    openssl/ts.h
    openssl/txt_db.h
    openssl/ui.h
    openssl/ui_compat.h
    openssl/whrlpool.h
    openssl/x509.h
    openssl/x509_vfy.h
    openssl/x509v3.h
    pthread-fixes.h
    stdint-msvc2008.h
    tree.h
    uv-aix.h
    uv-bsd.h
    uv-darwin.h
    uv-errno.h
    uv-linux.h
    uv-sunos.h
    uv-threadpool.h
    uv-unix.h
    uv-version.h
    uv-win.h
    uv.h
    v8-debug.h
    v8-platform.h
    v8-profiler.h
    v8-testing.h
    v8-util.h
    v8-version.h
    v8.h
    v8config.h