### PR TITLE
Clarifing of Windows installation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@ You will also need to install:
       * You also need to install the `Command Line Tools` via Xcode. You can find this under the menu `Xcode -> Preferences -> Downloads`
       * This step will install `gcc` and the related toolchain containing `make`
   * On Windows:
-    * Option 1: Install all the required tools and configurations using Microsoft's [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools) using `npm install --global --production windows-build-tools` from an elevated PowerShell or CMD.exe (run as Administrator).
+    * Option 1: Install all the required tools and configurations using Microsoft's [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools) using `npm install --global --production windows-build-tools` from an elevated PowerShell or CMD.exe (run as Administrator). It will install:
+      * Python 2.7
+      * [Microsoft Build Tools 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48159)
     * Option 2: Install tools and configuration manually:
       * Visual C++ Build Environment:
-        * Option 1: Install [Visual C++ Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools) using the **Default Install** option.
+        * Option 1: Install [Visual C++ Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools) using the **Default Install** option. Use this option if you don't have Visual Studio 2015 installed, otherwise it can not work.
 
         * Option 2: Install [Visual Studio 2015](https://www.visualstudio.com/products/visual-studio-community-vs) (or modify an existing installation) and select *Common Tools for Visual C++* during setup. This also works with the free Community and Express for Desktop editions.
 


### PR DESCRIPTION
I had problem with installation prerequisites for Windows.
I had installed Visual Studio 2015, but without package `Common Tools for Visual C++`.
I installed by first option `npm install --global --production windows-build-tools`, it seems that everything went ok, but installation of `buffertools` fails, because `CL.exe` is missing.
Manually installation of [Microsoft Build Tools 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48159) didn't help - installation succeed, but didn't help (CL.exe still missing). Only modifing existing installation of VS (adding `Common Tools for Visual C++`) fixed issue.

```
C:\Users\Pawel>npm install --global --production windows-build-tools

> windows-build-tools@1.1.0 postinstall C:\Users\Pawel\AppData\Roaming\npm\node_modules\windows-build-tools
> node ./lib/index.js

Downloading BuildTools_Full.exe
Downloading python-2.7.11.msi
[>                                            ] 0.0% (0 B/s)
Downloaded python-2.7.11.msi. Saved to C:\Users\Pawel\.windows-build-tools\python-2.7.11.msi.
Starting installation...
Launched installers, now waiting for them to finish.
This will likely take some time - please be patient!
Waiting for installers... |Successfully installed Python 2.7
Waiting for installers... /Successfully installed Visual Studio Build Tools.
C:\Users\Pawel\AppData\Roaming\npm
`-- windows-build-tools@1.1.0
  +-- cli-spinner@0.2.6
  `-- nugget@2.0.1
    +-- pretty-bytes@1.0.4
    | `-- meow@3.7.0
    |   `-- normalize-package-data@2.3.5
    |     `-- hosted-git-info@2.2.0
    `-- request@2.79.0
      `-- aws4@1.6.0


C:\Users\Pawel>npm i buffertools

> buffertools@2.1.4 install C:\Users\Pawel\node_modules\buffertools
> node-gyp rebuild


C:\Users\Pawel\node_modules\buffertools>if not defined npm_config_node_gyp (node "C:\Program Files\nodejs\node_modules\npm\bin\node-gyp-bin\\..\..\node_modules\node-gyp\bin\node-gyp.js" rebuild )  else (node "" rebuild )
Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.
TRACKER : error TRK0005: Failed to locate: "CL.exe". Nie można odnaleźć określonego pliku. [C:\Users\Pawel\node_modules\buffertools\build\buffertools.vcxproj]```