### PR TITLE
Add support for AIX

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -65,6 +65,11 @@
           'DYLIB_INSTALL_NAME_BASE': '@rpath'
         },
       }],
+      [ 'OS=="aix"', {
+        'ldflags': [
+          '-Wl,-bimport:<(node_exp_file)'
+        ],
+      }],
       [ 'OS=="win"', {
         'libraries': [
           '-lkernel32.lib',

--- a/lib/build.js
+++ b/lib/build.js
@@ -19,9 +19,15 @@ var fs = require('graceful-fs')
 exports.usage = 'Invokes `' + (win ? 'msbuild' : 'make') + '` and builds the module'
 
 function build (gyp, argv, callback) {
+  var platformMake = 'make'
+  if (process.platform === 'aix') {
+    platformMake = 'gmake'
+  } else if (process.platform.indexOf('bsd') !== -1) {
+    platformMake = 'gmake'
+  }
+
   var release = processRelease(argv, gyp, process.version, process.release)
-    , makeCommand = gyp.opts.make || process.env.MAKE
-      || (process.platform.indexOf('bsd') != -1 ? 'gmake' : 'make')
+    , makeCommand = gyp.opts.make || process.env.MAKE || platformMake
     , command = win ? 'msbuild' : makeCommand
     , buildDir = path.resolve('build')
     , configPath = path.resolve(buildDir, 'config.gypi')

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -19,6 +19,7 @@ var fs = require('graceful-fs')
   , spawn = cp.spawn
   , execFile = cp.execFile
   , win = process.platform == 'win32'
+  , findNodeDirectory = require('./find-node-directory')
 
 exports.usage = 'Generates ' + (win ? 'MSVC project files' : 'a Makefile') + ' for the current module'
 
@@ -299,6 +300,34 @@ function configure (gyp, argv, callback) {
       argv.push('-I', config)
     })
 
+    // for AIX we need to set up the path to the exp file
+    // which contains the symbols needed for linking.
+    // The file will either be in one of the following
+    // depending on whether it is an installed or
+    // development environment:
+    //  - the include/node directory
+    //  - the out/Release directory
+    //  - the out/Debug directory
+    //  - the root directory
+    var node_exp_file = ''
+    if (process.platform === 'aix') {
+      var node_root_dir = findNodeDirectory()
+      var candidates = ['include/node/node.exp',
+                        'out/Release/node.exp',
+                        'out/Debug/node.exp',
+                        'node.exp']
+      for (var next = 0; next < candidates.length; next++) {
+         node_exp_file = path.resolve(node_root_dir, candidates[next])
+         try {
+           fs.accessSync(node_exp_file, fs.R_OK)
+           // exp file found, stop looking
+           break
+         } catch (exception) {
+           // this candidate was not found or not readable, do nothing
+         }
+      }
+    }
+
     // this logic ported from the old `gyp_addon` python file
     var gyp_script = path.resolve(__dirname, '..', 'gyp', 'gyp_main.py')
     var addon_gypi = path.resolve(__dirname, '..', 'addon.gypi')
@@ -319,6 +348,9 @@ function configure (gyp, argv, callback) {
       argv.push('-Dlibrary=shared_library')
       argv.push('-Dvisibility=default')
       argv.push('-Dnode_root_dir=' + nodeDir)
+      if (process.platform === 'aix') {
+        argv.push('-Dnode_exp_file=' + node_exp_file)
+      }
       argv.push('-Dnode_gyp_dir=' + nodeGypDir)
       argv.push('-Dnode_lib_file=' + release.name + '.lib')
       argv.push('-Dmodule_root_dir=' + process.cwd())

--- a/lib/find-node-directory.js
+++ b/lib/find-node-directory.js
@@ -1,0 +1,61 @@
+var path = require('path')
+  , log = require('npmlog')
+
+function findNodeDirectory(scriptLocation, processObj) {
+  // set dirname and process if not passed in
+  // this facilitates regression tests
+  if (scriptLocation === undefined) {
+    scriptLocation = __dirname
+  }
+  if (processObj === undefined) {
+    processObj = process
+  }
+
+  // Have a look to see what is above us, to try and work out where we are
+  npm_parent_directory = path.join(scriptLocation, '../../../..')
+  log.verbose('node-gyp root', 'npm_parent_directory is '
+              + path.basename(npm_parent_directory))
+  node_root_dir = ""
+
+  log.verbose('node-gyp root', 'Finding node root directory')
+  if (path.basename(npm_parent_directory) === 'deps') {
+    // We are in a build directory where this script lives in
+    // deps/npm/node_modules/node-gyp/lib
+    node_root_dir = path.join(npm_parent_directory, '..')
+    log.verbose('node-gyp root', 'in build directory, root = '
+                + node_root_dir)
+  } else if (path.basename(npm_parent_directory) === 'node_modules') {
+    // We are in a node install directory where this script lives in
+    // lib/node_modules/npm/node_modules/node-gyp/lib or
+    // node_modules/npm/node_modules/node-gyp/lib depending on the
+    // platform
+    if (processObj.platform === 'win32') {
+      node_root_dir = path.join(npm_parent_directory, '..')
+    } else {
+      node_root_dir = path.join(npm_parent_directory, '../..')
+    }
+    log.verbose('node-gyp root', 'in install directory, root = '
+                + node_root_dir)
+  } else {
+    // We don't know where we are, try working it out from the location
+    // of the node binary
+    var node_dir = path.dirname(processObj.execPath)
+    var directory_up = path.basename(node_dir)
+    if (directory_up === 'bin') {
+      node_root_dir = path.join(node_dir, '..')
+    } else if (directory_up === 'Release' || directory_up === 'Debug') {
+      // If we are a recently built node, and the directory structure
+      // is that of a repository. If we are on Windows then we only need
+      // to go one level up, everything else, two
+      if (processObj.platform === 'win32') {
+        node_root_dir = path.join(node_dir, '..')
+      } else {
+        node_root_dir = path.join(node_dir, '../..')
+      }
+    }
+    // Else return the default blank, "".
+  }
+  return node_root_dir
+}
+
+module.exports = findNodeDirectory

--- a/test/test-find-node-directory.js
+++ b/test/test-find-node-directory.js
@@ -1,0 +1,115 @@
+var test = require('tape')
+var path = require('path')
+var findNodeDirectory = require('../lib/find-node-directory')
+
+var platforms = ['darwin', 'freebsd', 'linux', 'sunos', 'win32', 'aix']
+
+// we should find the directory based on the directory
+// the script is running in and it should match the layout
+// in a build tree where npm is installed in
+// .... /deps/npm
+test('test find-node-directory - node install', function (t) {
+  t.plan(platforms.length)
+  for (var next = 0; next < platforms.length; next++) {
+    var processObj = {execPath: '/x/y/bin/node', platform: platforms[next]}
+    t.equal(
+      findNodeDirectory('/x/deps/npm/node_modules/node-gyp/lib', processObj),
+                        path.join('/x'))
+  }
+})
+
+// we should find the directory based on the directory
+// the script is running in and it should match the layout
+// in an installed tree where npm is installed in
+// .... /lib/node_modules/npm or .../node_modules/npm
+// depending on the patform
+test('test find-node-directory - node build', function (t) {
+  t.plan(platforms.length)
+  for (var next = 0; next < platforms.length; next++) {
+    var processObj = {execPath: '/x/y/bin/node', platform: platforms[next]}
+    if (platforms[next] === 'win32') {
+      t.equal(
+        findNodeDirectory('/y/node_modules/npm/node_modules/node-gyp/lib',
+                           processObj), path.join('/y'))
+    } else {
+      t.equal(
+        findNodeDirectory('/y/lib/node_modules/npm/node_modules/node-gyp/lib',
+                           processObj), path.join('/y'))
+    }
+  }
+})
+
+// we should find the directory based on the execPath
+// for node and match because it was in the bin directory
+test('test find-node-directory - node in bin directory', function (t) {
+  t.plan(platforms.length)
+  for (var next = 0; next < platforms.length; next++) {
+    var processObj = {execPath: '/x/y/bin/node', platform: platforms[next]}
+    t.equal(
+      findNodeDirectory('/nothere/npm/node_modules/node-gyp/lib', processObj),
+      path.join('/x/y'))
+  }
+})
+
+// we should find the directory based on the execPath
+// for node and match because it was in the Release directory
+test('test find-node-directory - node in build release dir', function (t) {
+  t.plan(platforms.length)
+  for (var next = 0; next < platforms.length; next++) {
+    var processObj
+    if (platforms[next] === 'win32') {
+      processObj = {execPath: '/x/y/Release/node', platform: platforms[next]}
+    } else {
+      processObj = {execPath: '/x/y/out/Release/node',
+                    platform: platforms[next]}
+    }
+
+    t.equal(
+      findNodeDirectory('/nothere/npm/node_modules/node-gyp/lib', processObj),
+                        path.join('/x/y'))
+  }
+})
+
+// we should find the directory based on the execPath
+// for node and match because it was in the Debug directory
+test('test find-node-directory - node in Debug release dir', function (t) {
+  t.plan(platforms.length)
+  for (var next = 0; next < platforms.length; next++) {
+    var processObj
+    if (platforms[next] === 'win32') {
+      processObj = {execPath: '/a/b/Debug/node', platform: platforms[next]}
+    } else {
+      processObj = {execPath: '/a/b/out/Debug/node', platform: platforms[next]}
+    }
+
+    t.equal(
+      findNodeDirectory('/nothere/npm/node_modules/node-gyp/lib', processObj),
+                        path.join('/a/b'))
+  }
+})
+
+// we should not find it as it will not match based on the execPath nor
+// the directory from which the script is running
+test('test find-node-directory - not found', function (t) {
+  t.plan(platforms.length)
+  for (var next = 0; next < platforms.length; next++) {
+    var processObj = {execPath: '/x/y/z/y', platform:next}
+    t.equal(findNodeDirectory('/a/b/c/d', processObj), '')
+  }
+})
+
+// we should find the directory based on the directory
+// the script is running in and it should match the layout
+// in a build tree where npm is installed in
+// .... /deps/npm
+// same test as above but make sure additional directory entries
+// don't cause an issue
+test('test find-node-directory - node install', function (t) {
+  t.plan(platforms.length)
+  for (var next = 0; next < platforms.length; next++) {
+    var processObj = {execPath: '/x/y/bin/node', platform: platforms[next]}
+    t.equal(
+      findNodeDirectory('/x/y/z/a/b/c/deps/npm/node_modules/node-gyp/lib',
+                        processObj), path.join('/x/y/z/a/b/c'))
+  }
+})


### PR DESCRIPTION
For AIX we need to use gmake

For AIX we need to set up the path to the exp file
which contains the symbols needed for linking.
The file will either be in one of the following
depeding on whether are are in installed or
development environment:
  - the include/node directory
  - the out/Release directory

The work to add the required node.exp file is being covered in this PR https://github.com/nodejs/node/pull/3114