### PR TITLE
Update `--nodedir` description in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Command Options
 | `--dist-url=$url`                 | Download header tarball from custom URL
 | `--proxy=$url`                    | Set HTTP proxy for downloading header tarball
 | `--cafile=$cafile`                | Override default CA chain (to download tarball)
-| `--nodedir=$path`                 | Set the path to the node binary
+| `--nodedir=$path`                 | Set the path to the node source code
 | `--python=$path`                  | Set path to the python (2) binary
 | `--msvs_version=$version`         | Set Visual Studio version (win)
 | `--solution=$solution`            | Set Visual Studio Solution version (win)


### PR DESCRIPTION
The description erroneously stated that it should point the node binary.
It needs to point to the node source code.

Refs: https://github.com/nodejs/node-gyp/issues/1371