### PR TITLE
gyp: Revert quote_cmd workaround

### DIFF
--- a/gyp/pylib/gyp/generator/msvs.py
+++ b/gyp/pylib/gyp/generator/msvs.py
@@ -354,8 +354,6 @@ def _BuildCommandLineForRuleRaw(spec, cmd, cygwin_shell, has_input_path,
       command = ['type']
     else:
       command = [cmd[0].replace('/', '\\')]
-    if quote_cmd:
-      command = ['"%s"' % i for i in command]
     # Add call before command to ensure that commands can be tied together one
     # after the other without aborting in Incredibuild, since IB makes a bat
     # file out of the raw command string, and some commands (like python) are


### PR DESCRIPTION
There was a workaround added to include the cmd in quotes but with changes in `gyp` this was no longer needed. This was fixed in `node-chakracore` [here](https://github.com/nodejs/node-chakracore/pull/52/commits/0cd4cb887c2faacfa786a67e2018f6805612e6e2) but https://github.com/nodejs/node-gyp/pull/873 was not updated with the fix. Porting the fix to revert the `quote_cmd` fix.

Fixes: https://github.com/nodejs/node-gyp/issues/1151