### PR TITLE
update PRESUBMIT.py to support python 2.6

### DIFF
--- a/gyp/PRESUBMIT.py
+++ b/gyp/PRESUBMIT.py
@@ -132,6 +132,7 @@ TRYBOTS = [
 
 
 def GetPreferredTryMasters(_, change):
-  return {
-      'client.gyp': { t: set(['defaulttests']) for t in TRYBOTS },
-  }
+  client = { 'client.gyp': {}}
+  for t in TRYBOTS:
+    client['client.gyp'].push({t: set(['defaulttests'])})
+  return client


### PR DESCRIPTION
To support node-gyp python 2.6 and so we can build on default redhat EL6 configurations.