### PR TITLE
Allow setting request's "ciphers" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Command Options
 | `--dist-url=$url`                 | Download header tarball from custom URL
 | `--proxy=$url`                    | Set HTTP proxy for downloading header tarball
 | `--cafile=$cafile`                | Override default CA chain (to download tarball)
+| `--ciphers=$cipherlist`           | Override default [TLS cipher suite](https://www.openssl.org/docs/man1.0.2/apps/ciphers.html#CIPHER-LIST-FORMAT) (to download tarball)
 | `--nodedir=$path`                 | Set the path to the node binary
 | `--python=$path`                  | Set path to the python (2) binary
 | `--msvs_version=$version`         | Set Visual Studio version (win)

--- a/lib/install.js
+++ b/lib/install.js
@@ -440,7 +440,7 @@ function download (gyp, env, url) {
 
   // Support for setting specific TLS ciphers
   var cipherList = gyp.opts.ciphers
-  if (cipherList){
+  if (cipherList) {
     requestOpts.agentOptions = {ciphers: cipherList}
   }
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -438,6 +438,12 @@ function download (gyp, env, url) {
     requestOpts.ca = readCAFile(cafile)
   }
 
+  // Support for setting specific TLS ciphers
+  var cipherList = gyp.opts.ciphers
+  if (cipherList){
+    requestOpts.agentOptions = {ciphers: cipherList}
+  }
+
   // basic support for a proxy server
   var proxyUrl = gyp.opts.proxy
               || env.http_proxy

--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -214,3 +214,4 @@ Object.defineProperty(proto, 'version', {
     }
   , enumerable: true
 })
+

--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -74,6 +74,7 @@ proto.configDefs = {
     help: Boolean     // everywhere
   , arch: String      // 'configure'
   , cafile: String    // 'install'
+  , ciphers: String   // 'install'
   , debug: Boolean    // 'build'
   , directory: String // bin
   , make: String      // 'build'
@@ -213,4 +214,3 @@ Object.defineProperty(proto, 'version', {
     }
   , enumerable: true
 })
-


### PR DESCRIPTION
Some corporate proxy setups require the use of _very_ specific TLS cipher lists. This set's [request](https://github.com/request/request)'s `options.agentOptions.ciphers` property to a new node-gyp `ciphers` property to let the user choose the allowed TLS ciphers. 