### PR TITLE
allow long type along with int type

### DIFF
--- a/gyp/pylib/gyp/input.py
+++ b/gyp/pylib/gyp/input.py
@@ -1220,11 +1220,11 @@ def ProcessVariablesAndConditionsInDict(the_dict, phase, variables_in,
 
   for key, value in the_dict.iteritems():
     # Skip "variables", which was already processed if present.
-    if key != 'variables' and type(value) is str:
+    if key != 'variables' and isinstance(value, basestring):
       expanded = ExpandVariables(value, phase, variables, build_file)
-      if type(expanded) not in (str, int):
+      if not isinstance(expanded, (basestring, int, long)):
         raise ValueError(
-              'Variable expansion in this context permits str and int ' + \
+              'Variable expansion in this context permits str and int/long ' + \
               'only, found ' + expanded.__class__.__name__ + ' for ' + key)
       the_dict[key] = expanded
 
@@ -1279,21 +1279,21 @@ def ProcessVariablesAndConditionsInDict(the_dict, phase, variables_in,
   for key, value in the_dict.iteritems():
     # Skip "variables" and string values, which were already processed if
     # present.
-    if key == 'variables' or type(value) is str:
+    if key == 'variables' or isinstance(value, basestring):
       continue
-    if type(value) is dict:
+    if isinstance(value, dict):
       # Pass a copy of the variables dict so that subdicts can't influence
       # parents.
       ProcessVariablesAndConditionsInDict(value, phase, variables,
                                           build_file, key)
-    elif type(value) is list:
+    elif isinstance(value, list):
       # The list itself can't influence the variables dict, and
       # ProcessVariablesAndConditionsInList will make copies of the variables
       # dict if it needs to pass it to something that can influence it.  No
       # copy is necessary here.
       ProcessVariablesAndConditionsInList(value, phase, variables,
                                           build_file)
-    elif type(value) is not int:
+    elif not isinstance(value, (int, long)):
       raise TypeError('Unknown type ' + value.__class__.__name__ + \
                       ' for ' + key)
 


### PR DESCRIPTION
reopen of https://github.com/nodejs/node-gyp/pull/1085 pull request (single commit pull request)

refs https://github.com/yarnpkg/yarn/issues/2286
refs https://github.com/yarnpkg/yarn/issues/2376

allow long type as result of ExpandVariables call. along with str and int.
skip long type(value) along with int.

debug (buggy long type):
```json
[
  {"type(expanded)": "<type 'long'>", "expanded": "1483986851164", "value": "1483986851164", "phase": "0", "build_file": "binding.gyp"},
  {"type(expanded)": "<type 'long'>", "expanded": "1483986851164", "value": "1483986851164", "phase": "0", "build_file": "deps\\libexpat\\libexpat.gyp"}
]
```