### PR TITLE
configure: don't set ensure if tarball is set

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -72,8 +72,10 @@ function configure (gyp, argv, callback) {
         return callback(new Error('Invalid version number: ' + release.version))
       }
 
-      // ensure that the target node version's dev files are installed
-      gyp.opts.ensure = true
+      // If the tarball option is set, always remove and reinstall the headers
+      // into devdir. Otherwise only install if they're not already there.
+      gyp.opts.ensure = gyp.opts.tarball ? false : true
+
       gyp.commands.install([ release.version ], function (err, version) {
         if (err) return callback(err)
         log.verbose('get node dir', 'target node version installed:', release.versionDir)


### PR DESCRIPTION
If you're providing a path to a header tarball to install, you probably
want it to always be re-installed.

Fixes: https://github.com/nodejs/node-gyp/issues/1216