### PR TITLE
Remove path-array

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -287,9 +287,11 @@ function configure (gyp, argv, callback) {
       argv.unshift(gyp_script)
 
       // make sure python uses files that came with this particular node package
-      var pypath = process.env.PYTHONPATH ? [process.env.PYTHONPATH] : []
-      pypath.unshift(path.resolve(__dirname, '..', 'gyp', 'pylib'))
-      process.env.PYTHONPATH = pypath.join(process.platform === 'win32' ? ';' : ':')
+      var pypath = [path.join(__dirname, '..', 'gyp', 'pylib')]
+      if (process.env.PYTHONPATH) {
+        pypath.push(process.env.PYTHONPATH)
+      }
+      process.env.PYTHONPATH = pypath.join(win ? ';' : ':')
 
       var cp = gyp.spawn(python, argv)
       cp.on('exit', onCpExit)

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -14,7 +14,6 @@ var fs = require('graceful-fs')
   , semver = require('semver')
   , mkdirp = require('mkdirp')
   , cp = require('child_process')
-  , PathArray = require('path-array')
   , extend = require('util')._extend
   , processRelease = require('./process-release')
   , spawn = cp.spawn
@@ -288,8 +287,9 @@ function configure (gyp, argv, callback) {
       argv.unshift(gyp_script)
 
       // make sure python uses files that came with this particular node package
-      var pypath = new PathArray(process.env, 'PYTHONPATH')
-      pypath.unshift(path.join(__dirname, '..', 'gyp', 'pylib'))
+      var pypath = process.env.PYTHONPATH ? [process.env.PYTHONPATH] : []
+      pypath.unshift(path.resolve(__dirname, '..', 'gyp', 'pylib'))
+      process.env.PYTHONPATH = pypath.join(process.platform === 'win32' ? ';' : ':')
 
       var cp = gyp.spawn(python, argv)
       cp.on('exit', onCpExit)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "nopt": "2 || 3",
     "npmlog": "0 || 1 || 2 || 3",
     "osenv": "0",
-    "path-array": "^1.0.0",
     "request": "2",
     "rimraf": "2",
     "semver": "2.x || 3.x || 4 || 5",

--- a/test/test-configure-python.js
+++ b/test/test-configure-python.js
@@ -1,0 +1,73 @@
+'use strict'
+
+var test = require('tape')
+var path = require('path')
+var gyp = require('../lib/node-gyp')
+var requireInject = require('require-inject')
+var configure = requireInject('../lib/configure', {
+  'graceful-fs': {
+    'writeFile': function (file, data, cb) { cb() },
+    'stat': function (file, cb) { cb(null, {}) }
+  }
+})
+
+var EXPECTED_PYPATH = path.join(__dirname, '..', 'gyp', 'pylib')
+var SEPARATOR = process.platform == 'win32' ? ';' : ':'
+var SPAWN_RESULT = { on: function () { } }
+
+test('configure PYTHONPATH with no existing env', function (t) {
+  t.plan(1)
+
+  delete process.env.PYTHONPATH
+
+  var prog = gyp()
+  prog.parseArgv([])
+  prog.spawn = function () {
+    t.equal(process.env.PYTHONPATH, EXPECTED_PYPATH)
+    return SPAWN_RESULT
+  }
+  configure(prog, [])
+})
+
+test('configure PYTHONPATH with existing env of one dir', function (t) {
+  t.plan(2)
+
+  var existingPath = path.join('a', 'b')
+  process.env.PYTHONPATH = existingPath
+
+  var prog = gyp()
+  prog.parseArgv([])
+  prog.spawn = function () {
+
+    t.equal(process.env.PYTHONPATH, [EXPECTED_PYPATH, existingPath].join(SEPARATOR))
+
+    var dirs = process.env.PYTHONPATH.split(SEPARATOR)
+    t.deepEqual(dirs, [EXPECTED_PYPATH, existingPath])
+
+    return SPAWN_RESULT
+  }
+  configure(prog, [])
+})
+
+test('configure PYTHONPATH with existing env of multiple dirs', function (t) {
+  t.plan(2)
+
+  var pythonDir1 = path.join('a', 'b')
+  var pythonDir2 = path.join('b', 'c')
+  var existingPath = [pythonDir1, pythonDir2].join(SEPARATOR)
+  process.env.PYTHONPATH = existingPath
+
+  var prog = gyp()
+  prog.parseArgv([])
+  prog.spawn = function () {
+
+    t.equal(process.env.PYTHONPATH, [EXPECTED_PYPATH, existingPath].join(SEPARATOR))
+
+    var dirs = process.env.PYTHONPATH.split(SEPARATOR)
+    t.deepEqual(dirs, [EXPECTED_PYPATH, pythonDir1, pythonDir2])
+
+    return SPAWN_RESULT
+  }
+  configure(prog, [])
+})
+


### PR DESCRIPTION
This reverts commits 81eadc5692eb33f308209412daa7db5d53bcb744 and ff88e5fd1211877a9a6eb2a906f7e4d4ff377604.

Of the 5.5MB footprint of node-gyp, path-array makes up 3.6MB.

Removing this reduces the weight of npm (and ultimately node) appreciably (by 20%)