### PR TITLE
Fix deprecated dependency warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "minimatch": "^3.0.2",
     "mkdirp": "^0.5.0",
     "nopt": "2 || 3",
-    "npmlog": "0 || 1 || 2 || 3",
+    "npmlog": "0 || 1 || 2 || 3 || 4",
     "osenv": "0",
     "request": "2",
     "rimraf": "2",


### PR DESCRIPTION
![screenshot- 34](https://cloud.githubusercontent.com/assets/3505087/21073452/74b90178-bede-11e6-8a6b-87f9360b6c81.png)
**node-gyp** installs **npmlog@3.1.2**
**npmlog@3.1.2** installs **gauge@2.6.0**

**gauge@2.6.0** uses **has-color@0.1.7** that is been ranamed to _supports-color_

The warning is not showed if we tell **node-gyp** to use **npmlog@4.0.1**
**npmlog@4.0.1** installs **gauge@2.7.2** that fix the dependency warnings. 

See https://github.com/iarna/gauge/pull/77

![screenshot- 33](https://cloud.githubusercontent.com/assets/3505087/21073439/263f561e-bede-11e6-9bb6-3c64226404e0.png)


