### PR TITLE
Allow for npmlog@3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "minimatch": "1",
     "mkdirp": "^0.5.0",
     "nopt": "2 || 3",
-    "npmlog": "0 || 1 || 2",
+    "npmlog": "0 || 1 || 2 || 3",
     "osenv": "0",
     "path-array": "^1.0.0",
     "request": "2",


### PR DESCRIPTION
npmlog version 3 switches to gauge version 2.  The interface change is in
setGaugeTemplate, which node-gyp does not use.

(Allowing version 3, will let npm dedupe npmlog. As it is, we'll have two copies.)