### PR TITLE
doc: add --target option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Command Options
 | **Command**                       | **Description**
 |:----------------------------------|:------------------------------------------
 | `-j n`, `--jobs n`                | Run make in parallel
+| `--target=v6.2.1`                 | Node version to build for (default=process.version)
 | `--silly`, `--loglevel=silly`     | Log all progress to console
 | `--verbose`, `--loglevel=verbose` | Log most progress to console
 | `--silent`, `--loglevel=silent`   | Don't log anything to console


### PR DESCRIPTION
Missed this in #937 

If there are any other changes that need making to the README (or other documentation) I can add them in, this is a bit small by itself.