### PR TITLE
Replace fs.accessSync calls

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -1,5 +1,6 @@
 module.exports = exports = configure
-module.exports.test = { findPython: findPython }
+module.exports.test = { findAccessibleSync: findAccessibleSync, 
+  findPython: findPython }
 
 /**
  * Module dependencies.
@@ -20,6 +21,7 @@ var fs = require('graceful-fs')
   , execFile = cp.execFile
   , win = process.platform == 'win32'
   , findNodeDirectory = require('./find-node-directory')
+  , msgFormat = require('util').format
 
 exports.usage = 'Generates ' + (win ? 'MSVC project files' : 'a Makefile') + ' for the current module'
 
@@ -226,22 +228,21 @@ function configure (gyp, argv, callback) {
     //  - the out/Release directory
     //  - the out/Debug directory
     //  - the root directory
-    var node_exp_file = ''
+    var node_exp_file = undefined
     if (process.platform === 'aix') {
       var node_root_dir = findNodeDirectory()
       var candidates = ['include/node/node.exp',
                         'out/Release/node.exp',
                         'out/Debug/node.exp',
                         'node.exp']
-      for (var next = 0; next < candidates.length; next++) {
-         node_exp_file = path.resolve(node_root_dir, candidates[next])
-         try {
-           fs.accessSync(node_exp_file, fs.R_OK)
-           // exp file found, stop looking
-           break
-         } catch (exception) {
-           // this candidate was not found or not readable, do nothing
-         }
+      var logprefix = 'find exports file'
+      node_exp_file = findAccessibleSync(logprefix, node_root_dir, candidates)
+      if (node_exp_file !== undefined) {
+        log.verbose(logprefix, 'Found exports file: %s', node_exp_file)
+      } else {
+        var msg = msgFormat('Could not find node.exp file in %s', node_root_dir)
+        log.error(logprefix, 'Could not find exports file')
+        return callback(new Error(msg))
       }
     }
 
@@ -308,6 +309,29 @@ function configure (gyp, argv, callback) {
     }
   }
 
+}
+
+/**
+ * Returns the first file or directory from an array of candidates that is 
+ * readable by the current user, or undefined if none of the candidates are
+ * readable. 
+ */
+function findAccessibleSync (logprefix, dir, candidates) {
+  for (var next = 0; next < candidates.length; next++) {
+     var candidate = path.resolve(dir, candidates[next])
+     try {
+       var fd = fs.openSync(candidate, 'r')
+     } catch (e) {
+       // this candidate was not found or not readable, do nothing
+       log.silly(logprefix, 'Could not open %s: %s', candidate, e.message)
+       continue
+     }
+     fs.closeSync(fd)
+     log.silly(logprefix, 'Found readable %s', candidate)
+     return candidate
+  }
+
+  return undefined
 }
 
 function findPython (python, callback) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "node": ">= 0.8.0"
   },
   "devDependencies": {
-    "tape": "~4.2.0"
+    "tape": "~4.2.0",
+    "bindings": "~1.2.1",
+    "nan": "^2.0.0"
   },
   "scripts": {
     "test": "tape test/test-*"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   "devDependencies": {
     "tape": "~4.2.0",
     "bindings": "~1.2.1",
-    "nan": "^2.0.0"
+    "nan": "^2.0.0",
+    "require-inject": "~1.3.0"
   },
   "scripts": {
     "test": "tape test/test-*"

--- a/test/node_modules/hello_world/binding.gyp
+++ b/test/node_modules/hello_world/binding.gyp
@@ -1,0 +1,11 @@
+{
+  "targets": [
+    {
+      "target_name": "hello",
+      "sources": [ "hello.cc" ],
+      "include_dirs": [
+        "<!(node -e \"require('nan')\")"
+      ]
+    }
+  ]
+}

--- a/test/node_modules/hello_world/hello.cc
+++ b/test/node_modules/hello_world/hello.cc
@@ -1,0 +1,12 @@
+#include <nan.h>
+
+void Method(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  info.GetReturnValue().Set(Nan::New("world").ToLocalChecked());
+}
+
+void Init(v8::Local<v8::Object> exports) {
+  exports->Set(Nan::New("hello").ToLocalChecked(),
+               Nan::New<v8::FunctionTemplate>(Method)->GetFunction());
+}
+
+NODE_MODULE(hello, Init)

--- a/test/node_modules/hello_world/hello.js
+++ b/test/node_modules/hello_world/hello.js
@@ -1,0 +1,3 @@
+'use strict'
+var addon = require('bindings')('hello');
+exports.hello = function() { return addon.hello() }

--- a/test/node_modules/hello_world/package.json
+++ b/test/node_modules/hello_world/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "hello_world",
+  "version": "0.0.0",
+  "description": "Node.js Addons Example #1",
+  "main": "hello.js",
+  "private": true,
+  "dependencies": {
+    "bindings": "~1.2.1",
+    "nan": "^2.0.0"
+  },
+  "scripts": {
+    "test": "node hello.js"
+  },
+  "gypfile": true
+}

--- a/test/test-addon.js
+++ b/test/test-addon.js
@@ -1,0 +1,28 @@
+'use strict'
+
+var test = require('tape')
+var execFile = require('child_process').execFile
+var path = require('path')
+var addonPath = path.resolve(__dirname, 'node_modules', 'hello_world')
+var nodeGyp = path.resolve(__dirname, '..', 'bin', 'node-gyp.js')
+
+test('build simple addon', function (t) {
+  t.plan(3)
+
+  // Set the loglevel otherwise the output disappears when run via 'npm test'
+  var cmd = [nodeGyp, 'rebuild', '-C', addonPath, '--loglevel=verbose']
+  var proc = execFile(process.execPath, cmd, function (err, stdout, stderr) {
+    var logLines = stderr.toString().trim().split(/\r?\n/)
+    var lastLine = logLines[logLines.length-1]
+    t.strictEqual(err, null)
+    t.strictEqual(lastLine, 'gyp info ok', 'should end in ok')
+    try {
+      var binding = require('hello_world')
+      t.strictEqual(binding.hello(), 'world')
+    } catch (error) {
+      t.error(error, 'load module')
+    }
+  })
+  proc.stdout.setEncoding('utf-8')
+  proc.stderr.setEncoding('utf-8')
+})

--- a/test/test-find-accessible-sync.js
+++ b/test/test-find-accessible-sync.js
@@ -1,0 +1,86 @@
+'use strict'
+
+var test = require('tape')
+var path = require('path')
+var requireInject = require('require-inject')
+var configure = requireInject('../lib/configure', {
+  'graceful-fs': {
+    'closeSync': function (fd) { return undefined },
+    'openSync': function (path) {
+      if (readableFiles.some(function (f) { return f === path} )) {
+        return 0
+      } else {
+        var error = new Error('ENOENT - not found')
+        throw error
+      }
+    }
+  }
+})
+
+var dir = path.sep + 'testdir'
+var readableFile = 'readable_file'
+var anotherReadableFile = 'another_readable_file'
+var readableFileInDir = 'somedir' + path.sep + readableFile
+var readableFiles = [
+  path.resolve(dir, readableFile),
+  path.resolve(dir, anotherReadableFile),
+  path.resolve(dir, readableFileInDir)
+]
+
+test('find accessible - empty array', function (t) {
+  t.plan(1)
+
+  var candidates = []
+  var found = configure.test.findAccessibleSync('test', dir, candidates)
+  t.strictEqual(found, undefined)
+})
+
+test('find accessible - single item array, readable', function (t) {
+  t.plan(1)
+
+  var candidates = [ readableFile ]
+  var found = configure.test.findAccessibleSync('test', dir, candidates)
+  t.strictEqual(found, path.resolve(dir, readableFile))
+})
+
+test('find accessible - single item array, readable in subdir', function (t) {
+  t.plan(1)
+
+  var candidates = [ readableFileInDir ]
+  var found = configure.test.findAccessibleSync('test', dir, candidates)
+  t.strictEqual(found, path.resolve(dir, readableFileInDir))
+})
+
+test('find accessible - single item array, unreadable', function (t) {
+  t.plan(1)
+
+  var candidates = [ 'unreadable_file' ]
+  var found = configure.test.findAccessibleSync('test', dir, candidates)
+  t.strictEqual(found, undefined)
+})
+
+
+test('find accessible - multi item array, no matches', function (t) {
+  t.plan(1)
+
+  var candidates = [ 'non_existent_file', 'unreadable_file' ]
+  var found = configure.test.findAccessibleSync('test', dir, candidates)
+  t.strictEqual(found, undefined)
+})
+
+
+test('find accessible - multi item array, single match', function (t) {
+  t.plan(1)
+
+  var candidates = [ 'non_existent_file', readableFile ]
+  var found = configure.test.findAccessibleSync('test', dir, candidates)
+  t.strictEqual(found, path.resolve(dir, readableFile))
+})
+
+test('find accessible - multi item array, return first match', function (t) {
+  t.plan(1)
+
+  var candidates = [ 'non_existent_file', anotherReadableFile, readableFile ]
+  var found = configure.test.findAccessibleSync('test', dir, candidates)
+  t.strictEqual(found, path.resolve(dir, anotherReadableFile))
+})


### PR DESCRIPTION
9bfa0876b46764978492fffea074d2d7aa8954f9 (#753) added calls to `fs.accessSync` on AIX to test if the candidate exports file exists and is readable. Unfortunately `accessSync` does not exist in Node 0.10.x, so the exports file is not found and results in a linking error:
```
ld: 0706-003 Cannot find or read import file: /tmp/usenode.riclau/node-v0.10.45-aix-ppc64/node.exp
        ld:accessx(): A file or directory in the path name does not exist.
collect2: ld returned 255 exit status
gmake: *** [Release/obj.target/hello.node] Error 1
gyp ERR! build error
gyp ERR! stack Error: `gmake` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/home/users/riclau/sandbox/github/node-gyp/lib/build.js:276:23)
gyp ERR! stack     at ChildProcess.emit (events.js:98:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:820:12)
gyp ERR! System AIX 1
```