### PR TITLE
python: more informative error

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,7 +1,7 @@
 {
   "asi": true,
   "laxcomma": true,
-  "es5": true,
+  "esversion": 6,
   "node": true,
   "strict": false
 }

--- a/bin/node-gyp.js
+++ b/bin/node-gyp.js
@@ -87,8 +87,12 @@ function run () {
   prog.commands[command.name](command.args, function (err) {
     if (err) {
       log.error(command.name + ' error')
-      log.error('stack', err.stack)
-      errorMessage()
+      if (err.noPython) {
+        log.error(err.message)
+      } else {
+        log.error('stack', err.stack)
+        errorMessage()
+      }
       log.error('not ok')
       return process.exit(1)
     }

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -461,7 +461,7 @@ PythonFinder.prototype = {
         this.log.silly('stripping "rc" identifier from version')
         version = version.replace(/rc(.*)$/ig, '')
       }
-      var range = semver.Range('>=2.5.0 <3.0.0')
+      var range = semver.Range('>=2.6.0 <3.0.0')
       var valid = false
       try {
         valid = range.test(version)
@@ -479,19 +479,32 @@ PythonFinder.prototype = {
   },
 
   failNoPython: function failNoPython () {
-    var errmsg =
-        'Can\'t find Python executable "' + this.python +
-        '", you can set the PYTHON env variable.'
-    this.callback(new Error(errmsg))
+    const err = new Error(
+      '\n******************************************************************\n' +
+      `node-gyp can't use "${this.python}",\n` +
+      'It is recommended that you install python 2.7, set the PYTHON env,\n' +
+      'or use the --python switch to point to a Python >= v2.6.0 & < 3.0.0.\n' +
+      'For more information consult the documentation at:\n' +
+      'https://github.com/nodejs/node-gyp#installation\n' +
+      '***********************************************************************'
+    );
+    err.noPython = true;
+    this.callback(err)
   },
 
   failPythonVersion: function failPythonVersion (badVersion) {
-    var errmsg =
-        'Python executable "' + this.python +
-        '" is v' + badVersion + ', which is not supported by gyp.\n' +
-        'You can pass the --python switch to point to ' +
-        'Python >= v2.5.0 & < 3.0.0.'
-    this.callback(new Error(errmsg))
+    const err = new Error(
+      '\n******************************************************************\n' +
+      `Python executable "${this.python}" is v${badVersion}\n` +
+      'this version is not supported by GYP and hence by node-gyp.\n' +
+      'It is recommended that you install python 2.7, set the PYTHON env,\n' +
+      'or use the --python switch to point to a Python >= v2.6.0 & < 3.0.0.\n' +
+      'For more information consult the documentation at:\n' +
+      'https://github.com/nodejs/node-gyp#installation\n' +
+      '***********************************************************************'
+    );
+    err.noPython = true;
+    this.callback(err)
   },
 
   // Called on Windows when "python" isn't available in the current $PATH.

--- a/test/test-find-python.js
+++ b/test/test-find-python.js
@@ -74,7 +74,7 @@ test('find python - python', function (t) {
 })
 
 test('find python - python too old', function (t) {
-  t.plan(4)
+  t.plan(5)
 
   var f = new TestPythonFinder('python', done)
   f.which = function(program, cb) {
@@ -88,13 +88,14 @@ test('find python - python too old', function (t) {
   }
   f.checkPython()
 
-  function done(err, python) {
-    t.ok(/is not supported by gyp/.test(err))
+  function done(err) {
+    t.ok(/this version is not supported by GYP/.test(err))
+    t.ok(/For more information consult the documentation/.test(err))
   }
 })
 
 test('find python - python too new', function (t) {
-  t.plan(4)
+  t.plan(5)
 
   var f = new TestPythonFinder('python', done)
   f.which = function(program, cb) {
@@ -108,8 +109,9 @@ test('find python - python too new', function (t) {
   }
   f.checkPython()
 
-  function done(err, python) {
-    t.ok(/is not supported by gyp/.test(err))
+  function done (err) {
+    t.ok(/this version is not supported by GYP/.test(err))
+    t.ok(/For more information consult the documentation/.test(err))
   }
 })
 
@@ -123,8 +125,8 @@ test('find python - no python', function (t) {
   }
   f.checkPython()
 
-  function done(err, python) {
-    t.ok(/Can't find Python executable/.test(err))
+  function done(err) {
+    t.ok(/For more information consult the documentation/.test(err))
   }
 })
 
@@ -170,8 +172,8 @@ test('find python - no python2, no python, unix', function (t) {
   }
   f.checkPython()
 
-  function done(err, python) {
-    t.ok(/Can't find Python executable/.test(err))
+  function done(err) {
+    t.ok(/For more information consult the documentation/.test(err))
   }
 })
 
@@ -242,7 +244,7 @@ test('find python - python 3, use python launcher', function (t) {
 
 test('find python - python 3, use python launcher, python 2 too old',
      function (t) {
-  t.plan(9)
+  t.plan(10)
 
   var f = new TestPythonFinder('python', done)
   f.checkedPythonLauncher = false
@@ -271,8 +273,9 @@ test('find python - python 3, use python launcher, python 2 too old',
   }
   f.checkPython()
 
-  function done(err, python) {
-    t.ok(/is not supported by gyp/.test(err))
+  function done(err) {
+    t.ok(/this version is not supported by GYP/.test(err))
+    t.ok(/For more information consult the documentation/.test(err))
   }
 })
 
@@ -334,6 +337,6 @@ test('find python - no python, no python launcher, bad guess', function (t) {
   f.checkPython()
 
   function done(err, python) {
-    t.ok(/Can't find Python executable/.test(err))
+    t.ok(/For more information consult the documentation/.test(err))
   }
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm install && npm test` passes
- [X] tests are included <!-- Bug fixes and new features should include tests -->
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Description of change
more informative error when failing to find a suitable python:
```
gyp info it worked if it ends with ok
gyp verb cli [ 'C:\\bin\\dev\\node\\node4.exe',
gyp verb cli   'D:\\code\\4node\\node-gyp\\bin\\node-gyp.js',
gyp verb cli   'configure',
gyp verb cli   '--loglevel=verbose' ]
gyp info using node-gyp@4.0.0
gyp info using node@4.8.2 | win32 | x64
gyp verb command configure []
gyp verb check python checking for Python executable "python2" in the PATH
gyp verb `which` failed Error: not found: python2
gyp verb `which` failed     at getNotFoundError (D:\code\4node\node-gyp\node_modules\which\which.js:13:12)
gyp verb `which` failed     at F (D:\code\4node\node-gyp\node_modules\which\which.js:68:19)
gyp verb `which` failed     at E (D:\code\4node\node-gyp\node_modules\which\which.js:80:29)
gyp verb `which` failed     at D:\code\4node\node-gyp\node_modules\which\which.js:89:16
gyp verb `which` failed     at D:\code\4node\node-gyp\node_modules\isexe\index.js:42:5
gyp verb `which` failed     at D:\code\4node\node-gyp\node_modules\isexe\windows.js:36:5
gyp verb `which` failed     at FSReqWrap.oncomplete (fs.js:82:15)
gyp verb `which` failed  python2 { [Error: not found: python2]
gyp verb `which` failed   stack: 'Error: not found: python2\n    at getNotFoundError (D:\\code\\4node\\node-gyp\\node_modules\\which\\which.js:13:12)\n    at F (D:\\code\\4node\\node-gyp\\node_modules\\which\\which.js:68:19)\n    at E (D:\\code\\4node\\node-gyp\\node_modules\\which\\which.js:80:29)\n    at D:\\code\\4node\\node-gyp\\node_modules\\which\\which.js:89:16\n    at D:\\code\\4node\\node-gyp\\node_modules\\isexe\\index.js:42:5\n    at D:\\code\\4node\\node-gyp\\node_modules\\isexe\\windows.js:36:5\n    at FSReqWrap.oncomplete (fs.js:82:15)',
gyp verb `which` failed   code: 'ENOENT' }
gyp verb check python checking for Python executable "python" in the PATH
gyp verb `which` failed Error: not found: python
gyp verb `which` failed     at getNotFoundError (D:\code\4node\node-gyp\node_modules\which\which.js:13:12)
gyp verb `which` failed     at F (D:\code\4node\node-gyp\node_modules\which\which.js:68:19)
gyp verb `which` failed     at E (D:\code\4node\node-gyp\node_modules\which\which.js:80:29)
gyp verb `which` failed     at D:\code\4node\node-gyp\node_modules\which\which.js:89:16
gyp verb `which` failed     at D:\code\4node\node-gyp\node_modules\isexe\index.js:42:5
gyp verb `which` failed     at D:\code\4node\node-gyp\node_modules\isexe\windows.js:36:5
gyp verb `which` failed     at FSReqWrap.oncomplete (fs.js:82:15)
gyp verb `which` failed  python { [Error: not found: python]
gyp verb `which` failed   stack: 'Error: not found: python\n    at getNotFoundError (D:\\code\\4node\\node-gyp\\node_modules\\which\\which.js:13:12)\n    at F (D:\\code\\4node\\node-gyp\\node_modules\\which\\which.js:68:19)\n    at E (D:\\code\\4node\\node-gyp\\node_modules\\which\\which.js:80:29)\n    at D:\\code\\4node\\node-gyp\\node_modules\\which\\which.js:89:16\n    at D:\\code\\4node\\node-gyp\\node_modules\\isexe\\index.js:42:5\n    at D:\\code\\4node\\node-gyp\\node_modules\\isexe\\windows.js:36:5\n    at FSReqWrap.oncomplete (fs.js:82:15)',
gyp verb `which` failed   code: 'ENOENT' }
gyp verb could not find "python". checking python launcher 
gyp verb could not find "python". guessing location 
gyp verb ensuring that file exists: C:\Python27\python.exe
gyp ERR! configure error 
gyp ERR! 
******************************************************************
node-gyp can't use "python",
It is recommended that you install python 2.7, set the PYTHON env,
or use the --python switch to point to a Python >= v2.6.0 & < 3.0.0.
For more information consult the documentation at:
https://github.com/nodejs/node-gyp#installation
*********************************************************************** 
gyp ERR! not ok 
```

