### PR TITLE
lib: do not check nvm path if not default release

### DIFF
--- a/lib/process-release.js
+++ b/lib/process-release.js
@@ -52,7 +52,8 @@ function processRelease (argv, gyp, defaultVersion, defaultRelease) {
   }
 
   // check for the nvm.sh standard mirror env variables
-  if (!overrideDistUrl) {
+  // do not check env if not a default release
+  if (!overrideDistUrl && !defaultRelease) {
     if (isIojs) {
       if (process.env.IOJS_ORG_MIRROR) {
         overrideDistUrl = process.env.IOJS_ORG_MIRROR


### PR DESCRIPTION
Currently the check for nvm mirror addresses will always happen,
even if the release in question is not default and provides it's own
url for finding headers.

This extra boolean check will ensure that non default releases will
use the embedded url for headers