### PR TITLE
Add --devdir flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Command Options
 | `--thin=yes`                      | Enable thin static libraries
 | `--arch=$arch`                    | Set target architecture (e.g. ia32)
 | `--tarball=$path`                 | Get headers from a local tarball
+| `--devdir=$path`                  | SDK download directory (default=~/.node-gyp)
 | `--ensure`                        | Don't reinstall headers if already present
 | `--dist-url=$url`                 | Download header tarball from custom URL
 | `--proxy=$url`                    | Set HTTP proxy for downloading header tarball

--- a/bin/node-gyp.js
+++ b/bin/node-gyp.js
@@ -12,6 +12,8 @@ process.title = 'node-gyp'
 
 var gyp = require('../')
 var log = require('npmlog')
+var osenv = require('osenv')
+var path = require('path')
 
 /**
  * Process and execute the selected commands.
@@ -20,6 +22,19 @@ var log = require('npmlog')
 var prog = gyp()
 var completed = false
 prog.parseArgv(process.argv)
+prog.devDir = prog.opts.devdir
+
+var homeDir = osenv.home()
+if (prog.devDir) {
+  prog.devDir = prog.devDir.replace(/^~/, homeDir)
+} else if (homeDir) {
+  prog.devDir = path.resolve(homeDir, '.node-gyp')
+} else {
+  throw new Error(
+    "node-gyp requires that the user's home directory is specified " +
+    "in either of the environmental variables HOME or USERPROFILE. " +
+    "Overide with: --devdir /path/to/.node-gyp")
+}
 
 if (prog.todo.length === 0) {
   if (~process.argv.indexOf('-v') || ~process.argv.indexOf('--version')) {

--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -46,18 +46,7 @@ function gyp () {
 function Gyp () {
   var self = this
 
-  // set the dir where node-gyp dev files get installed
-  // TODO: make this *more* configurable?
-  //       see: https://github.com/nodejs/node-gyp/issues/21
-  var homeDir = process.env.HOME || process.env.USERPROFILE
-  if (!homeDir) {
-    throw new Error(
-      "node-gyp requires that the user's home directory is specified " +
-      "in either of the environmental variables HOME or USERPROFILE"
-    );
-  }
-  this.devDir = path.resolve(homeDir, '.node-gyp')
-
+  this.devDir = ''
   this.commands = {}
 
   commands.forEach(function (command) {
@@ -92,6 +81,7 @@ proto.configDefs = {
   , ensure: Boolean   // 'install'
   , solution: String  // 'build' (windows only)
   , proxy: String     // 'install'
+  , devdir: String   // everywhere
   , nodedir: String   // 'configure'
   , loglevel: String  // everywhere
   , python: String    // 'configure'


### PR DESCRIPTION
Overrides the location where node-gyp will look for (and download to)
the node.js SDK.

For harmonization with the --nodedir flag, `osenv.home()` is now used
instead of `process.env.HOME || process.env.USERPROFILE`.

`osenv.home()` defaults to the built-in `os.homedir()` when available
and falls back to sane defaults based on the platform.

`%USERPROFILE%` is now preferred on Windows and `%HOME%` is ignored;
similarly, UNIX systems ignore `$USERPROFILE` from now on.  Neither
behavior made much sense, IMO.

Fixes: https://github.com/nodejs/node-gyp/issues/21