### PR TITLE
Enable Node.js to build with Microsoft's ChakraCore engine

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -8,7 +8,7 @@
       '<(node_root_dir)/include/node',
       '<(node_root_dir)/src',
       '<(node_root_dir)/deps/uv/include',
-      '<(node_root_dir)/deps/v8/include'
+      '<(node_root_dir)/<(node_engine_include_dir)'
     ],
     'defines!': [
       'BUILDING_UV_SHARED=1',  # Inherited from common.gypi.
@@ -79,6 +79,12 @@
         ],
       }],
       [ 'OS=="win"', {
+        'conditions': [
+          ['node_engine=="chakracore"', {
+            'library_dirs': [ '<(node_root_dir)/$(ConfigurationName)' ],
+            'libraries': [ '<@(node_engine_libs)' ],
+          }],
+        ],
         'libraries': [
           '-lkernel32.lib',
           '-luser32.lib',

--- a/addon.gypi
+++ b/addon.gypi
@@ -1,15 +1,13 @@
 {
+  'variables' : {
+    'node_engine_include_dir%': 'deps/v8/include',
+  },
   'target_defaults': {
     'type': 'loadable_module',
     'win_delay_load_hook': 'true',
     'product_prefix': '',
 
     'conditions': [
-      [ 'node_engine=="v8"', {
-        'variables': {
-          'node_engine_include_dir%': 'deps/v8/include'
-        },
-      }],
       [ 'node_engine=="chakracore"', {
         'variables': {
           'node_engine_include_dir%': 'deps/chakrashim/include'

--- a/addon.gypi
+++ b/addon.gypi
@@ -4,6 +4,19 @@
     'win_delay_load_hook': 'true',
     'product_prefix': '',
 
+    'conditions': [
+      [ 'node_engine=="v8"', {
+        'variables': {
+          'node_engine_include_dir%': 'deps/v8/include'
+        },
+      }],
+      [ 'node_engine=="chakracore"', {
+        'variables': {
+          'node_engine_include_dir%': 'deps/chakrashim/include'
+        },
+      }]
+    ],
+
     'include_dirs': [
       '<(node_root_dir)/include/node',
       '<(node_root_dir)/src',

--- a/gyp/pylib/gyp/generator/msvs.py
+++ b/gyp/pylib/gyp/generator/msvs.py
@@ -338,6 +338,8 @@ def _BuildCommandLineForRuleRaw(spec, cmd, cygwin_shell, has_input_path,
       command = ['type']
     else:
       command = [cmd[0].replace('/', '\\')]
+    if quote_cmd:
+      command = ['"%s"' % i for i in command]
     # Add call before command to ensure that commands can be tied together one
     # after the other without aborting in Incredibuild, since IB makes a bat
     # file out of the raw command string, and some commands (like python) are
@@ -3209,6 +3211,9 @@ def _GetMSBuildProjectReferences(project):
           ['ReferenceOutputAssembly', 'false']
           ]
       for config in dependency.spec.get('configurations', {}).itervalues():
+        if config.get('msvs_use_library_dependency_inputs', 0):
+          project_ref.append(['UseLibraryDependencyInputs', 'true'])
+          break
         # If it's disabled in any config, turn it off in the reference.
         if config.get('msvs_2010_disable_uldi_when_referenced', 0):
           project_ref.append(['UseLibraryDependencyInputs', 'false'])

--- a/gyp/pylib/gyp/generator/msvs.py
+++ b/gyp/pylib/gyp/generator/msvs.py
@@ -285,6 +285,22 @@ def _ConfigFullName(config_name, config_data):
   return '%s|%s' % (_ConfigBaseName(config_name, platform_name), platform_name)
 
 
+def _ConfigWindowsTargetPlatformVersion(config_data):
+  ver = config_data.get('msvs_windows_target_platform_version')
+  if not ver or re.match(r'^\d+', ver):
+    return ver
+  for key in [r'HKLM\Software\Microsoft\Microsoft SDKs\Windows\%s',
+              r'HKLM\Software\Wow6432Node\Microsoft\Microsoft SDKs\Windows\%s']:
+    sdkdir = MSVSVersion._RegistryGetValue(key % ver, 'InstallationFolder')
+    if not sdkdir:
+      continue
+    version = MSVSVersion._RegistryGetValue(key % ver, 'ProductVersion') or ''
+    # find a matching entry in sdkdir\include
+    names = sorted([x for x in os.listdir(r'%s\include' % sdkdir) \
+                    if x.startswith(version)], reverse = True)
+    return names[0]
+
+
 def _BuildCommandLineForRuleRaw(spec, cmd, cygwin_shell, has_input_path,
                                 quote_cmd, do_setup_env):
 
@@ -2663,6 +2679,22 @@ def _GetMSBuildGlobalProperties(spec, guid, gyp_file_name):
       properties[0].append(['ApplicationType', 'Windows Phone'])
     else:
       properties[0].append(['ApplicationType', 'Windows Store'])
+
+  platform_name = None
+  msvs_windows_target_platform_version = None
+  for configuration in spec['configurations'].itervalues():
+    platform_name = platform_name or _ConfigPlatform(configuration)
+    msvs_windows_target_platform_version = \
+                    msvs_windows_target_platform_version or \
+                    _ConfigWindowsTargetPlatformVersion(configuration)
+    if platform_name and msvs_windows_target_platform_version:
+      break
+
+  if platform_name == 'ARM':
+    properties[0].append(['WindowsSDKDesktopARMSupport', 'true'])
+  if msvs_windows_target_platform_version:
+    properties[0].append(['WindowsTargetPlatformVersion', \
+                          str(msvs_windows_target_platform_version)])
 
   return properties
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -226,7 +226,9 @@ function build (gyp, argv, callback) {
 
     // Specify the build type, Release by default
     if (win) {
-      var p = arch === 'x64' ? 'x64' : 'Win32'
+      var archLower = arch.toLowerCase()
+      var p = archLower === 'x64' ? 'x64' :
+              (archLower === 'arm' ? 'ARM' : 'Win32')
       argv.push('/p:Configuration=' + buildType + ';Platform=' + p)
       if (jobs) {
         var j = parseInt(jobs, 10)

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -272,7 +272,8 @@ function configure (gyp, argv, callback) {
       argv.push('-Dnode_gyp_dir=' + nodeGypDir)
       argv.push('-Dnode_lib_file=' + release.name + '.lib')
       argv.push('-Dmodule_root_dir=' + process.cwd())
-      argv.push('-Dnode_engine=' + (gyp.opts.node_engine || process.jsEngine || 'v8'))
+      argv.push('-Dnode_engine=' +
+        (gyp.opts.node_engine || process.jsEngine || 'v8'))
       argv.push('--depth=.')
       argv.push('--no-parallel')
 

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -272,6 +272,7 @@ function configure (gyp, argv, callback) {
       argv.push('-Dnode_gyp_dir=' + nodeGypDir)
       argv.push('-Dnode_lib_file=' + release.name + '.lib')
       argv.push('-Dmodule_root_dir=' + process.cwd())
+      argv.push('-Dnode_engine=' + (gyp.opts.node_engine || process.jsEngine || 'v8'))
       argv.push('--depth=.')
       argv.push('--no-parallel')
 


### PR DESCRIPTION
Enable node.js to build with Microsoft's chakracore engine on Windows x86, x64 and ARM architecture.

The changes were originally made as part of nodejs/node#4765, but based on @shigeki [comments](https://github.com/nodejs/node/pull/4765#commitcomment-15548451) and my [response](https://github.com/nodejs/node/pull/4765#issuecomment-173313320), I removed those changes from the PR and sending it separately to this repo.

Commits summary : 
- Add support to build node.js with chakracore
- Add support to build node.js with chakracore for Windows on ARM machines.
