### PR TITLE
gyp: fix android generator

### DIFF
--- a/gyp/pylib/gyp/generator/android.py
+++ b/gyp/pylib/gyp/generator/android.py
@@ -164,7 +164,7 @@ class AndroidMkWriter(object):
     if self.toolset == 'host':
       self.WriteLn('LOCAL_IS_HOST_MODULE := true')
       self.WriteLn('LOCAL_MULTILIB := $(GYP_HOST_MULTILIB)')
-    else:
+    elif sdk_version > 0:
       self.WriteLn('LOCAL_MODULE_TARGET_ARCH := '
                    '$(TARGET_$(GYP_VAR_PREFIX)ARCH)')
       self.WriteLn('LOCAL_SDK_VERSION := %s' % sdk_version)
@@ -965,7 +965,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
   builddir_name = generator_flags.get('output_dir', 'out')
   limit_to_target_all = generator_flags.get('limit_to_target_all', False)
   write_alias_targets = generator_flags.get('write_alias_targets', True)
-  sdk_version = generator_flags.get('aosp_sdk_version', 19)
+  sdk_version = generator_flags.get('aosp_sdk_version', 0)
   android_top_dir = os.environ.get('ANDROID_BUILD_TOP')
   assert android_top_dir, '$ANDROID_BUILD_TOP not set; you need to run lunch.'
 


### PR DESCRIPTION
When generating Android .mk files, ready to be used within Android build
system, we don't need LOCAL_SDK_VERSION specified, since the Android
build system already uses the latest one.
By specifying LOCAL_SDK_VERSION in Android makefiles, the build using
Android build system will fail, because the build system won't set the
path to stlport from prebuilts.

Signed-off-by: Robert Chiras <robert.chiras@intel.com>

#Note: This patch is very useful to help integrate node into an Android build system, mostly used by vendors when generating their products. I know the android generator is not maintained anymore, but fixing this generator is crucial for building node as target in an Android build system.