### PR TITLE
Add `target_modules_version` variable into generated config.gypi file

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -81,6 +81,29 @@ function configure (gyp, argv, callback) {
     }
   }
 
+  function getModulesVersion(nodeDir) {
+
+    var sources = [
+      path.join(nodeDir, 'include/node/node_version.h'),
+      path.join(nodeDir, 'src/node_version.h'),
+    ]
+
+    for (var i = 0; i < sources.length; ++i) {
+      try {
+        var source = fs.readFileSync(sources[i], { encoding: 'utf8'})
+        var version = source.match(/^#define\s+NODE_MODULE_VERSION\s+(\d+)/m)
+        if (!version) {
+          err = new Error("can't find #define NODE_MODULE_VERSION in " + sources[i]);
+          callback(err);
+        }
+        return parseInt(version[1], 10);
+      }
+      catch (e) {}
+    }
+    err = new Error("can't read node_version.h in " + nodeDir)
+    callback(err);
+  }
+
   function createBuildDir () {
     log.verbose('build dir', 'attempting to create "build" dir: %s', buildDir)
     mkdirp(buildDir, function (err, isNew) {
@@ -127,6 +150,12 @@ function configure (gyp, argv, callback) {
 
     // set the target_arch variable
     variables.target_arch = gyp.opts.arch || process.arch || 'ia32'
+
+    // set the target_platform variable
+    variables.target_platform = process.platform
+
+    // set the target modules version
+    variables.target_modules_version = getModulesVersion(nodeDir)
 
     // set the node development directory
     variables.nodedir = nodeDir

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -128,15 +128,18 @@ function configure (gyp, argv, callback) {
 
     // set the target_arch variable
     variables.target_arch = gyp.opts.arch || process.arch || 'ia32'
-    log.verbose('build/' + configFilename, 'target arch: ' + variables.target_arch)
+    log.verbose('build/' + configFilename,
+      'target arch: ' + variables.target_arch)
 
     // set the target_platform variable
     variables.target_platform = process.platform
-    log.verbose('build/' + configFilename, 'target platform: ' + variables.target_platform)
+    log.verbose('build/' + configFilename,
+      'target platform: ' + variables.target_platform)
 
     // set the target modules version
     variables.target_modules_version = nodeModulesVersion(nodeDir)
-    log.verbose('build/' + configFilename, 'modules version: ' + variables.target_modules_version)
+    log.verbose('build/' + configFilename,
+      'modules version: ' + variables.target_modules_version)
 
     // set the node development directory
     variables.nodedir = nodeDir
@@ -332,7 +335,7 @@ function nodeModulesVersion(nodeDir) {
   // parse version from the base name of nodeDir
   // probably removing optional `releaseName-` prefix
   var nodeVersion = semver.valid(versionStr)
-                 || semver.valid(versionStr.substr(versionStr.indexOf('-') + 1))
+        || semver.valid(versionStr.substr(versionStr.indexOf('-') + 1))
 
   if (!nodeVersion) {
     throw new Error('Can\'t extract target version from ' + nodeDir)
@@ -349,7 +352,7 @@ function nodeModulesVersion(nodeDir) {
   }
   nodeVersion = path.join(nodeDir, nodeVersion)
 
-  var modulesVersion = fs.readFileSync(nodeVersion, { encoding: 'utf8'})
+  var modulesVersion = fs.readFileSync(nodeVersion, { encoding: 'utf8' })
                           .match(/#define\s+NODE_MODULE_VERSION\s+\(?(\S+)\)?/)
   if (!modulesVersion) {
     throw new Error('#define NODE_MODULE_VERSION not found in ' + nodeVersion)

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -83,25 +83,35 @@ function configure (gyp, argv, callback) {
 
   function getModulesVersion(nodeDir) {
 
-    var sources = [
-      path.join(nodeDir, 'include/node/node_version.h'),
-      path.join(nodeDir, 'src/node_version.h'),
-    ]
+    var name, source, version
 
-    for (var i = 0; i < sources.length; ++i) {
-      try {
-        var source = fs.readFileSync(sources[i], { encoding: 'utf8'})
-        var version = source.match(/^#define\s+NODE_MODULE_VERSION\s+(\d+)/m)
-        if (!version) {
-          err = new Error("can't find #define NODE_MODULE_VERSION in " + sources[i]);
-          callback(err);
-        }
-        return parseInt(version[1], 10);
-      }
-      catch (e) {}
+    // NODE_MODULE_VERSION is defined in different files
+    // depending on the target Node.js version
+    if (semver.gte(release.semver, '3.0.0')) {
+      name = 'include/node/node_version.h'
+    } else if (semver.gt(release.semver, '0.11.4')) {
+      name = 'src/node_version.h'
+    } else {
+      name = 'src/node.h'
     }
-    err = new Error("can't read node_version.h in " + nodeDir)
-    callback(err);
+    name = path.join(nodeDir, name)
+
+    try {
+      source = fs.readFileSync(name, { encoding: 'utf8'}) 
+    } catch (e) {
+      err = e
+      callback(err)
+      return undefined
+    }
+
+    version = source.match(/#define\s+NODE_MODULE_VERSION\s+\(?(\S+)\)?/)
+    if (version === null) {
+      err = new Error('#define NODE_MODULE_VERSION not found in ' + name)
+      callback(err)
+      return undefined
+    }
+    version = parseInt(version[1])
+    return version
   }
 
   function createBuildDir () {
@@ -150,12 +160,15 @@ function configure (gyp, argv, callback) {
 
     // set the target_arch variable
     variables.target_arch = gyp.opts.arch || process.arch || 'ia32'
+    log.verbose('build/' + configFilename, 'target arch: ' + variables.target_arch)
 
     // set the target_platform variable
     variables.target_platform = process.platform
+    log.verbose('build/' + configFilename, 'target platform: ' + variables.target_platform)
 
     // set the target modules version
     variables.target_modules_version = getModulesVersion(nodeDir)
+    log.verbose('build/' + configFilename, 'modules version: ' + variables.target_modules_version)
 
     // set the node development directory
     variables.nodedir = nodeDir

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -1,6 +1,7 @@
 module.exports = exports = configure
 module.exports.test = { findAccessibleSync: findAccessibleSync, 
-  findPython: findPython }
+  findPython: findPython,
+  nodeModulesVersion: nodeModulesVersion }
 
 /**
  * Module dependencies.
@@ -81,39 +82,6 @@ function configure (gyp, argv, callback) {
     }
   }
 
-  function getModulesVersion(nodeDir) {
-
-    var name, source, version
-
-    // NODE_MODULE_VERSION is defined in different files
-    // depending on the target Node.js version
-    if (semver.gte(release.semver, '3.0.0')) {
-      name = 'include/node/node_version.h'
-    } else if (semver.gt(release.semver, '0.11.4')) {
-      name = 'src/node_version.h'
-    } else {
-      name = 'src/node.h'
-    }
-    name = path.join(nodeDir, name)
-
-    try {
-      source = fs.readFileSync(name, { encoding: 'utf8'}) 
-    } catch (e) {
-      err = e
-      callback(err)
-      return undefined
-    }
-
-    version = source.match(/#define\s+NODE_MODULE_VERSION\s+\(?(\S+)\)?/)
-    if (version === null) {
-      err = new Error('#define NODE_MODULE_VERSION not found in ' + name)
-      callback(err)
-      return undefined
-    }
-    version = parseInt(version[1])
-    return version
-  }
-
   function createBuildDir () {
     log.verbose('build dir', 'attempting to create "build" dir: %s', buildDir)
     mkdirp(buildDir, function (err, isNew) {
@@ -167,7 +135,7 @@ function configure (gyp, argv, callback) {
     log.verbose('build/' + configFilename, 'target platform: ' + variables.target_platform)
 
     // set the target modules version
-    variables.target_modules_version = getModulesVersion(nodeDir)
+    variables.target_modules_version = nodeModulesVersion(nodeDir)
     log.verbose('build/' + configFilename, 'modules version: ' + variables.target_modules_version)
 
     // set the node development directory
@@ -351,6 +319,42 @@ function configure (gyp, argv, callback) {
     }
   }
 
+}
+
+/**
+ * Returns value of NODE_MODULE_VERSION define
+ * from Node source code in specified directory
+ * for specified Node version
+ */
+function nodeModulesVersion(nodeDir) {
+  var versionStr = path.basename(nodeDir)
+
+  // parse version from the base name of nodeDir
+  // probably removing optional `releaseName-` prefix
+  var nodeVersion = semver.valid(versionStr)
+                 || semver.valid(versionStr.substr(versionStr.indexOf('-') + 1))
+
+  if (!nodeVersion) {
+    throw new Error('Can\'t extract target version from ' + nodeDir)
+  }
+
+  // NODE_MODULE_VERSION may be defined in different files
+  // depending on the target Node.js version
+  if (semver.gte(nodeVersion, '3.0.0')) {
+    nodeVersion = 'include/node/node_version.h'
+  } else if (semver.gt(nodeVersion, '0.11.4')) {
+    nodeVersion = 'src/node_version.h'
+  } else {
+    nodeVersion = 'src/node.h'
+  }
+  nodeVersion = path.join(nodeDir, nodeVersion)
+
+  var modulesVersion = fs.readFileSync(nodeVersion, { encoding: 'utf8'})
+                          .match(/#define\s+NODE_MODULE_VERSION\s+\(?(\S+)\)?/)
+  if (!modulesVersion) {
+    throw new Error('#define NODE_MODULE_VERSION not found in ' + nodeVersion)
+  }
+  return parseInt(modulesVersion[1]).toString()
 }
 
 /**

--- a/test/test-node-modules-version.js
+++ b/test/test-node-modules-version.js
@@ -1,0 +1,34 @@
+'use strict'
+
+var test = require('tape')
+var path = require('path')
+var semver = require('semver')
+var processRelease = require('../lib/process-release')
+var configure = require('../lib/configure')
+
+var gyp = require('../lib/node-gyp')() // for gyp.devDir
+gyp.parseArgv([]) // to initialize gyp.opts
+
+test('modules version for the current release', function (t) {
+  t.plan(1)
+
+  var release = processRelease([], gyp, process.version)
+  var nodeDir = path.join(gyp.devDir, release.versionDir)
+  var modulesVersion = configure.test.nodeModulesVersion(nodeDir)
+  t.equal(modulesVersion, process.versions.modules,
+    nodeDir + ' modulesVersion=' + modulesVersion)
+})
+
+test('node modules version for installed targets', function (t) {
+  gyp.commands.list([], function(err, versions) {
+    if (err) return t.fail(err)
+    t.plan(versions.length)
+
+    versions.forEach(function(version) {
+      var nodeDir = path.join(gyp.devDir, version)
+      var modulesVersion = configure.test.nodeModulesVersion(nodeDir)
+      t.ok(modulesVersion > 0,
+        nodeDir + ' modulesVersion=' + modulesVersion)
+    })
+  })
+})


### PR DESCRIPTION
It may be handy to have multiple native addon binaries for several Node.js versions (i.e. 0.12, 4.X, 5.X). Node.js has a value for the native modules version as `process.versions.modules`.

A particular C++ addon can be loaded in JavaScript depending on Node.js version like this:

```js
  // loads 'addon_win32_x64_m47.node' for Node.js 5.0 on Windows x64
  // loads 'addon_linux_x64_m46.node' for Node.js 4.X on Linux x64
  var native = require('addon' + process.platform + '_'
              + process.arch + '_m' + process.versions.modules + '.node');
```

The target binary file name should be set with `product_name` directive in binding.gyp file in a such way:

```gyp
  {
    'targets': [
      {
        'product_name': 'addon_<(target_platform)_<(target_arch)_m<(target_modules_version)'
        ... # rest of GYP directives
      }
    ]
  }
```

where `target_platform` is a configuration variable with value from Node.js `process.platform` property.

But the `process.versions.modules` value can't be used for `target_modules_version` since node-gyp can build targets for different Node.js versions specified with a `--target` command-line option.

To resolve this issue, a function getModulesVersion() was added on `configure` step to get a value of `NODE_MODULE_VERSION` defined in `node_version.h` file in a supplied directory with Node.js development files.