### PR TITLE
Allow for npmlog@2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "minimatch": "1",
     "mkdirp": "^0.5.0",
     "nopt": "2 || 3",
-    "npmlog": "0 || 1",
+    "npmlog": "0 || 1 || 2",
     "osenv": "0",
     "path-array": "^1.0.0",
     "request": "2",


### PR DESCRIPTION
The breaking change introduced in npmlog 2.x was to anyone who was using the
log as an event emitter and was listening for error events. Since node-gyp
doesn't do these things, it isn't impacted by this change.
