### PR TITLE
Change source path for cmake

### DIFF
--- a/gyp/pylib/gyp/generator/cmake.py
+++ b/gyp/pylib/gyp/generator/cmake.py
@@ -679,7 +679,7 @@ def WriteTarget(namer, qualified_target, target_dicts, build_dir, config_to_use,
   for src in srcs:
     _, ext = os.path.splitext(src)
     src_type = COMPILABLE_EXTENSIONS.get(ext, None)
-    src_norm_path = NormjoinPath(path_from_cmakelists_to_gyp, src);
+    src_norm_path = NormjoinPathForceCMakeSource(path_from_cmakelists_to_gyp, src);
 
     if src_type == 's':
       s_sources.append(src_norm_path)


### PR DESCRIPTION
If use relative path for source file, it will give an not found error when I include CMakeLists from other CMakeLists
``` cmake
include(build/Release/CMakeLists.txt)
```

I'm using CLion for dev

