### PR TITLE
test: fix test/test-configure-python on AIX

### DIFF
--- a/test/test-configure-python.js
+++ b/test/test-configure-python.js
@@ -6,6 +6,8 @@ var gyp = require('../lib/node-gyp')
 var requireInject = require('require-inject')
 var configure = requireInject('../lib/configure', {
   'graceful-fs': {
+    'openSync': function (file, mode) { return 0; },
+    'closeSync': function (fd) { },
     'writeFile': function (file, data, cb) { cb() },
     'stat': function (file, cb) { cb(null, {}) }
   }
@@ -26,7 +28,7 @@ test('configure PYTHONPATH with no existing env', function (t) {
     t.equal(process.env.PYTHONPATH, EXPECTED_PYPATH)
     return SPAWN_RESULT
   }
-  configure(prog, [])
+  configure(prog, [], t.fail)
 })
 
 test('configure PYTHONPATH with existing env of one dir', function (t) {
@@ -46,7 +48,7 @@ test('configure PYTHONPATH with existing env of one dir', function (t) {
 
     return SPAWN_RESULT
   }
-  configure(prog, [])
+  configure(prog, [], t.fail)
 })
 
 test('configure PYTHONPATH with existing env of multiple dirs', function (t) {
@@ -68,5 +70,5 @@ test('configure PYTHONPATH with existing env of multiple dirs', function (t) {
 
     return SPAWN_RESULT
   }
-  configure(prog, [])
+  configure(prog, [], t.fail)
 })


### PR DESCRIPTION
https://github.com/nodejs/citgm/pull/370#issuecomment-282780390, test/test-configure-python is failing on AIX:
```
-bash-4.3$ node --version
v6.10.0
-bash-4.3$ node test/test-configure-python.js
TAP version 13
# configure PYTHONPATH with no existing env
gyp ERR! find exports file Could not find exports file
/home/users/riclau/sandbox/github/node-gyp/lib/configure.js:245
        return callback(new Error(msg))
               ^

TypeError: callback is not a function
    at runGyp (/home/users/riclau/sandbox/github/node-gyp/lib/configure.js:245:16)
    at findConfigs (/home/users/riclau/sandbox/github/node-gyp/lib/configure.js:170:23)
    at /home/users/riclau/sandbox/github/node-gyp/lib/configure.js:183:9
    at Object.stat (/home/users/riclau/sandbox/github/node-gyp/test/test-configure-python.js:10:35)
    at findConfigs (/home/users/riclau/sandbox/github/node-gyp/lib/configure.js:173:8)
    at /home/users/riclau/sandbox/github/node-gyp/lib/configure.js:183:9
    at Object.stat (/home/users/riclau/sandbox/github/node-gyp/test/test-configure-python.js:10:35)
    at findConfigs (/home/users/riclau/sandbox/github/node-gyp/lib/configure.js:173:8)
    at Object.writeFile (/home/users/riclau/sandbox/github/node-gyp/test/test-configure-python.js:9:46)
    at createConfigFile (/home/users/riclau/sandbox/github/node-gyp/lib/configure.js:164:8)
-bash-4.3$
```

On AIX, `lib/configure.js` attempts to locate node.exp via [calls to fs.openSync() and fs.closeSync()](https://github.com/nodejs/node-gyp/blob/v3.5.0/lib/configure.js#L322-L338). Add these functions to the [mocked `graceful-fs` object](https://github.com/nodejs/node-gyp/blob/v3.5.0/test/test-configure-python.js#L8-L11) in test/test-configure-python.js.