### PR TITLE
Python info needs own header

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Install tools and configuration manually:
 
    If the above steps didn't work for you, please visit [Microsoft's Node.js Guidelines for Windows](https://github.com/Microsoft/nodejs-guidelines/blob/master/windows-environment.md#compiling-native-addon-modules) for additional tips.
 
-## Configuring Python Dependency
+### Configuring Python Dependency
 
 If you have multiple Python versions installed, you can identify which Python
 version `node-gyp` uses by setting the '--python' variable:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Install tools and configuration manually:
 ### Configuring Python Dependency
 
 If you have multiple Python versions installed, you can identify which Python
-version `node-gyp` uses by setting the "--python" variable:
+version `node-gyp` uses by setting the `--python` variable:
 
 ``` bash
 $ node-gyp --python /path/to/python2.7

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Install tools and configuration manually:
 ### Configuring Python Dependency
 
 If you have multiple Python versions installed, you can identify which Python
-version `node-gyp` uses by setting the '--python' variable:
+version `node-gyp` uses by setting the "--python" variable:
 
 ``` bash
 $ node-gyp --python /path/to/python2.7

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Install tools and configuration manually:
 
    If the above steps didn't work for you, please visit [Microsoft's Node.js Guidelines for Windows](https://github.com/Microsoft/nodejs-guidelines/blob/master/windows-environment.md#compiling-native-addon-modules) for additional tips.
 
+## Configuring Python Dependency
+
 If you have multiple Python versions installed, you can identify which Python
 version `node-gyp` uses by setting the '--python' variable:
 


### PR DESCRIPTION
There must be some kind of separation there in the Readme. It isn't clear this isn't part of the Windows installation information.