### PR TITLE
Fix include path when pointing to Node.js source

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -18,7 +18,10 @@
     'include_dirs': [
       '<(node_root_dir)/include/node',
       '<(node_root_dir)/src',
+      '<(node_root_dir)/deps/openssl/config',
+      '<(node_root_dir)/deps/openssl/openssl/include',
       '<(node_root_dir)/deps/uv/include',
+      '<(node_root_dir)/deps/zlib',
       '<(node_root_dir)/<(node_engine_include_dir)'
     ],
     'defines!': [


### PR DESCRIPTION
Refs
- nodejs/citgm#226
- https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/449/

When building modules that include headers from Node.js dependencies (that are not libuv or V8) compilation fails when `--nodedir` is used to point to a Node.js source tree. 
e.g. `nodereport`'s [`node_report.cc`](https://github.com/nodejs/nodereport/blob/v1.0.5/src/node_report.cc) includes `ares.h` and `zlib.h` 
```
-bash-4.2$ node-gyp rebuild --nodedir /home/riclau/sandbox/scratch/tmp/node-v6.9.1-src/
gyp info it worked if it ends with ok
gyp info using node-gyp@3.4.0
gyp info using node@6.9.1 | linux | x64
gyp info spawn /usr/bin/python2
gyp info spawn args [ '/dev/shm/usenode.riclau/node-v6.9.1-linux-x64/lib/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args   'binding.gyp',
gyp info spawn args   '-f',
gyp info spawn args   'make',
gyp info spawn args   '-I',
gyp info spawn args   '/home/users/riclau/sandbox/github/nodereport/build/config.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/dev/shm/usenode.riclau/node-v6.9.1-linux-x64/lib/node_modules/node-gyp/addon.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/home/riclau/sandbox/scratch/tmp/node-v6.9.1-src/common.gypi',
gyp info spawn args   '-Dlibrary=shared_library',
gyp info spawn args   '-Dvisibility=default',
gyp info spawn args   '-Dnode_root_dir=/home/riclau/sandbox/scratch/tmp/node-v6.9.1-src/',
gyp info spawn args   '-Dnode_gyp_dir=/dev/shm/usenode.riclau/node-v6.9.1-linux-x64/lib/node_modules/node-gyp',
gyp info spawn args   '-Dnode_lib_file=node.lib',
gyp info spawn args   '-Dmodule_root_dir=/home/users/riclau/sandbox/github/nodereport',
gyp info spawn args   '--depth=.',
gyp info spawn args   '--no-parallel',
gyp info spawn args   '--generator-output',
gyp info spawn args   'build',
gyp info spawn args   '-Goutput_dir=.' ]
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
make: Entering directory `/home/users/riclau/sandbox/github/nodereport/build'
make: Warning: File `nodereport.target.mk' has modification time 893 s in the future
  CXX(target) Release/obj.target/nodereport/src/node_report.o
../src/node_report.cc:6:18: fatal error: ares.h: No such file or directory
 #include "ares.h"
                  ^
compilation terminated.
make: *** [Release/obj.target/nodereport/src/node_report.o] Error 1
make: Leaving directory `/home/users/riclau/sandbox/github/nodereport/build'
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/dev/shm/usenode.riclau/node-v6.9.1-linux-x64/lib/node_modules/node-gyp/lib/build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:106:13)
gyp ERR! stack     at ChildProcess.emit (events.js:191:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)
gyp ERR! System Linux 3.10.0-327.18.2.el7.x86_64
gyp ERR! command "/dev/shm/usenode.riclau/node-v6.9.1-linux-x64/bin/node" "/dev/shm/usenode.riclau/node-v6.9.1-linux-x64/bin/node-gyp" "rebuild" "--nodedir" "/home/riclau/sandbox/scratch/tmp/node-v6.9.1-src/"
gyp ERR! cwd /home/users/riclau/sandbox/github/nodereport
gyp ERR! node -v v6.9.1
gyp ERR! node-gyp -v v3.4.0
gyp ERR! not ok
-bash-4.2$
```

This is because the header files for Node.js dependencies are in a different location in the Node.js source tree compared to the release tarballs (see [`tools/install.py`](https://github.com/nodejs/node/blob/v6.9.1/tools/install.py#L146)). 