### PR TITLE
Remove use of soon to be deprecated util._extend

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -15,7 +15,6 @@ var fs = require('graceful-fs')
   , mkdirp = require('mkdirp')
   , cp = require('child_process')
   , PathArray = require('path-array')
-  , extend = require('util')._extend
   , processRelease = require('./process-release')
   , spawn = cp.spawn
   , execFile = cp.execFile
@@ -365,7 +364,10 @@ function findPython (python, callback) {
   }
 
   function checkPythonVersion () {
-    var env = extend({}, process.env)
+    var env = {};
+    for (var k in process.env) {
+      env[k] = process.env[k];
+    }
     env.TERM = 'dumb'
 
     execFile(python, ['-c', 'import platform; print(platform.python_version());'], { env: env }, function (err, stdout) {


### PR DESCRIPTION
Replace it with a simple loop, instead of pulling in a dependency, since
it is only used in the one place and there aren't really any corner
cases in this usage.

See: nodejs/node#4593