### PR TITLE
configure: Add params for inherit defaults config

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -111,10 +111,12 @@ function configure (gyp, argv, callback) {
     // doing so could cause problems in cases where the `node` executable was
     // compiled on a different machine (with different lib/include paths) than
     // the machine where the addon is being built to
-    defaults.cflags = []
-    defaults.defines = []
-    defaults.include_dirs = []
-    defaults.libraries = []
+    if (!process.env.GYP_INHERIT_DEFAULTS || !~argv.indexOf('--enable-inherit')) {
+      defaults.cflags = []
+      defaults.defines = []
+      defaults.include_dirs = []
+      defaults.libraries = []
+    }
 
     // set the default_configuration prop
     if ('debug' in gyp.opts) {


### PR DESCRIPTION
By default, Configure don't inherit the "defaults" from
node's `process.config` object. But sometimes it need to be
inherit from node's compile params.

So add `process.env.GYP_INHERIT_DEFAULTS` environment variable
and `--enable-inherit` arguments to control it.
