### PR TITLE
process.platform will never be kfreebsd

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -21,7 +21,7 @@ exports.usage = 'Invokes `' + (win ? 'msbuild' : 'make') + '` and builds the mod
 function build (gyp, argv, callback) {
   var release = processRelease(argv, gyp, process.version, process.release)
     , makeCommand = gyp.opts.make || process.env.MAKE
-      || (process.platform.indexOf('bsd') != -1 && process.platform.indexOf('kfreebsd') == -1 ? 'gmake' : 'make')
+      || (process.platform.indexOf('bsd') != -1 ? 'gmake' : 'make')
     , command = win ? 'msbuild' : makeCommand
     , buildDir = path.resolve('build')
     , configPath = path.resolve(buildDir, 'config.gypi')


### PR DESCRIPTION
This platform value came from debian package, and now the value
from debian package is simply "freebsd", so this check is useless.