### PR TITLE
Enable V8 deprecation warnings for native modules

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -11,7 +11,9 @@
       '<(node_root_dir)/deps/v8/include'
     ],
     'defines': [
-      'NODE_GYP_MODULE_NAME=>(_target_name)'
+      'NODE_GYP_MODULE_NAME=>(_target_name)',
+      # Warn when using deprecated V8 APIs.
+      'V8_DEPRECATION_WARNINGS=1'
     ],
 
     'target_conditions': [


### PR DESCRIPTION
It will be helpful for native module developers to be aware of any
deprecated apis they are using so that they can update before their
modules break completely. Module developers can override this option
in their binding.gyp if they do not want to see these warnings.