### PR TITLE
Consider using micromatch

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -18,7 +18,6 @@ var fs = require('graceful-fs')
   , log = require('npmlog')
   , semver = require('semver')
   , request = require('request')
-  , micromatch = require('micromatch')
   , mkdir = require('mkdirp')
   , processRelease = require('./process-release')
   , win = process.platform == 'win32'
@@ -390,7 +389,8 @@ function install (gyp, argv, callback) {
 
   function valid (file) {
     // header files
-    return micromatch.isMatch(file, '*.{h,gypi}', { matchBase: true });
+    var extname = path.extname(file);
+    return extname === '.h' || extname === '.gypi';
   }
 
   /**

--- a/lib/install.js
+++ b/lib/install.js
@@ -20,7 +20,7 @@ var fs = require('graceful-fs')
   , semver = require('semver')
   , fstream = require('fstream')
   , request = require('request')
-  , minimatch = require('minimatch')
+  , micromatch = require('micromatch')
   , mkdir = require('mkdirp')
   , processRelease = require('./process-release')
   , win = process.platform == 'win32'
@@ -396,8 +396,7 @@ function install (gyp, argv, callback) {
 
   function valid (file) {
     // header files
-    return minimatch(file, '*.h', { matchBase: true }) ||
-           minimatch(file, '*.gypi', { matchBase: true })
+    return micromatch.isMatch(file, '*.{h,gypi}', { matchBase: true });
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "glob": "^7.0.3",
     "graceful-fs": "^4.1.2",
-    "micromatch": "^2.3.11",
     "mkdirp": "^0.5.0",
     "nopt": "2 || 3",
     "npmlog": "0 || 1 || 2 || 3 || 4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "fstream": "^1.0.0",
     "glob": "^7.0.3",
     "graceful-fs": "^4.1.2",
-    "minimatch": "^3.0.2",
+    "micromatch": "^2.3.11",
     "mkdirp": "^0.5.0",
     "nopt": "2 || 3",
     "npmlog": "0 || 1 || 2 || 3 || 4",


### PR DESCRIPTION
Hi,

This PR is doing two things:

- Replace minimatch with [micromatch](https://www.npmjs.com/package/micromatch).
- Update the glob pattern for matching valid header files so only one pass is made.

When the glob pattern is updated to `'*.{h,gypi}'`, `micromatch` will create one regexp pattern that will only do one pass over the file being checked. This differs from `minimatch` that creates 2 different regexp patterns and will check the file twice if the pattern doesn't match `'*.h'`.

Thanks for considering this.
