### PR TITLE
Chore: Header-ify the Install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 node-gyp
 =========
-### Node.js native addon build tool
+## Node.js native addon build tool
 
 `node-gyp` is a cross-platform command-line tool written in Node.js for compiling
 native addon modules for Node.js.  It bundles the [gyp](https://gyp.gsrc.io)
@@ -14,7 +14,7 @@ Multiple target versions of node are supported (i.e. `0.8`, ..., `4`, `5`, `6`,
 etc.), regardless of what version of node is actually installed on your system
 (`node-gyp` downloads the necessary development files or headers for the target version).
 
-#### Features:
+## Features
 
  * Easy to use, consistent interface
  * Same commands to build your module on every platform
@@ -32,29 +32,39 @@ $ npm install -g node-gyp
 
 You will also need to install:
 
-  * On Unix:
-    * `python` (`v2.7` recommended, `v3.x.x` is __*not*__ supported)
-    * `make`
-    * A proper C/C++ compiler toolchain, like [GCC](https://gcc.gnu.org)
-  * On Mac OS X:
-    * `python` (`v2.7` recommended, `v3.x.x` is __*not*__ supported) (already installed on Mac OS X)
-    * [Xcode](https://developer.apple.com/xcode/download/)
-      * You also need to install the `Command Line Tools` via Xcode. You can find this under the menu `Xcode -> Preferences -> Downloads`
-      * This step will install `gcc` and the related toolchain containing `make`
-  * On Windows:
-    * Option 1: Install all the required tools and configurations using Microsoft's [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools) using `npm install --global --production windows-build-tools` from an elevated PowerShell or CMD.exe (run as Administrator).
-    * Option 2: Install tools and configuration manually:
-      * Visual C++ Build Environment:
-        * Option 1: Install [Visual C++ Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools) using the **Default Install** option.
+### On Unix
 
-        * Option 2: Install [Visual Studio 2015](https://www.visualstudio.com/products/visual-studio-community-vs) (or modify an existing installation) and select *Common Tools for Visual C++* during setup. This also works with the free Community and Express for Desktop editions.
+   * `python` (`v2.7` recommended, `v3.x.x` is __*not*__ supported)
+   * `make`
+   * A proper C/C++ compiler toolchain, like [GCC](https://gcc.gnu.org)
 
-        > :bulb: [Windows Vista / 7 only] requires [.NET Framework 4.5.1](http://www.microsoft.com/en-us/download/details.aspx?id=40773)
+### On Mac OS X
 
-      * Install [Python 2.7](https://www.python.org/downloads/) (`v3.x.x` is not supported), and run `npm config set python python2.7` (or see below for further instructions on specifying the proper Python version and path.)
-      * Launch cmd, `npm config set msvs_version 2015`
+   * `python` (`v2.7` recommended, `v3.x.x` is __*not*__ supported) (already installed on Mac OS X)
+   * [Xcode](https://developer.apple.com/xcode/download/)
+     * You also need to install the `Command Line Tools` via Xcode. You can find this under the menu `Xcode -> Preferences -> Downloads`
+     * This step will install `gcc` and the related toolchain containing `make`
 
-    If the above steps didn't work for you, please visit [Microsoft's Node.js Guidelines for Windows](https://github.com/Microsoft/nodejs-guidelines/blob/master/windows-environment.md#compiling-native-addon-modules) for additional tips.
+### On Windows
+
+#### Option 1
+
+Install all the required tools and configurations using Microsoft's [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools) using `npm install --global --production windows-build-tools` from an elevated PowerShell or CMD.exe (run as Administrator).
+
+#### Option 2
+
+Install tools and configuration manually:
+   * Visual C++ Build Environment:
+     * Option 1: Install [Visual C++ Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools) using the **Default Install** option.
+
+     * Option 2: Install [Visual Studio 2015](https://www.visualstudio.com/products/visual-studio-community-vs) (or modify an existing installation) and select *Common Tools for Visual C++* during setup. This also works with the free Community and Express for Desktop editions.
+
+     > :bulb: [Windows Vista / 7 only] requires [.NET Framework 4.5.1](http://www.microsoft.com/en-us/download/details.aspx?id=40773)
+
+   * Install [Python 2.7](https://www.python.org/downloads/) (`v3.x.x` is not supported), and run `npm config set python python2.7` (or see below for further instructions on specifying the proper Python version and path.)
+   * Launch cmd, `npm config set msvs_version 2015`
+
+   If the above steps didn't work for you, please visit [Microsoft's Node.js Guidelines for Windows](https://github.com/Microsoft/nodejs-guidelines/blob/master/windows-environment.md#compiling-native-addon-modules) for additional tips.
 
 If you have multiple Python versions installed, you can identify which Python
 version `node-gyp` uses by setting the '--python' variable:


### PR DESCRIPTION
Enable linking to the platform specific installation instructions.

The initial heading levels were changed since it was goin h1->h3 for the subheading