### PR TITLE
gyp: Export LD_LIBRARY_PATH quoted in case $(builddir) contains spaces

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+Thank you for reporting an issue. The more information you can give us, the
+better the chance we can fix your problem.
+
+This issue tracker is for issues with node-gyp,
+if you have an issue installing a specific module, please file an issue on
+that module's issue tracker (`npm issues modulename`).
+-->
+
+* **Node Version**: <!-- `node -v` and `npm -v` -->
+* **Platform**: <!-- `uname -a` (UNIX), or `systeminfo | findstr /B /C:"OS Name" /C:"OS Version" /C:"System Type"` (Windows) -->
+* **Compiler**: <!-- `cc -v` (UNIX) or `msbuild /version & cl` (Windows) -->
+* **Module**: <!-- what you tried to build/install -->
+
+<details><summary>Verbose output (from npm or node-gyp):</summary>
+
+<!-- Paste your log between the backticks. Contents of npm-debug.log or verbose build output -->
+
+```
+
+```
+
+</details>
+
+<!-- Any further details -->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!--
+Thank you for your pull request. Please review the below requirements.
+
+Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
+-->
+
+##### Checklist
+<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
+
+- [ ] `npm install && npm test` passes
+- [ ] tests are included <!-- Bug fixes and new features should include tests -->
+- [ ] documentation is changed or added
+- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
+
+##### Description of change
+<!-- Provide a description of the change -->
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to node-gyp
+
+## Code of Conduct
+
+Please read the
+[Code of Conduct](https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md)
+which explains the minimum behavior expectations for node-gyp contributors.
+
+<a id="developers-certificate-of-origin"></a>
+## Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+* (a) The contribution was created in whole or in part by me and I
+  have the right to submit it under the open source license
+  indicated in the file; or
+
+* (b) The contribution is based upon previous work that, to the best
+  of my knowledge, is covered under an appropriate open source
+  license and I have the right under that license to submit that
+  work with modifications, whether created in whole or in part
+  by me, under the same open source license (unless I am
+  permitted to submit under a different license), as indicated
+  in the file; or
+
+* (c) The contribution was provided directly to me by some other
+  person who certified (a), (b) or (c) and I have not modified
+  it.
+
+* (d) I understand and agree that this project and the contribution
+  are public and that a record of the contribution (including all
+  personal information I submit with it, including my sign-off) is
+  maintained indefinitely and may be redistributed consistent with
+  this project or the open source license(s) involved.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 node-gyp
 =========
