### PR TITLE
doc: add github PR and Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+Thank you for reporting an issue. The more information you can give us, the
+better the chance we can fix your problem.
+
+This issue tracker is for issues with node-gyp,
+if you have an issue installing a specific module, please file an issue on
+that module's issue tracker (`npm issues modulename`).
+-->
+
+* **Node Version**: <!-- `node -v` and `npm -v` -->
+* **Platform**: <!-- `uname -a` (UNIX), or `systeminfo | findstr /B /C:"OS Name" /C:"OS Version" /C:"System Type"` (Windows) -->
+* **Compiler**: <!-- `cc -v` (UNIX) or `msbuild /version & cl` (Windows) -->
+* **Module**: <!-- what you tried to build/install -->
+
+<details><summary>Verbose output (from npm or node-gyp):</summary>
+
+<!-- Paste your log between the backticks. Contents of npm-debug.log or verbose build output -->
+
+```
+
+```
+
+</details>
+
+<!-- Any further details -->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!--
+Thank you for your pull request. Please review the below requirements.
+
+Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
+-->
+
+##### Checklist
+<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
+
+- [ ] `npm install test` passes
+- [ ] tests are included <!-- Bug fixes and new features should include tests -->
+- [ ] documentation is changed or added
+- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
+
+##### Description of change
+<!-- Provide a description of the change -->
+


### PR DESCRIPTION
Give users reporting bugs a clearer idea of the info that will be helpful when reporting issues.

Refs: https://github.com/nodejs/node/tree/master/.github

Also points users towards module issue trackers first.

I have no idea if the windows info is correct (or whether `node-gyp` uses `cc` on all UNIX). Please correct.

The PR template should be updated if/when we get a CONTRIBUTING.md (tracked in https://github.com/nodejs/node-gyp/issues/881)