### PR TITLE
Fix: module compilation within termux-app on android

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -52,6 +52,14 @@
         'standalone_static_library': '<(standalone_static_library)'
       }],
 
+      ['_type!="executable"', {
+        'conditions': [
+          [ 'OS=="android"', {
+            'cflags!': [ '-fPIE' ],
+          }]
+        ]
+      }],
+
       ['_win_delay_load_hook=="true"', {
         # If the addon specifies `'win_delay_load_hook': 'true'` in its
         # binding.gyp, link a delay-load hook into the DLL. This hook ensures
@@ -135,10 +143,10 @@
           '_FILE_OFFSET_BITS=64'
         ],
       }],
-      [ 'OS in "freebsd openbsd netbsd solaris" or \
+      [ 'OS in "freebsd openbsd netbsd solaris android" or \
          (OS=="linux" and target_arch!="ia32")', {
         'cflags': [ '-fPIC' ],
-      }]
+      }],
     ]
   }
 }


### PR DESCRIPTION
##### Description of change
To solve the problem of linking a compiled module against a preinstalled library of termux-app on android I added a special condition branch to add the required -fPIC flag for the c and c++ compiler. After that everything compiled, linked and works as expected.