### PR TITLE
Upgrade semver dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "osenv": "0",
     "request": "2",
     "rimraf": "2",
-    "semver": "2.x || 3.x || 4 || 5",
+    "semver": "~5.3.0",
     "tar": "^2.0.0",
     "which": "1"
   },


### PR DESCRIPTION
Should fix reports of "TypeError: Cannot read property 'length' of
undefined" runtime exceptions where node-gyp uses a buggy version
of semver due to our overly broad accepted version range.

npm updated to semver@5.3.0 recently so we can too now and still
share the module with npm, keeping the download small.

Fixes: https://github.com/nodejs/node-gyp/issues/1094

CI: https://ci.nodejs.org/view/All/job/nodegyp-test-commit/35/