### PR TITLE
Use python2 binary in gyp script

### DIFF
--- a/gyp/gyp
+++ b/gyp/gyp
@@ -4,5 +4,13 @@
 # found in the LICENSE file.
 
 set -e
+
+# Detect if it exists: http://stackoverflow.com/a/677212/247482
+if command -v python2 >/dev/null 2>&1; then
+  python=python2
+else
+  python=python
+fi
+
 base=$(dirname "$0")
-exec python "${base}/gyp_main.py" "$@"
+exec $python "${base}/gyp_main.py" "$@"


### PR DESCRIPTION
extends work started by #527

also falls back to `python` on not [PEP 394](https://www.python.org/dev/peps/pep-0394/) compatible platforms (OSX and very old linux distributions)