### PR TITLE
Improves Windows support.

### DIFF
--- a/bin/node-gyp.js
+++ b/bin/node-gyp.js
@@ -25,9 +25,8 @@ prog.parseArgv(process.argv)
 prog.devDir = prog.opts.devdir
 
 var homeDir = osenv.home()
-if (process.env.LOCALAPPDATA) {
-  // TODO: create intermediate directories
-  pro.devDir = path.resolve(process.env.LOCALAPPDATA, 'nodejs', 'node-gyp')
+if (process.env.LOCALAPPDATA && process.platform === 'win32') {
+  prog.devDir = path.resolve(process.env.LOCALAPPDATA, 'nodejs', 'node-gyp')
 } else if (prog.devDir) {
   prog.devDir = prog.devDir.replace(/^~/, homeDir)
 } else if (homeDir) {

--- a/bin/node-gyp.js
+++ b/bin/node-gyp.js
@@ -25,14 +25,18 @@ prog.parseArgv(process.argv)
 prog.devDir = prog.opts.devdir
 
 var homeDir = osenv.home()
-if (prog.devDir) {
+if (process.env.LOCALAPPDATA) {
+  // TODO: create intermediate directories
+  pro.devDir = path.resolve(process.env.LOCALAPPDATA, 'nodejs', 'node-gyp')
+} else if (prog.devDir) {
   prog.devDir = prog.devDir.replace(/^~/, homeDir)
 } else if (homeDir) {
   prog.devDir = path.resolve(homeDir, '.node-gyp')
 } else {
   throw new Error(
     "node-gyp requires that the user's home directory is specified " +
-    "in either of the environmental variables HOME or USERPROFILE. " +
+    "in either of the environmental variables HOME or USERPROFILE, " +
+    "or LOCALAPPDATA is set." +
     "Overide with: --devdir /path/to/.node-gyp")
 }
 


### PR DESCRIPTION
This is a naive fix for #1124.  On Windows, files should not be stored directly in `%USERPROFILE%` for a number of reasons.  Instead, store the files in an appropriate location on Windows such as `%LOCALAPPDATA%/<vendor>/<product>`.