### PR TITLE
gyp: don't print xcodebuild not found errors

### DIFF
--- a/gyp/pylib/gyp/xcode_emulation.py
+++ b/gyp/pylib/gyp/xcode_emulation.py
@@ -429,7 +429,7 @@ class XcodeSettings(object):
     # Since the CLT has no SDK paths anyway, returning None is the
     # most sensible route and should still do the right thing.
     try:
-      return GetStdout(['xcodebuild', '-version', '-sdk', sdk, infoitem])
+      return GetStdoutQuiet(['xcodebuild', '-version', '-sdk', sdk, infoitem])
     except:
       pass
 
@@ -1251,7 +1251,7 @@ def XcodeVersion():
   if XCODE_VERSION_CACHE:
     return XCODE_VERSION_CACHE
   try:
-    version_list = GetStdout(['xcodebuild', '-version']).splitlines()
+    version_list = GetStdoutQuiet(['xcodebuild', '-version']).splitlines()
     # In some circumstances xcodebuild exits 0 but doesn't return
     # the right results; for example, a user on 10.7 or 10.8 with
     # a bogus path set via xcode-select
@@ -1299,6 +1299,17 @@ def CLTVersion():
       return re.search(regex, output).groupdict()['version']
     except:
       continue
+
+
+def GetStdoutQuiet(cmdlist):
+  """Returns the content of standard output returned by invoking |cmdlist|.
+  Ignores the stderr.
+  Raises |GypError| if the command return with a non-zero return code."""
+  job = subprocess.Popen(cmdlist, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  out = job.communicate()[0]
+  if job.returncode != 0:
+    raise GypError('Error %d running %s' % (job.returncode, cmdlist[0]))
+  return out.rstrip('\n')
 
 
 def GetStdout(cmdlist):


### PR DESCRIPTION
As node-gyp rebuild doesn't seem to need xcodebuild, we don't need to be printing the error every time GYP is run.

Refs: https://github.com/nodejs/node-gyp/pull/1057
Refs: https://chromium-review.googlesource.com/c/492046/
Refs: https://github.com/nodejs/node-gyp/issues/569

As the previous attempts haven't landed, I thought I'd aim for a minimal diff. This seems to remove all `node-gyp build` warnings during `npm install` of a native module, and errors from running configure in node core, although for some reason the first line in Node's built-in gyp [uses `xcrun` rather than `xcodebuild`](https://github.com/nodejs/node/blob/8803b69c724e7b03ec0fc4c82b71575262487624/tools/gyp/pylib/gyp/xcode_emulation.py#L498).

This is caused by me running a "getting started with node" course, and having half the audience stuck because "there was an error in the build".

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)