### PR TITLE
gyp: update xml string encoding conversion

### DIFF
--- a/gyp/pylib/gyp/easy_xml.py
+++ b/gyp/pylib/gyp/easy_xml.py
@@ -4,6 +4,7 @@
 
 import re
 import os
+import locale
 
 
 def XmlToString(content, encoding='utf-8', pretty=False):
@@ -115,11 +116,10 @@ def WriteXmlIfChanged(content, path, encoding='utf-8', pretty=False,
   xml_string = XmlToString(content, encoding, pretty)
   if win32 and os.linesep != '\r\n':
     xml_string = xml_string.replace('\n', '\r\n')
-    
-  try:
-    xml_string = xml_string.encode(encoding)
-  except Exception:
-    xml_string = unicode(xml_string, 'latin-1').encode(encoding)
+
+  default_encoding = locale.getdefaultlocale()[1]
+  if default_encoding.upper() != encoding.upper():
+    xml_string = xml_string.decode(default_encoding).encode(encoding)
 
   # Get the old content
   try:

--- a/test/fixtures/test-charmap.py
+++ b/test/fixtures/test-charmap.py
@@ -1,0 +1,19 @@
+import sys
+import locale
+
+reload(sys)
+
+def main():
+  encoding = locale.getdefaultlocale()[1]
+  sys.setdefaultencoding(encoding)
+  textmap = {
+    'cp936': u'\u4e2d\u6587',
+    'cp1252': u'Lat\u012Bna',
+    'cp932': u'\u306b\u307b\u3093\u3054'
+  }
+  if textmap.has_key(encoding):
+    print textmap[encoding]
+  return True
+
+if __name__ == '__main__':
+  print main()

--- a/test/test-addon.js
+++ b/test/test-addon.js
@@ -1,10 +1,18 @@
 'use strict'
 
 var test = require('tape')
-var execFile = require('child_process').execFile
 var path = require('path')
+var fs = require('graceful-fs')
+var child_process = require('child_process')
 var addonPath = path.resolve(__dirname, 'node_modules', 'hello_world')
 var nodeGyp = path.resolve(__dirname, '..', 'bin', 'node-gyp.js')
+var execFileSync = child_process.execFileSync
+var execFile = child_process.execFile
+
+function runHello() {
+  var testCode = "console.log(require('hello_world').hello())"
+  return execFileSync('node', ['-e', testCode], { cwd: __dirname }).toString()
+}
 
 test('build simple addon', function (t) {
   t.plan(3)
@@ -16,12 +24,56 @@ test('build simple addon', function (t) {
     var lastLine = logLines[logLines.length-1]
     t.strictEqual(err, null)
     t.strictEqual(lastLine, 'gyp info ok', 'should end in ok')
-    try {
-      var binding = require('hello_world')
-      t.strictEqual(binding.hello(), 'world')
-    } catch (error) {
-      t.error(error, 'load module')
+    t.strictEqual(runHello().trim(), 'world')
+  })
+  proc.stdout.setEncoding('utf-8')
+  proc.stderr.setEncoding('utf-8')
+})
+
+test('build simple addon in path with non-ascii characters', function (t) {
+  t.plan(3)
+
+  var data, config, nodeDir, testNodeDir
+  var configPath = path.join(addonPath, 'build', 'config.gypi')
+
+  try {
+    data = fs.readFileSync(configPath, 'utf8')
+  } catch (err) {
+    t.error(err)
+    return
+  }
+  config = JSON.parse(data.replace(/\#.+\n/, ''))
+  nodeDir = config.variables.nodedir
+  // Create path with non-ascii characters
+  testNodeDir = path.join(addonPath, '非英文字符')
+  try {
+    fs.symlinkSync(nodeDir, testNodeDir, 'dir')
+  } catch (err) {
+    switch (err.code) {
+      case 'EEXIST': break
+      case 'EPERM':
+        t.error(err, 'Please try to running console as an administrator')
+        return
+      default:
+        t.error(err)
+        return
     }
+  }
+
+  var cmd = [nodeGyp, 'rebuild', '-C', addonPath,
+             '--loglevel=verbose', '-nodedir=' + testNodeDir]
+  var proc = execFile(process.execPath, cmd, function (err, stdout, stderr) {
+    try {
+      fs.unlink(testNodeDir)
+    } catch (err) {
+      t.error(err)
+    }
+
+    var logLines = stderr.toString().trim().split(/\r?\n/)
+    var lastLine = logLines[logLines.length-1]
+    t.strictEqual(err, null)
+    t.strictEqual(lastLine, 'gyp info ok', 'should end in ok')
+    t.strictEqual(runHello().trim(), 'world')
   })
   proc.stdout.setEncoding('utf-8')
   proc.stderr.setEncoding('utf-8')


### PR DESCRIPTION
My project depends on the `node-sass`, but it can not successfully install, so I tried using the `npm rebuild node-sass --force` command to build the `node-sass` on Windows 10.  But it could not be built successfully, error message is: `"node_version.h": No such file or directory`

I guess this is the problem of compiling configuration,  and I found the `node-sass\build\binding.vcxproj ` file from the output information, so I opened it with the editor and found that the configuration item has garbled text: 

![qq 20170520130717](https://cloud.githubusercontent.com/assets/1730073/26273193/42a13ec8-3d5d-11e7-8eed-e70c25b3d434.png)

My username can not be displayed correctly, there seems to be a encoding conversion bug when writing to the `binding.vcxproj` file.  I took some time to debug it, Eventually I found the problem out here: [easy_xml.py#L120](https://github.com/lc-soft/node-gyp/blob/master/gyp/pylib/gyp/easy_xml.py#L120) 

![qq 20170520130900](https://cloud.githubusercontent.com/assets/1730073/26273210/7f50985a-3d5d-11e7-9268-0941e73f059a.png)

Since `xml_string` contains non-ascii characters, `xml_string.encode()` will fail and throw an exception, and then this string will be treated as `latin-1` encoded string to convert, but my default locale character encoding is not `latin-1`,  therefore, the `binding.vcproj` file is written with the wrong content.

After modification, the contents of the output file is correct.

![qq 20170520130513](https://cloud.githubusercontent.com/assets/1730073/26273182/ffdca4b0-3d5c-11e7-842e-e487e62dd523.png)

`node-sass` can be built successfully.

```
gyp info ok
Installed to F:\work\XXXXXX\node_modules\node-sass\vendor\win32-x64-48\binding.node
node-sass@4.5.3 F:\work\XXXXXX\node_modules\node-sass
```


