### PR TITLE
Disable strict-ssl mode when a custom dist-url is provided…

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -452,6 +452,12 @@ function download (gyp, env, url) {
     }
   }
 
+  //strictSSL Disabled for custom dist-url
+  var customDistUrl = gyp.opts['dist-url'] || gyp.opts.disturl;
+  if (customDistUrl) {
+    requestOpts.strictSSL = false
+  }
+
   var req = request(requestOpts)
   req.on('response', function (res) {
     log.http(res.statusCode, url)


### PR DESCRIPTION
Since we provide a custom HTTPS URL for headers tarball, we take responsibility of the provided server certificate validity. 

This PR is for fixing an issue I have in my corporate network and I think it can fix a lot of issues related to headers download in a corporate network which are opened in other modules based on node-gyp.