### PR TITLE
gyp: improvements for android generator

### DIFF
--- a/gyp/pylib/gyp/generator/android.py
+++ b/gyp/pylib/gyp/generator/android.py
@@ -875,6 +875,7 @@ class AndroidMkWriter(object):
       self.WriteLn('LOCAL_PRELINK_MODULE := false')
       self.WriteLn('include $(BUILD_%sSHARED_LIBRARY)' % modifier)
     elif self.type == 'executable':
+      self.WriteLn('LOCAL_CXX_STL := libc++_static')
       # Executables are for build and test purposes only, so they're installed
       # to a directory that doesn't get included in the system image.
       self.WriteLn('LOCAL_MODULE_PATH := $(gyp_shared_intermediate_dir)')
@@ -1080,7 +1081,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
   root_makefile.write('GYP_CONFIGURATION ?= %s\n' % default_configuration)
   root_makefile.write('GYP_VAR_PREFIX ?=\n')
   root_makefile.write('GYP_HOST_VAR_PREFIX ?=\n')
-  root_makefile.write('GYP_HOST_MULTILIB ?=\n')
+  root_makefile.write('GYP_HOST_MULTILIB ?= first\n')
 
   # Write out the sorted list of includes.
   root_makefile.write('\n')


### PR DESCRIPTION
When generating Android.mk files for HOST binaries, we need to specify
the LOCAL_CXX_STL to use when linking.
Also, set the variable GYP_HOST_MULTILIB to 'first'. This is used as
LOCAL_MULTILIB, and since we don't provide flags for both types of
builds (32-bit and 64-bit), the build system will try to build both and
fail.
More details about LOCAL_MULTILIB can be found here:
https://source.android.com/source/64-bit-builds.html

Signed-off-by: Robert Chiras <robert.chiras@intel.com>