### PR TITLE
Problem: command options aren't documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,17 @@ Commands
 | `list`        | Lists the currently installed node development file versions
 | `remove`      | Removes the node development header files for the given version
 
+Command options
+---------------
+
+`node-gyp` accepts the following command options:
+
+| **Option**         | **Description**
+|:-------------------|:------------------------------------------------
+| `-j n`, `--jobs n` | For `build`: run parallel builds
+| `-silly`, `--loglevel=silly` | Log all progress to console
+| `-verbose`, `--loglevel=verbose` | Log most progress to console
+| `-silent`, `--loglevel=silent` | Don't log anything
 
 License
 -------

--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -112,6 +112,7 @@ proto.shorthands = {
   , j: '--jobs'
   , silly: '--loglevel=silly'
   , verbose: '--loglevel=verbose'
+  , silent: '--loglevel=silent'
 }
 
 /**


### PR DESCRIPTION
Especially the --jobs and logging options are valuable and deserve to
be documented.

Solution: add 'Command options' section to README.md.

Note: I also added a -silent option to switch off all logging, for
consistency with the other logging options.