### PR TITLE
Override BUILDING_UV_SHARED, BUILDING_V8_SHARED.

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -10,8 +10,14 @@
       '<(node_root_dir)/deps/uv/include',
       '<(node_root_dir)/deps/v8/include'
     ],
+    'defines!': [
+      'BUILDING_UV_SHARED=1',  # Inherited from common.gypi.
+      'BUILDING_V8_SHARED=1',  # Inherited from common.gypi.
+    ],
     'defines': [
       'NODE_GYP_MODULE_NAME=>(_target_name)',
+      'USING_UV_SHARED=1',
+      'USING_V8_SHARED=1',
       # Warn when using deprecated V8 APIs.
       'V8_DEPRECATION_WARNINGS=1'
     ],


### PR DESCRIPTION
We were inheriting BUILDING_UV_SHARED and BUILDING_V8_SHARED from
the common.gypi from the node.js source tree.  Override them with
USING_UV_SHARED and USING_V8_SHARED so symbols get tagged with
`__declspec(dllimport)` instead of `__declspec(dllexport)`, which
is the desired attribute when building add-ons.

Fixes: https://github.com/nodejs/node-gyp/issues/914