### PR TITLE
Check definedness of argv[0] first

### DIFF
--- a/lib/process-release.js
+++ b/lib/process-release.js
@@ -13,7 +13,7 @@ var semver = require('semver')
 // file names. Inputs come from command-line switches (--target, --dist-url),
 // `process.version` and `process.release` where it exists.
 function processRelease (argv, gyp, defaultVersion, defaultRelease) {
-  var version = (semver.valid(argv[0]) && argv[0]) || gyp.opts.target || defaultVersion
+  var version = (argv[0] && semver.valid(argv[0])) || gyp.opts.target || defaultVersion
     , versionSemver = semver.parse(version)
     , overrideDistUrl = gyp.opts['dist-url'] || gyp.opts.disturl
     , isDefaultVersion


### PR DESCRIPTION
I'm not really sure what the `&& argv[0]` is for, but if that is a safegard for `argv[0]` being defined it makes more sense to check that before `semver.valid()` is called on it.
At least I had the case where this broke because that was actually undefined.