### PR TITLE
Fix escaping -I includes when path contains spaces

### DIFF
--- a/gyp/pylib/gyp/generator/make.py
+++ b/gyp/pylib/gyp/generator/make.py
@@ -1211,7 +1211,7 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
       includes = config.get('include_dirs')
       if includes:
         includes = map(Sourceify, map(self.Absolutify, includes))
-      self.WriteList(includes, 'INCS_%s' % configname, prefix='-I')
+      self.WriteList(includes, 'INCS_%s' % configname, prefix='-I', quoter=EscapeShellArgument)
 
     compilable = filter(Compilable, sources)
     objs = map(self.Objectify, map(self.Absolutify, map(Target, compilable)))


### PR DESCRIPTION
Fixes #65