### PR TITLE
Log dist-url.

### DIFF
--- a/lib/process-release.js
+++ b/lib/process-release.js
@@ -74,6 +74,8 @@ function processRelease (argv, gyp, defaultVersion, defaultRelease) {
     }
   }
 
+  if (overrideDistUrl)
+    log.verbose('download', 'using dist-url', overrideDistUrl)
 
   if (overrideDistUrl)
     distBaseUrl = overrideDistUrl.replace(/\/+$/, '')


### PR DESCRIPTION
The default download URL can be overridden by `--dist-url` or one of the
`*_MIRROR` environment variables.  Log the URL to ease troubleshooting.

Fixes: https://github.com/nodejs/node-gyp/issues/1169
CI: https://ci.nodejs.org/job/nodegyp-test-pull-request/8/