### PR TITLE
except e: --> except Exception:

### DIFF
--- a/gyp/pylib/gyp/mac_tool.py
+++ b/gyp/pylib/gyp/mac_tool.py
@@ -127,7 +127,7 @@ class MacTool(object):
     fp = open(file_name, 'rb')
     try:
       header = fp.read(3)
-    except e:
+    except Exception:
       fp.close()
       return None
     fp.close()


### PR DESCRIPTION
In the current code __e__ is both undefined and unused so this code will raise an NameError exception which masks the original exception.

An alternative solution would be: __except Exception as e:__ but that still creates an unused variable.

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

