### PR TITLE
build: use target_arch config variable to link against node.lib

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -92,7 +92,7 @@
           '-luuid.lib',
           '-lodbc32.lib',
           '-lDelayImp.lib',
-          '-l"<(node_root_dir)/$(ConfigurationName)/<(node_lib_file)"'
+          '-l"<(node_root_dir)/<(target_arch)/<(node_lib_file)"'
         ],
         'msvs_disabled_warnings': [
           # warning C4251: 'node::ObjectWrap::handle_' : class 'v8::Persistent<T>'

--- a/addon.gypi
+++ b/addon.gypi
@@ -92,7 +92,7 @@
           '-luuid.lib',
           '-lodbc32.lib',
           '-lDelayImp.lib',
-          '-l"<(node_root_dir)/<(target_arch)/<(node_lib_file)"'
+          '-l"<(node_lib_file)"'
         ],
         'msvs_disabled_warnings': [
           # warning C4251: 'node::ObjectWrap::handle_' : class 'v8::Persistent<T>'

--- a/lib/build.js
+++ b/lib/build.js
@@ -11,7 +11,6 @@ var fs = require('graceful-fs')
   , glob = require('glob')
   , log = require('npmlog')
   , which = require('which')
-  , mkdirp = require('mkdirp')
   , exec = require('child_process').exec
   , processRelease = require('./process-release')
   , win = process.platform == 'win32'
@@ -36,7 +35,6 @@ function build (gyp, argv, callback) {
     , config
     , arch
     , nodeDir
-    , copyDevLib
 
   loadConfigGypi()
 
@@ -60,7 +58,6 @@ function build (gyp, argv, callback) {
       buildType = config.target_defaults.default_configuration
       arch = config.variables.target_arch
       nodeDir = config.variables.nodedir
-      copyDevLib = config.variables.copy_dev_lib == 'true'
 
       if ('debug' in gyp.opts) {
         buildType = gyp.opts.debug ? 'Debug' : 'Release'
@@ -115,7 +112,7 @@ function build (gyp, argv, callback) {
         return
       }
       log.verbose('`which` succeeded for `' + command + '`', execPath)
-      copyNodeLib()
+      doBuild()
     })
   }
 
@@ -173,36 +170,12 @@ function build (gyp, argv, callback) {
             return
           }
           command = msbuildPath
-          copyNodeLib()
+          doBuild()
         })
       })()
     })
   }
 
-  /**
-   * Copies the node.lib file for the current target architecture into the
-   * current proper dev dir location.
-   */
-
-  function copyNodeLib () {
-    if (!win || !copyDevLib) return doBuild()
-
-    var buildDir = path.resolve(nodeDir, buildType)
-      , archNodeLibPath = path.resolve(nodeDir, arch, release.name + '.lib')
-      , buildNodeLibPath = path.resolve(buildDir, release.name + '.lib')
-
-    mkdirp(buildDir, function (err, isNew) {
-      if (err) return callback(err)
-      log.verbose('"' + buildType + '" dir needed to be created?', isNew)
-      var rs = fs.createReadStream(archNodeLibPath)
-        , ws = fs.createWriteStream(buildNodeLibPath)
-      log.verbose('copying "' + release.name + '.lib" for ' + arch, buildNodeLibPath)
-      rs.pipe(ws)
-      rs.on('error', callback)
-      ws.on('error', callback)
-      rs.on('end', doBuild)
-    })
-  }
 
   /**
    * Actually spawn the process and compile the module.

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -131,9 +131,6 @@ function configure (gyp, argv, callback) {
     // set the node development directory
     variables.nodedir = nodeDir
 
-    // don't copy dev libraries with nodedir option
-    variables.copy_dev_lib = !gyp.opts.nodedir
-
     // disable -T "thin" static archives by default
     variables.standalone_static_library = gyp.opts.thin ? 0 : 1
 

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -257,6 +257,9 @@ function configure (gyp, argv, callback) {
         output_dir = buildDir
       }
       var nodeGypDir = path.resolve(__dirname, '..')
+      var nodeLibFile = path.join(nodeDir,
+        !gyp.opts.nodedir ? '<(target_arch)' : '$(Configuration)',
+        release.name + '.lib')
 
       argv.push('-I', addon_gypi)
       argv.push('-I', common_gypi)
@@ -267,7 +270,7 @@ function configure (gyp, argv, callback) {
         argv.push('-Dnode_exp_file=' + node_exp_file)
       }
       argv.push('-Dnode_gyp_dir=' + nodeGypDir)
-      argv.push('-Dnode_lib_file=' + release.name + '.lib')
+      argv.push('-Dnode_lib_file=' + nodeLibFile)
       argv.push('-Dmodule_root_dir=' + process.cwd())
       argv.push('--depth=.')
       argv.push('--no-parallel')


### PR DESCRIPTION
PR extracted form #962

 on Windows

Using `target_arch` in addon.gypi to link against Node.js library.
This variable was written into build/config.gypi on the `configure` stage.

Do not copy node.lib into node_root_dir/Release or node_root_dir/Debug
on Windows, link it from node_root_dir/target_arch directory.

Removed unused copyNodeLib() function
Removed unused `copy_dev_lib` variable introduced in commit
@84d24189735e19350a93aaf9f6a327bb4c52349e
