### PR TITLE
Fix test-find-python on v0.10.x buildbot.

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -375,6 +375,7 @@ PythonFinder.prototype = {
   env: process.env,
   execFile: cp.execFile,
   log: log,
+  resolve: path.win32 && path.win32.resolve || path.resolve,
   stat: fs.stat,
   which: which,
   win: win,
@@ -499,8 +500,7 @@ PythonFinder.prototype = {
     if (rootDir[rootDir.length - 1] !== '\\') {
       rootDir += '\\'
     }
-    var resolve = path.win32 && path.win32.resolve || path.resolve
-    var pythonPath = resolve(rootDir, 'Python27', 'python.exe')
+    var pythonPath = this.resolve(rootDir, 'Python27', 'python.exe')
     this.log.verbose('ensuring that file exists:', pythonPath)
     this.stat(pythonPath, function (err, stat) {
       if (err) {


### PR DESCRIPTION
Work around a v0.10.x CI issue where path.resolve() on UNIX systems
prefixes Windows paths with the current working directory.

v0.12 and up are free of this issue because they use
path.win32.resolve() which does the right thing.

CI: https://ci.nodejs.org/job/nodegyp-test-pull-request/9/