### PR TITLE
gyp: fix runtime "NameError"s

### DIFF
--- a/gyp/gyptest.py
+++ b/gyp/gyptest.py
@@ -10,6 +10,7 @@ gyptest.py -- test runner for GYP tests.
 
 import os
 import optparse
+import shlex
 import subprocess
 import sys
 

--- a/gyp/pylib/gyp/mac_tool.py
+++ b/gyp/pylib/gyp/mac_tool.py
@@ -125,7 +125,7 @@ class MacTool(object):
     fp = open(file_name, 'rb')
     try:
       header = fp.read(3)
-    except e:
+    except Exception:
       fp.close()
       return None
     fp.close()


### PR DESCRIPTION
In "gyp/gyptest.py", `shlex` is used, but it is not imported. So it
will throw `NameError` at runtime.

In "gyp/pylib/gyp/mac_tool.py", the `except` block expects the type of
exception to be the first item or nothing. As it is, the block will
throw a `NameError` at runtime.