### PR TITLE
win: work around __pfnDliNotifyHook2 type change

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -43,7 +43,7 @@
         'conditions': [
           [ 'OS=="win"', {
             'sources': [
-              '<(node_gyp_dir)/src/win_delay_load_hook.c',
+              '<(node_gyp_dir)/src/win_delay_load_hook.cc',
             ],
             'msvs_settings': {
               'VCLinkerTool': {

--- a/src/win_delay_load_hook.cc
+++ b/src/win_delay_load_hook.cc
@@ -31,6 +31,6 @@ static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
   return (FARPROC) m;
 }
 
-PfnDliHook __pfnDliNotifyHook2 = load_exe_hook;
+decltype(__pfnDliNotifyHook2) __pfnDliNotifyHook2 = load_exe_hook;
 
 #endif


### PR DESCRIPTION
Visual Studio 2015 Update 3 defines __pfnDliNotifyHook2 as const.

Fixes: https://github.com/nodejs/node-gyp/issues/949