### PR TITLE
Add support for a custom release name when downloading headers

### DIFF
--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -99,6 +99,7 @@ proto.configDefs = {
   , 'tarball': String // 'install'
   , jobs: String      // 'build'
   , thin: String      // 'configure'
+  , releaseName: String // 'build'
 }
 
 /**
@@ -222,4 +223,3 @@ Object.defineProperty(proto, 'version', {
     }
   , enumerable: true
 })
-

--- a/lib/process-release.js
+++ b/lib/process-release.js
@@ -9,16 +9,16 @@ var semver = require('semver')
   , bitsreV3 = /\/win-(x86|ia32|x64)\// // io.js v3.x.x shipped with "ia32" but should
                                         // have been "x86"
 
-// Captures all the logic required to determine download URLs, local directory and 
+// Captures all the logic required to determine download URLs, local directory and
 // file names. Inputs come from command-line switches (--target, --dist-url),
 // `process.version` and `process.release` where it exists.
 function processRelease (argv, gyp, defaultVersion, defaultRelease) {
   var version = (semver.valid(argv[0]) && argv[0]) || gyp.opts.target || defaultVersion
     , versionSemver = semver.parse(version)
     , overrideDistUrl = gyp.opts['dist-url'] || gyp.opts.disturl
+    , name = gyp.opts.releaseName
     , isDefaultVersion
     , isIojs
-    , name
     , distBaseUrl
     , baseUrl
     , libUrl32
@@ -44,7 +44,7 @@ function processRelease (argv, gyp, defaultVersion, defaultRelease) {
     // v3 onward, has process.release
     name = defaultRelease.name.replace(/io\.js/, 'iojs') // remove the '.' for directory naming purposes
     isIojs = name === 'iojs'
-  } else {
+  } else if (!name) {
     // old node or alternative --target=
     // semver.satisfies() doesn't like prerelease tags so test major directly
     isIojs = versionSemver.major >= 1 && versionSemver.major < 4


### PR DESCRIPTION
This fixes an underlying issue which caused this issue over at `electron-rebuild` https://github.com/electron/electron-rebuild/issues/66

Basically `node-gyp` assumes that any version in the semver major range `1 --> 4` is `iojs`.  Recently electron hit a major version bump to `1.x.y`.  This caused `node-gyp` to start attempting to download `iojs` headers when they are in fact still node headers but the version number tracks electron not node.

This PR adds a `releaseName` parameter that will allow `electron-rebuild` (and other tools) to specify their own release names thus allowing electron to force the name to be "node" regardless of the major version they choose to use.