### PR TITLE
Open the build file with universal-newlines mode

### DIFF
--- a/gyp/pylib/gyp/input.py
+++ b/gyp/pylib/gyp/input.py
@@ -230,7 +230,10 @@ def LoadOneBuildFile(build_file_path, data, aux_data, includes,
     return data[build_file_path]
 
   if os.path.exists(build_file_path):
-    build_file_contents = open(build_file_path).read()
+    # Open the build file for read ('r') with universal-newlines mode ('U')
+    # to make sure platform specific newlines ('\r\n' or '\r') are converted to '\n'
+    # which otherwise will fail eval()
+    build_file_contents = open(build_file_path, 'rU').read()
   else:
     raise GypError("%s not found (cwd: %s)" % (build_file_path, os.getcwd()))
 


### PR DESCRIPTION
To make sure platform specific newlines ('\r\n' or '\r') are converted to '\n' which otherwise will fail eval().

Reference to python docs (Note: this mode is deprecated in python3 but needed in python2)
https://docs.python.org/2.7/glossary.html#term-universal-newlines
https://docs.python.org/2.7/library/functions.html#open

This should handle multiple issues reported on syntax error reading binding.gyp (partial list):
https://github.com/nodejs/node-gyp/issues/979
https://github.com/nodejs/node-gyp/issues/199
https://github.com/stephenwvickers/node-net-ping/issues/24
https://github.com/stephenwvickers/node-net-ping/issues/21
https://github.com/mathiask88/node-snap7/issues/11
https://github.com/node-hid/node-hid/issues/28
https://github.com/xdenser/node-firebird-libfbclient/issues/24