-### Node.js native addon build tool
+## Node.js native addon build tool
 
 `node-gyp` is a cross-platform command-line tool written in Node.js for compiling
 native addon modules for Node.js.  It bundles the [gyp](https://gyp.gsrc.io)
@@ -14,7 +14,7 @@ Multiple target versions of node are supported (i.e. `0.8`, ..., `4`, `5`, `6`,
 etc.), regardless of what version of node is actually installed on your system
 (`node-gyp` downloads the necessary development files or headers for the target version).
 
-#### Features:
+## Features
 
  * Easy to use, consistent interface
  * Same commands to build your module on every platform
@@ -32,29 +32,39 @@ $ npm install -g node-gyp
 
 You will also need to install:
 
-  * On Unix:
-    * `python` (`v2.7` recommended, `v3.x.x` is __*not*__ supported)
-    * `make`
-    * A proper C/C++ compiler toolchain, like [GCC](https://gcc.gnu.org)
-  * On Mac OS X:
-    * `python` (`v2.7` recommended, `v3.x.x` is __*not*__ supported) (already installed on Mac OS X)
-    * [Xcode](https://developer.apple.com/xcode/download/)
-      * You also need to install the `Command Line Tools` via Xcode. You can find this under the menu `Xcode -> Preferences -> Downloads`
-      * This step will install `gcc` and the related toolchain containing `make`
-  * On Windows:
-    * Option 1: Install all the required tools and configurations using Microsoft's [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools) using `npm install --global --production windows-build-tools` from an elevated PowerShell or CMD.exe (run as Administrator).
-    * Option 2: Install tools and configuration manually:
-      * Visual C++ Build Environment:
-        * Option 1: Install [Visual C++ Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools) using the **Default Install** option.
+### On Unix
 
-        * Option 2: Install [Visual Studio 2015](https://www.visualstudio.com/products/visual-studio-community-vs) (or modify an existing installation) and select *Common Tools for Visual C++* during setup. This also works with the free Community and Express for Desktop editions.
+   * `python` (`v2.7` recommended, `v3.x.x` is __*not*__ supported)
+   * `make`
+   * A proper C/C++ compiler toolchain, like [GCC](https://gcc.gnu.org)
 
-        > :bulb: [Windows Vista / 7 only] requires [.NET Framework 4.5.1](http://www.microsoft.com/en-us/download/details.aspx?id=40773)
+### On Mac OS X
 
-      * Install [Python 2.7](https://www.python.org/downloads/) (`v3.x.x` is not supported), and run `npm config set python python2.7` (or see below for further instructions on specifying the proper Python version and path.)
-      * Launch cmd, `npm config set msvs_version 2015`
+   * `python` (`v2.7` recommended, `v3.x.x` is __*not*__ supported) (already installed on Mac OS X)
+   * [Xcode](https://developer.apple.com/xcode/download/)
+     * You also need to install the `Command Line Tools` via Xcode. You can find this under the menu `Xcode -> Preferences -> Downloads`
+     * This step will install `gcc` and the related toolchain containing `make`
 
-    If the above steps didn't work for you, please visit [Microsoft's Node.js Guidelines for Windows](https://github.com/Microsoft/nodejs-guidelines/blob/master/windows-environment.md#compiling-native-addon-modules) for additional tips.
+### On Windows
+
+#### Option 1
+
+Install all the required tools and configurations using Microsoft's [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools) using `npm install --global --production windows-build-tools` from an elevated PowerShell or CMD.exe (run as Administrator).
+
+#### Option 2
+
+Install tools and configuration manually:
+   * Visual C++ Build Environment:
+     * Option 1: Install [Visual C++ Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools) using the **Default Install** option.
+
+     * Option 2: Install [Visual Studio 2015](https://www.visualstudio.com/products/visual-studio-community-vs) (or modify an existing installation) and select *Common Tools for Visual C++* during setup. This also works with the free Community and Express for Desktop editions.
+
+     > :bulb: [Windows Vista / 7 only] requires [.NET Framework 4.5.1](http://www.microsoft.com/en-us/download/details.aspx?id=40773)
+
+   * Install [Python 2.7](https://www.python.org/downloads/) (`v3.x.x` is not supported), and run `npm config set python python2.7` (or see below for further instructions on specifying the proper Python version and path.)
+   * Launch cmd, `npm config set msvs_version 2015`
+
+   If the above steps didn't work for you, please visit [Microsoft's Node.js Guidelines for Windows](https://github.com/Microsoft/nodejs-guidelines/blob/master/windows-environment.md#compiling-native-addon-modules) for additional tips.
 
 If you have multiple Python versions installed, you can identify which Python
 version `node-gyp` uses by setting the '--python' variable:

--- a/gyp/pylib/gyp/easy_xml.py
+++ b/gyp/pylib/gyp/easy_xml.py
@@ -4,6 +4,7 @@
 
 import re
 import os
+import locale
 
 
 def XmlToString(content, encoding='utf-8', pretty=False):
@@ -115,11 +116,10 @@ def WriteXmlIfChanged(content, path, encoding='utf-8', pretty=False,
   xml_string = XmlToString(content, encoding, pretty)
   if win32 and os.linesep != '\r\n':
     xml_string = xml_string.replace('\n', '\r\n')
-    
-  try:
-    xml_string = xml_string.encode(encoding)
-  except Exception:
-    xml_string = unicode(xml_string, 'latin-1').encode(encoding)
+
+  default_encoding = locale.getdefaultlocale()[1]
+  if default_encoding.upper() != encoding.upper():
+    xml_string = xml_string.decode(default_encoding).encode(encoding)
 
   # Get the old content
   try:

--- a/gyp/pylib/gyp/generator/make.py
+++ b/gyp/pylib/gyp/generator/make.py
@@ -916,11 +916,12 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
       # libraries, but until everything is made cross-compile safe, also use
       # target libraries.
       # TODO(piman): when everything is cross-compile safe, remove lib.target
-      self.WriteLn('cmd_%s = LD_LIBRARY_PATH=$(builddir)/lib.host:'
-                   '$(builddir)/lib.target:$$LD_LIBRARY_PATH; '
+      subst_builddir = '$(subst \',\'\\\'\',$(builddir))'
+      self.WriteLn('cmd_%s = LD_LIBRARY_PATH=\'%s/lib.host:'
+                   '%s/lib.target\':$$LD_LIBRARY_PATH; '
                    'export LD_LIBRARY_PATH; '
                    '%s%s'
-                   % (name, cd_action, command))
+                   % (name, subst_builddir, subst_builddir, cd_action, command))
       self.WriteLn()
       outputs = map(self.Absolutify, outputs)
       # The makefile rules are all relative to the top dir, but the gyp actions

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -72,8 +72,10 @@ function configure (gyp, argv, callback) {
         return callback(new Error('Invalid version number: ' + release.version))
       }
 
-      // ensure that the target node version's dev files are installed
-      gyp.opts.ensure = true
+      // If the tarball option is set, always remove and reinstall the headers
+      // into devdir. Otherwise only install if they're not already there.
+      gyp.opts.ensure = gyp.opts.tarball ? false : true
+
       gyp.commands.install([ release.version ], function (err, version) {
         if (err) return callback(err)
         log.verbose('get node dir', 'target node version installed:', release.versionDir)

--- a/lib/install.js
+++ b/lib/install.js
@@ -15,10 +15,8 @@ var fs = require('graceful-fs')
   , rm = require('rimraf')
   , path = require('path')
   , crypto = require('crypto')
-  , zlib = require('zlib')
   , log = require('npmlog')
   , semver = require('semver')
-  , fstream = require('fstream')
   , request = require('request')
   , minimatch = require('minimatch')
   , mkdir = require('mkdirp')
@@ -144,41 +142,33 @@ function install (gyp, argv, callback) {
       var tarPath = gyp.opts.tarball
       var badDownload = false
         , extractCount = 0
-        , gunzip = zlib.createGunzip()
-        , extracter = tar.Extract({ path: devDir, strip: 1, filter: isValid })
 
       var contentShasums = {}
       var expectShasums = {}
 
       // checks if a file to be extracted from the tarball is valid.
       // only .h header files and the gyp files get extracted
-      function isValid () {
-        var name = this.path.substring(devDir.length + 1)
-        var isValid = valid(name)
-        if (name === '' && this.type === 'Directory') {
-          // the first directory entry is ok
-          return true
-        }
+      function isValid (path, entry) {
+        var isValid = valid(path)
         if (isValid) {
-          log.verbose('extracted file from tarball', name)
+          log.verbose('extracted file from tarball', path)
           extractCount++
         } else {
           // invalid
-          log.silly('ignoring from tarball', name)
+          log.silly('ignoring from tarball', path)
         }
         return isValid
       }
 
-      gunzip.on('error', cb)
-      extracter.on('error', cb)
-      extracter.on('end', afterTarball)
-
-      // download the tarball, gunzip and extract!
+      // download the tarball and extract!
 
       if (tarPath) {
-        var input = fs.createReadStream(tarPath)
-        input.pipe(gunzip).pipe(extracter)
-        return
+        return tar.extract({
+          file: tarPath,
+          strip: 1,
+          filter: isValid,
+          cwd: devDir
+        }).then(afterTarball, cb)
       }
 
       try {
@@ -218,7 +208,11 @@ function install (gyp, argv, callback) {
         })
 
         // start unzipping and untaring
-        req.pipe(gunzip).pipe(extracter)
+        res.pipe(tar.extract({
+          strip: 1,
+          cwd: devDir,
+          filter: isValid
+        }).on('close', afterTarball).on('error', cb))
       })
 
       // invoked after the tarball has finished being extracted

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bindings",
     "gyp"
   ],
-  "version": "3.6.2",
+  "version": "4.0.0",
   "installVersion": 9,
   "author": "Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "bin": "./bin/node-gyp.js",
   "main": "./lib/node-gyp.js",
   "dependencies": {
-    "fstream": "^1.0.0",
     "glob": "^7.0.3",
     "graceful-fs": "^4.1.2",
     "minimatch": "^3.0.2",
@@ -33,11 +32,11 @@
     "request": "2",
     "rimraf": "2",
     "semver": "~5.3.0",
-    "tar": "^2.0.0",
+    "tar": "^3.1.3",
     "which": "1"
   },
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 4.0.0"
   },
   "devDependencies": {
     "tape": "~4.2.0",

--- a/test/fixtures/test-charmap.py
+++ b/test/fixtures/test-charmap.py
@@ -1,0 +1,19 @@
+import sys
+import locale
+
+reload(sys)
+
+def main():
+  encoding = locale.getdefaultlocale()[1]
+  sys.setdefaultencoding(encoding)
+  textmap = {
+    'cp936': u'\u4e2d\u6587',
+    'cp1252': u'Lat\u012Bna',
+    'cp932': u'\u306b\u307b\u3093\u3054'
+  }
+  if textmap.has_key(encoding):
+    print textmap[encoding]
+  return True
+
+if __name__ == '__main__':
+  print main()

--- a/test/node_modules/name's (weird)/binding.gyp
+++ b/test/node_modules/name's (weird)/binding.gyp
@@ -1,0 +1,15 @@
+{
+  "targets": [
+    {
+      "target_name": "hello",
+      "actions": [{
+          "inputs": [""],
+          "outputs": ["hello.js"],
+          "action_name": "create_hello_js",
+          "action": [
+              "sh", "./hello.sh"
+          ]
+      }]
+    }
+  ]
+}

--- a/test/node_modules/name's (weird)/hello.sh
+++ b/test/node_modules/name's (weird)/hello.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+printf "console.log('world');\n" > hello.js

--- a/test/node_modules/name's (weird)/package.json
+++ b/test/node_modules/name's (weird)/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "odd (name)",
+  "version": "0.0.0",
+  "description": "Node.js Addons Example #2",
+  "main": "hello.js",
+  "private": true,
+  "dependencies": {
+  },
+  "scripts": {
+    "test": "node hello.js"
+  },
+  "gypfile": true
+}

--- a/test/test-actions.js
+++ b/test/test-actions.js
@@ -1,0 +1,34 @@
+'use strict'
+
+var child_process = require('child_process')
+var test = require('tape')
+var path = require('path')
+
+var execFileSync = child_process.execFileSync
+var execFile = child_process.execFile
+
+var addonPath = path.resolve(__dirname, 'node_modules', 'name\'s (weird)')
+var nodeGyp = path.resolve(__dirname, '..', 'bin', 'node-gyp.js')
+
+function runSpacedName() {
+  var testCode = "require('name\\'s (weird)')"
+  return execFileSync('node', ['-e', testCode], { cwd: __dirname }).toString()
+}
+
+test('build addon w/ actions and spaces in path', function (t) {
+  t.plan(3)
+
+  // Set the loglevel otherwise the output disappears when run via 'npm test'
+  var cmd = [ nodeGyp, 'rebuild', '-C', addonPath, '--loglevel=verbose' ]
+
+  var proc = execFile(process.execPath, cmd, function (err, stdout, stderr) {
+    var logLines = stderr.toString().trim().split(/\r?\n/)
+    var lastLine = logLines[logLines.length-1]
+    t.strictEqual(err, null)
+    t.strictEqual(lastLine, 'gyp info ok', 'should end in ok')
+    t.strictEqual(runSpacedName().trim(), 'world')
+  })
+
+  proc.stdout.setEncoding('utf-8')
+  proc.stderr.setEncoding('utf-8')
+})

--- a/test/test-addon.js
+++ b/test/test-addon.js
@@ -1,10 +1,35 @@
 'use strict'
 
 var test = require('tape')
-var execFile = require('child_process').execFile
 var path = require('path')
+var fs = require('graceful-fs')
+var child_process = require('child_process')
 var addonPath = path.resolve(__dirname, 'node_modules', 'hello_world')
 var nodeGyp = path.resolve(__dirname, '..', 'bin', 'node-gyp.js')
+var execFileSync = child_process.execFileSync
+var execFile = child_process.execFile
+
+function runHello() {
+  var testCode = "console.log(require('hello_world').hello())"
+  return execFileSync('node', ['-e', testCode], { cwd: __dirname }).toString()
+}
+
+function getEncoding() {
+  var code = 'import locale;print locale.getdefaultlocale()[1]'
+  return execFileSync('python', ['-c', code]).toString().trim()
+}
+
+function checkCharmapValid() {
+  var data
+  try {
+    data = execFileSync('python', ['fixtures/test-charmap.py'],
+                        { cwd: __dirname })
+  } catch (err) {
+    return false
+  }
+  var lines = data.toString().trim().split('\n')
+  return lines.pop() === 'True'
+}
 
 test('build simple addon', function (t) {
   t.plan(3)
@@ -16,12 +41,72 @@ test('build simple addon', function (t) {
     var lastLine = logLines[logLines.length-1]
     t.strictEqual(err, null)
     t.strictEqual(lastLine, 'gyp info ok', 'should end in ok')
-    try {
-      var binding = require('hello_world')
-      t.strictEqual(binding.hello(), 'world')
-    } catch (error) {
-      t.error(error, 'load module')
+    t.strictEqual(runHello().trim(), 'world')
+  })
+  proc.stdout.setEncoding('utf-8')
+  proc.stderr.setEncoding('utf-8')
+})
+
+test('build simple addon in path with non-ascii characters', function (t) {
+  t.plan(1)
+
+  if (!checkCharmapValid()) {
+    return t.skip('python console app can\'t encode non-ascii character.')
+  }
+
+  var testDirNames = {
+    'cp936': '文件夹',
+    'cp1252': 'Latīna',
+    'cp932': 'フォルダ'
+  }
+  // Select non-ascii characters by current encoding
+  var testDirName = testDirNames[getEncoding()]
+  // If encoding is UTF-8 or other then no need to test
+  if (!testDirName) {
+    return t.skip('no need to test')
+  }
+
+  t.plan(3)
+
+  var data, configPath = path.join(addonPath, 'build', 'config.gypi')
+  try {
+    data = fs.readFileSync(configPath, 'utf8')
+  } catch (err) {
+    t.error(err)
+    return
+  }
+  var config = JSON.parse(data.replace(/\#.+\n/, ''))
+  var nodeDir = config.variables.nodedir
+  var testNodeDir = path.join(addonPath, testDirName)
+  // Create symbol link to path with non-ascii characters
+  try {
+    fs.symlinkSync(nodeDir, testNodeDir, 'dir')
+  } catch (err) {
+    switch (err.code) {
+      case 'EEXIST': break
+      case 'EPERM':
+        t.error(err, 'Please try to running console as an administrator')
+        return
+      default:
+        t.error(err)
+        return
     }
+  }
+
+  var cmd = [nodeGyp, 'rebuild', '-C', addonPath,
+             '--loglevel=verbose', '-nodedir=' + testNodeDir]
+  var proc = execFile(process.execPath, cmd, function (err, stdout, stderr) {
+    try {
+      fs.unlink(testNodeDir)
+    } catch (err) {
+      t.error(err)
+    }
+
+    var logLines = stderr.toString().trim().split(/\r?\n/)
+    var lastLine = logLines[logLines.length-1]
+    t.strictEqual(err, null)
+    t.strictEqual(lastLine, 'gyp info ok', 'should end in ok')
+    t.strictEqual(runHello().trim(), 'world')
   })
   proc.stdout.setEncoding('utf-8')
   proc.stderr.setEncoding('utf-8')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Description of change

This change will make sure that the path to the build directory gets properly quoted and escaped when running actions.