### PR TITLE
build: rename copyNodeLib() to doBuild()

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -124,7 +124,7 @@ function build (gyp, argv, callback) {
     if (config.variables.msbuild_path) {
       command = config.variables.msbuild_path
       log.verbose('using MSBuild:', command)
-      copyNodeLib()
+      doBuild()
       return
     }
 


### PR DESCRIPTION
@refack 
I use the `npm test` command to run the test, unfortunately, the test does not pass, in which there is a error message:

``` text
...
gyp verb node dev dir C:\Users\鍒樿秴\.node-gyp\6.3.1
gyp verb found first Solution file build/binding.sln
gyp verb using MSBuild: D:\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe
gyp ERR! UNCAUGHT EXCEPTION
gyp ERR! stack ReferenceError: copyNodeLib is not defined
gyp ERR! stack     at findMsbuild (F:\浠ｇ爜搴揬GitHub\node-gyp\lib\build.js:127:7)
gyp ERR! stack     at F:\浠ｇ爜搴揬GitHub\node-gyp\lib\build.js:107:11
gyp ERR! stack     at F (F:\浠ｇ爜搴揬GitHub\node-gyp\node_modules\.1.2.14@which\which.js:68:16)
gyp ERR! stack     at E (F:\浠ｇ爜搴揬GitHub\node-gyp\node_modules\.1.2.14@which\which.js:80:29)
gyp ERR! stack     at F:\浠ｇ爜搴揬GitHub\node-gyp\node_modules\.1.2.14@which\which.js:89:16
gyp ERR! stack     at F:\浠ｇ爜搴揬GitHub\node-gyp\node_modules\.2.0.0@isexe\index.js:42:5
gyp ERR! stack     at F:\浠ｇ爜搴揬GitHub\node-gyp\node_modules\.2.0.0@isexe\windows.js:36:5
gyp ERR! stack     at FSReqWrap.oncomplete (fs.js:123:15)
gyp ERR! System Windows_NT 10.0.14393
gyp ERR! command "D:\\nodejs\\node.exe" "F:\\浠ｇ爜搴揬\GitHub\\node-gyp\\bin\\node-gyp.js" "rebuild" "-C" "F:\\浠ｇ爜搴揬\GitHub\\node-gyp\\test\\node_modules\\hello_world" "--loglevel=verbose"
gyp ERR! cwd F:\浠ｇ爜搴揬GitHub\node-gyp\test\node_modules\hello_world
gyp ERR! node -v v6.3.1
gyp ERR! node-gyp -v v3.6.1
gyp ERR! This is a bug in `node-gyp`.
gyp ERR! Try to update node-gyp and file an Issue if it does not help:
gyp ERR!     <https://github.com/nodejs/node-gyp/issues>
...
```
 
`copyNodeLib()` is not defined, I searched the entire file directory and did not find the definition of `copyNodeLib()`.

Finally, I found [this commit](https://github.com/nodejs/node-gyp/commit/0913b2dd99f8508e5130c95adf5702295c979b2c#diff-26b681bd4dac10f25d5293c7595c435bL118) after browsing commits history, and the author did not rename all `copyNodeLib()` to `doBuild()`, so I added this change.

**ps.** output message encoding is incorrect.