### PR TITLE
#890 Add support for the Python launcher on Windows

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -325,7 +325,7 @@ function findPython (python, callback) {
           return checkPython()
         }
         if (win) {
-          guessPython()
+          checkPythonLauncher()
         } else {
           failNoPython()
         }
@@ -337,6 +337,31 @@ function findPython (python, callback) {
         python = execPath
         checkPythonVersion()
       }
+    })
+  }
+
+  // Distributions of Python on Windows by default install with the "py.exe"
+  // Python launcher which is more likely to exist than the Python executable
+  // being in the $PATH.
+  // Because the Python launcher supports all versions of Python, we have to
+  // explicitly request a Python 2 version. This is done by supplying "-2" as
+  // the first command line argument. Since "py.exe -2" would be an invalid
+  // executable for "execFile", we have to use the launcher to figure out
+  // where the actual "python.exe" executable is located.
+  function checkPythonLauncher () {
+    log.verbose('could not find "' + python + '". checking python launcher')
+    var env = extend({}, process.env)
+    env.TERM = 'dumb'
+
+    var launcherArgs = ['-2', '-c', 'import sys; print sys.executable']
+    execFile('py.exe', launcherArgs, { env: env }, function (err, stdout) {
+      if (err) {
+        guessPython()
+        return
+      }
+      python = stdout.trim()
+      log.verbose('check python launcher', 'python executable found: %j', python)
+      checkPythonVersion()
     })
   }
 


### PR DESCRIPTION
This is a pull request for the issue #890: “Provide fallback to Python launcher on Windows when python.exe cannot be found”.

The changes here attempt to have very little impact. The new check is just inserted between the `checkPython` call (looking for the `'python'` executable) and the `guessPython` call on Windows. Since the Python launcher will give an explicit Python 2 executable, it is more explicit than if we found a match using `guessPython`, so I gave the launcher solution more priority.

As explained in the commit message, we cannot make a call to `py.exe -2` since that wouldn’t work with `execFile`, so I had to make an actual call to the Python launcher to get the full path of the Python executable. But if the command succeeds, then that reliably gives us a valid Python 2 executable.

If there is no Python 2 version registered with the launcher, the launcher will fail when attempting to call it with `-2`. When there is no Python launcher, `execFile` will fail. In both cases, the old next step `guessPython` will run.

> When looking for a Python executable on Windows, before falling back to guessing the default location or failing completely, attempt to use the Python launcher to figure out the location of the Python executable.
> 
> The Python launcher is being distributed by default with Python distributions on Windows, and is placed in the %WINDIR% folder (which is in the PATH). This allows us to locate a Python installation even if it was installed without putting the python.exe executable itself into the PATH.
> 
> Because the Python launcher supports all versions of Python, we have to explicitly request a Python 2 version. This is done by supplying "-2" as the first command line argument. Since "py.exe -2" would be an invalid executable for "execFile", we have to use the launcher to figure out where the actual "python.exe" executable is located.