### PR TITLE
Use npm's cafile config re #848

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -425,7 +425,6 @@ function install (gyp, argv, callback) {
 
 function download (gyp, env, url) {
   log.http('GET', url)
-
   var requestOpts = {
       uri: url
     , headers: {
@@ -433,7 +432,8 @@ function download (gyp, env, url) {
       }
   }
 
-  var cafile = gyp.opts.cafile
+  var cafile = gyp.opts.cafile || process.env.npm_config_cafile;
+
   if (cafile) {
     requestOpts.ca = readCAFile(cafile)
   }


### PR DESCRIPTION
Do a google search for "UNABLE_TO_GET_ISSUER_CERT_LOCALLY" or "can't install behind corporate firewall" or "can't install behind proxy".

tl;dr I need to install a module, which requires something to be rebuilt, and it fails because node-gyp doesn't honor my npm configurations for cafiles (for corporate self-signed certificate).

Specifically, this addresses needing to download node's headers when an install/update requires a rebuild.