### PR TITLE
Generator: msvs: compile .mm files

### DIFF
--- a/gyp/pylib/gyp/generator/msvs.py
+++ b/gyp/pylib/gyp/generator/msvs.py
@@ -2120,7 +2120,7 @@ def _MapFileToMsBuildSourceType(source, rule_dependencies,
   if ext in extension_to_rule_name:
     group = 'rule'
     element = extension_to_rule_name[ext]
-  elif ext in ['.cc', '.cpp', '.c', '.cxx']:
+  elif ext in ['.cc', '.cpp', '.c', '.cxx', '.mm']:
     group = 'compile'
     element = 'ClCompile'
   elif ext in ['.h', '.hxx']:


### PR DESCRIPTION
Hi guys,

  in a native node extension I want to compile .mm file with C/C++ compiler on Windows.

It does not appear in vcxproj in CLCompile group. I did the modification to fix it.

Cheers