### PR TITLE
Copying node.lib timestamp to prevent redundant link with msbuild

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -200,7 +200,15 @@ function build (gyp, argv, callback) {
       rs.pipe(ws)
       rs.on('error', callback)
       ws.on('error', callback)
-      rs.on('end', doBuild)
+      rs.on('end', function(){
+        fs.stat(archNodeLibPath, function(err, stat){
+          if (err) return callback(err)
+          fs.utimes(buildNodeLibPath, stat.atime, stat.mtime, function(err){
+            if (err) return callback(err)
+            doBuild();
+          })
+        })
+      })
     })
   }
 


### PR DESCRIPTION
I noticed node-gyp build always creates a new .node binary even when no code/lib were changed.
Turns out that the fact that node.lib copy is created by writing the file each time, which changes its timestamp, is causing msbuild.exe to trigger a link operation.
writing the file, and copying the timestamp resolves this issue.
