### PR TITLE
Fix IndexError when parsing GYP files.

### DIFF
--- a/gyp/pylib/gyp/input.py
+++ b/gyp/pylib/gyp/input.py
@@ -2033,7 +2033,7 @@ def MakePathRelative(to_file, fro_file, item):
         gyp.common.RelativePath(os.path.dirname(fro_file),
                                 os.path.dirname(to_file)),
                                 item)).replace('\\', '/')
-    if item[-1] == '/':
+    if item[-1:] == '/':
       ret += '/'
     return ret
 


### PR DESCRIPTION
GYP automatically turns variables ending in _dir, _file or _path into
absolute paths but didn't check for empty strings.

It interacted badly with variables inherited through the environment
from npm, the `scripts-prepend-node-path=false` setting in particular
because it is turned into `npm_config_script_prepend_node_path=`.

Fixes: https://github.com/nodejs/node-gyp/issues/1217
CI: https://ci.nodejs.org/job/nodegyp-test-pull-request/32/