### PR TITLE
import shlex for shlex.split()

### DIFF
--- a/gyp/gyptest.py
+++ b/gyp/gyptest.py
@@ -10,6 +10,7 @@ gyptest.py -- test runner for GYP tests.
 
 import os
 import optparse
+import shlex
 import subprocess
 import sys
 


### PR DESCRIPTION
shlex.split() is called on line 75 but shlex is never imported.

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

