### PR TITLE
Upgrade to tar v3

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -15,10 +15,8 @@ var fs = require('graceful-fs')
   , rm = require('rimraf')
   , path = require('path')
   , crypto = require('crypto')
-  , zlib = require('zlib')
   , log = require('npmlog')
   , semver = require('semver')
-  , fstream = require('fstream')
   , request = require('request')
   , minimatch = require('minimatch')
   , mkdir = require('mkdirp')
@@ -144,41 +142,33 @@ function install (gyp, argv, callback) {
       var tarPath = gyp.opts.tarball
       var badDownload = false
         , extractCount = 0
-        , gunzip = zlib.createGunzip()
-        , extracter = tar.Extract({ path: devDir, strip: 1, filter: isValid })
 
       var contentShasums = {}
       var expectShasums = {}
 
       // checks if a file to be extracted from the tarball is valid.
       // only .h header files and the gyp files get extracted
-      function isValid () {
-        var name = this.path.substring(devDir.length + 1)
-        var isValid = valid(name)
-        if (name === '' && this.type === 'Directory') {
-          // the first directory entry is ok
-          return true
-        }
+      function isValid (path, entry) {
+        var isValid = valid(path)
         if (isValid) {
-          log.verbose('extracted file from tarball', name)
+          log.verbose('extracted file from tarball', path)
           extractCount++
         } else {
           // invalid
-          log.silly('ignoring from tarball', name)
+          log.silly('ignoring from tarball', path)
         }
         return isValid
       }
 
-      gunzip.on('error', cb)
-      extracter.on('error', cb)
-      extracter.on('end', afterTarball)
-
-      // download the tarball, gunzip and extract!
+      // download the tarball and extract!
 
       if (tarPath) {
-        var input = fs.createReadStream(tarPath)
-        input.pipe(gunzip).pipe(extracter)
-        return
+        return tar.extract({
+          file: tarPath,
+          strip: 1,
+          filter: isValid,
+          cwd: devDir
+        }).then(afterTarball, cb)
       }
 
       try {
@@ -218,7 +208,11 @@ function install (gyp, argv, callback) {
         })
 
         // start unzipping and untaring
-        req.pipe(gunzip).pipe(extracter)
+        res.pipe(tar.extract({
+          strip: 1,
+          cwd: devDir,
+          filter: isValid
+        }).on('close', afterTarball).on('error', cb))
       })
 
       // invoked after the tarball has finished being extracted

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bindings",
     "gyp"
   ],
-  "version": "3.6.2",
+  "version": "4.0.0",
   "installVersion": 9,
   "author": "Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "bin": "./bin/node-gyp.js",
   "main": "./lib/node-gyp.js",
   "dependencies": {
-    "fstream": "^1.0.0",
     "glob": "^7.0.3",
     "graceful-fs": "^4.1.2",
     "minimatch": "^3.0.2",
@@ -33,11 +32,11 @@
     "request": "2",
     "rimraf": "2",
     "semver": "~5.3.0",
-    "tar": "^2.0.0",
+    "tar": "^3.1.3",
     "which": "1"
   },
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 4.0.0"
   },
   "devDependencies": {
     "tape": "~4.2.0",


### PR DESCRIPTION
Tar version 3 performs better and is more well tested than its
predecessor.  npm will be using this in the near future, so there is no
benefit in shipping a node-gyp that uses the slower and less reliable
fstream-based tar.