### PR TITLE
Fixes for when Python is installed in MSYS environment

### DIFF
--- a/gyp/gyp_main.py
+++ b/gyp/gyp_main.py
@@ -9,7 +9,10 @@ import sys
 
 # Make sure we're using the version of pylib in this repo, not one installed
 # elsewhere on the system.
-sys.path.insert(0, os.path.join(os.path.dirname(sys.argv[0]), 'pylib'))
+if sys.platform == 'msys':
+  sys.path.insert(0, os.path.join(sys.path[0], 'pylib'))
+else:
+  sys.path.insert(0, os.path.join(os.path.dirname(sys.argv[0]), 'pylib'))
 import gyp
 
 if __name__ == '__main__':

--- a/gyp/pylib/gyp/common.py
+++ b/gyp/pylib/gyp/common.py
@@ -141,6 +141,10 @@ def RelativePath(path, relative_to, follow_path_symlink=True):
   # symlink, this option has no effect.
 
   # Convert to normalized (and therefore absolute paths).
+  if sys.platform == 'msys':
+    path = path.replace('C:\\','/c/').replace('\\','/')
+    relative_to = relative_to.replace('C:\\','/c/').replace('\\','/')
+
   if follow_path_symlink:
     path = os.path.realpath(path)
   else:

--- a/gyp/pylib/gyp/generator/msvs.py
+++ b/gyp/pylib/gyp/generator/msvs.py
@@ -162,7 +162,12 @@ def _FixPath(path):
   Returns:
     The path with all slashes made into backslashes.
   """
-  if fixpath_prefix and path and not os.path.isabs(path) and not path[0] == '$':
+  
+  if sys.platform == 'msys':
+    path = path.replace('/c/','C:\\')
+    if fixpath_prefix and path and not path.startswith('C:\\') and not path[0] == '$':
+        path = os.path.join(fixpath_prefix, path)
+  elif fixpath_prefix and path and not os.path.isabs(path) and not path[0] == '$':
     path = os.path.join(fixpath_prefix, path)
   path = path.replace('/', '\\')
   path = _NormalizedSource(path)
@@ -3111,7 +3116,10 @@ def _VerifySourcesExist(sources, root_dir):
       missing_sources.extend(_VerifySourcesExist(source.contents, root_dir))
     else:
       if '$' not in source:
-        full_path = os.path.join(root_dir, source)
+        if (sys.platform == 'msys' or sys.platform == 'win32') and source.startswith('C:\\'):
+		  full_path = source
+        else:
+          full_path = os.path.join(root_dir, source)
         if not os.path.exists(full_path):
           missing_sources.append(full_path)
   return missing_sources


### PR DESCRIPTION
Allow node-gyp to run in Windows when the python executable is installed in an MSYS environment.

Fixes are mainly to do with problems when handling path strings, and when adding relative file paths to the MSBuild project file.