### PR TITLE
Add configuration for SSL verification when downloading content behind corporate proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Command Options
 | `--ensure`                        | Don't reinstall headers if already present
 | `--dist-url=$url`                 | Download header tarball from custom URL
 | `--proxy=$url`                    | Set HTTP proxy for downloading header tarball
+| `--strictssl=true|false`          | Set SSL certificate verification to on/off
 | `--cafile=$cafile`                | Override default CA chain (to download tarball)
 | `--nodedir=$path`                 | Set the path to the node binary
 | `--python=$path`                  | Set path to the python (2) binary

--- a/lib/install.js
+++ b/lib/install.js
@@ -443,10 +443,16 @@ function download (gyp, env, url) {
               || env.http_proxy
               || env.HTTP_PROXY
               || env.npm_config_proxy
+  
+  var strictSsl = true;
+  if (!gyp.opts.strictssl) {
+    strictSsl = gyp.opts.strictssl
+  }
   if (proxyUrl) {
     if (/^https?:\/\//i.test(proxyUrl)) {
       log.verbose('download', 'using proxy url: "%s"', proxyUrl)
       requestOpts.proxy = proxyUrl
+      requestOpts.strictSSL = strictSsl
     } else {
       log.warn('download', 'ignoring invalid "proxy" config setting: "%s"', proxyUrl)
     }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bindings",
     "gyp"
   ],
-  "version": "3.5.0",
+  "version": "3.5.1",
   "installVersion": 9,
   "author": "Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)",
   "repository": {


### PR DESCRIPTION
### Case
When trying to do `node-gyp install` then some packages are downloaded from internet resources. 

### Problem
If you trying to do that behind corporate proxy then additional option `--proxy` should be setup, but this option is not enough if SSL certificate is modified on this proxy, then below error occurs:
> Error: unable to verify the first certificate

### Solution
Turn off check of SSL certificate via setting `strictSSL` set to `false` on `request` object (default: `true`). Then get this value in command line via `--strictssl` option that accepts `true` or `false` value.