### PR TITLE
Fix infinite loop with zero-length options.

### DIFF
--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -164,7 +164,9 @@ proto.parseArgv = function parseOpts (argv) {
     } else {
       // add the user-defined options to the config
       name = name.substring(npm_config_prefix.length)
-      this.opts[name] = val
+      // gyp@741b7f1 enters an infinite loop when it encounters
+      // zero-length options so ensure those don't get through.
+      if (name) this.opts[name] = val
     }
   }, this)
 

--- a/test/test-options.js
+++ b/test/test-options.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var test = require('tape')
+var gyp = require('../lib/node-gyp')
+
+test('options in environment', function (t) {
+  t.plan(1)
+
+  // Zero-length keys should get filtered out.
+  process.env.npm_config_ = '42'
+  // Other keys should get added.
+  process.env.npm_config_x = '42'
+  // Except loglevel.
+  process.env.npm_config_loglevel = 'debug'
+
+  var g = gyp();
+  g.parseArgv(['rebuild'])  // Also sets opts.argv.
+
+  t.deepEqual(Object.keys(g.opts).sort(), ['argv', 'x'])
+})


### PR DESCRIPTION
The bundled copy of GYP enters an infinite loop when it encounters a
zero-length option so ensure those don't get through.

The root cause is a bad guard in gyp/pylib/gyp/input.py that doesn't
take into account that `'' in 'whatever'` evaluates to True.

Fixes: https://github.com/nodejs/node-gyp/issues/744

R=@rvagg