### PR TITLE
Prefix build targets with /t: on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 gyp/test
-node_modules
+node_modules/*
+!test/node_modules/hello_world
+build
 test/.node-gyp

--- a/lib/build.js
+++ b/lib/build.js
@@ -24,6 +24,10 @@ function build (gyp, argv, callback) {
     platformMake = 'gmake'
   } else if (process.platform.indexOf('bsd') !== -1) {
     platformMake = 'gmake'
+  } else if (win && argv.length > 0) {
+    argv = argv.map(function(target) {
+      return '/t:' + target
+    })
   }
 
   var release = processRelease(argv, gyp, process.version, process.release)

--- a/test/node_modules/hello_world/binding.gyp
+++ b/test/node_modules/hello_world/binding.gyp
@@ -6,6 +6,12 @@
       "include_dirs": [
         "<!(node -e \"require('nan')\")"
       ]
+    }, {
+      "target_name": "world",
+      "sources": [ "world.cc" ],
+      "include_dirs": [
+        "<!(node -e \"require('nan')\")"
+      ]
     }
   ]
 }

--- a/test/node_modules/hello_world/world.cc
+++ b/test/node_modules/hello_world/world.cc
@@ -1,0 +1,12 @@
+#include <nan.h>
+
+void Method(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  info.GetReturnValue().Set(Nan::New("hello").ToLocalChecked());
+}
+
+void Init(v8::Local<v8::Object> exports) {
+  exports->Set(Nan::New("world").ToLocalChecked(),
+               Nan::New<v8::FunctionTemplate>(Method)->GetFunction());
+}
+
+NODE_MODULE(world, Init)

--- a/test/node_modules/hello_world/world.js
+++ b/test/node_modules/hello_world/world.js
@@ -1,0 +1,3 @@
+'use strict'
+var addon = require('bindings')('world');
+exports.world = function() { return addon.world() }

--- a/test/test-addon.js
+++ b/test/test-addon.js
@@ -9,9 +9,7 @@ var nodeGyp = path.resolve(__dirname, '..', 'bin', 'node-gyp.js')
 test('build simple addon', function (t) {
   t.plan(3)
 
-  // Set the loglevel otherwise the output disappears when run via 'npm test'
-  var cmd = [nodeGyp, 'rebuild', '-C', addonPath, '--loglevel=verbose']
-  var proc = execFile(process.execPath, cmd, function (err, stdout, stderr) {
+  exec(t, ['rebuild'], [], function (err, stdout, stderr) {
     var logLines = stderr.toString().trim().split(/\r?\n/)
     var lastLine = logLines[logLines.length-1]
     t.strictEqual(err, null)
@@ -23,6 +21,38 @@ test('build simple addon', function (t) {
       t.error(error, 'load module')
     }
   })
+})
+
+test('build specific addon', function (t) {
+  t.plan(4)
+
+  exec(t, ['clean', 'configure'], [], function (err) {
+    t.error(err, 'clean build')
+
+    exec(t, ['build'], ['hello'], function (err, stdout, stderr) {
+      var logLines = stderr.toString().trim().split(/\r?\n/)
+      var lastLine = logLines[logLines.length-1]
+      t.strictEqual(err, null)
+      t.strictEqual(lastLine, 'gyp info ok', 'should end in ok')
+      try {
+        var binding = require('hello_world')
+        t.strictEqual(binding.hello(), 'world')
+      } catch (error) {
+        t.error(error, 'load module')
+      }
+    })
+  })
+})
+
+function exec(t, cmd, args, cb) {
+  // Set the loglevel otherwise the output disappears when run via 'npm test'
+  var toExec = [nodeGyp]
+    .concat(cmd)
+    .concat(['-C', addonPath, '--loglevel=verbose'])
+    .concat(args)
+
+  t.comment(toExec.join(' '))
+  var proc = execFile(process.execPath, toExec, cb)
   proc.stdout.setEncoding('utf-8')
   proc.stderr.setEncoding('utf-8')
-})
+}

--- a/test/test-addon.js
+++ b/test/test-addon.js
@@ -7,40 +7,26 @@ var addonPath = path.resolve(__dirname, 'node_modules', 'hello_world')
 var nodeGyp = path.resolve(__dirname, '..', 'bin', 'node-gyp.js')
 
 test('build simple addon', function (t) {
-  t.plan(3)
+  t.plan(4)
 
-  exec(t, ['rebuild'], [], function (err, stdout, stderr) {
+  exec(t, ['clean', 'rebuild'], [], function (err, stdout, stderr) {
     var logLines = stderr.toString().trim().split(/\r?\n/)
     var lastLine = logLines[logLines.length-1]
     t.strictEqual(err, null)
     t.strictEqual(lastLine, 'gyp info ok', 'should end in ok')
     try {
-      var binding = require('hello_world')
-      t.strictEqual(binding.hello(), 'world')
+      var hello = require('hello_world/hello')
+      t.strictEqual(hello.hello(), 'world')
     } catch (error) {
       t.error(error, 'load module')
     }
-  })
-})
 
-test('build specific addon', function (t) {
-  t.plan(4)
-
-  exec(t, ['clean', 'configure'], [], function (err) {
-    t.error(err, 'clean build')
-
-    exec(t, ['build'], ['hello'], function (err, stdout, stderr) {
-      var logLines = stderr.toString().trim().split(/\r?\n/)
-      var lastLine = logLines[logLines.length-1]
-      t.strictEqual(err, null)
-      t.strictEqual(lastLine, 'gyp info ok', 'should end in ok')
-      try {
-        var binding = require('hello_world')
-        t.strictEqual(binding.hello(), 'world')
-      } catch (error) {
-        t.error(error, 'load module')
-      }
-    })
+    try {
+      var world = require('hello_world/world')
+      t.strictEqual(world.world(), 'hello')
+    } catch (error) {
+      t.error(error, 'load module')
+    }
   })
 })
 

--- a/test/test-specific-addon.js
+++ b/test/test-specific-addon.js
@@ -1,0 +1,48 @@
+'use strict'
+
+var test = require('tape')
+var execFile = require('child_process').execFile
+var path = require('path')
+var addonPath = path.resolve(__dirname, 'node_modules', 'hello_world')
+var nodeGyp = path.resolve(__dirname, '..', 'bin', 'node-gyp.js')
+
+test('build specific addon', function (t) {
+  t.plan(5)
+
+  exec(t, ['clean', 'configure'], [], function (err) {
+    t.error(err, 'clean build')
+
+    exec(t, ['build'], ['hello'], function (err, stdout, stderr) {
+      var logLines = stderr.toString().trim().split(/\r?\n/)
+      var lastLine = logLines[logLines.length-1]
+      t.strictEqual(err, null)
+      t.strictEqual(lastLine, 'gyp info ok', 'should end in ok')
+      try {
+        var hello = require('hello_world/hello')
+        t.strictEqual(hello.hello(), 'world')
+      } catch (error) {
+        t.error(error, 'load module')
+      }
+
+      try {
+        var world = require('hello_world/world')
+        t.fail('should not have loaded unbuilt module')
+      } catch (e) {
+        t.ok(/Could not locate the bindings file/.test(e), 'should not build world')
+      }
+    })
+  })
+})
+
+function exec(t, cmd, args, cb) {
+  // Set the loglevel otherwise the output disappears when run via 'npm test'
+  var toExec = [nodeGyp]
+    .concat(cmd)
+    .concat(['-C', addonPath, '--loglevel=verbose'])
+    .concat(args)
+
+  t.comment(toExec.join(' '))
+  var proc = execFile(process.execPath, toExec, cb)
+  proc.stdout.setEncoding('utf-8')
+  proc.stderr.setEncoding('utf-8')
+}


### PR DESCRIPTION
Currently, on non-Windows platforms, it is possible to have a multi-target native module and specify building just some of the targets using `node-gyp build my_target`. On Windows, however, specifying the target(s) to build requires the [`/t:` or `/target:` flag](https://msdn.microsoft.com/en-us/library/ms164311.aspx). Without this change you will get the error `MSB1008` because MSBuild things you are trying to specify multiple solutions.