### PR TITLE
Fix infinite install loop.

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -1,7 +1,12 @@
+module.exports = exports = function (gyp, argv, callback) {
+  return install(fs, gyp, argv, callback)
+}
 
-module.exports = exports = install
-
-module.exports.test = { download: download, readCAFile: readCAFile }
+module.exports.test = {
+  download: download,
+  install: install,
+  readCAFile: readCAFile,
+}
 
 exports.usage = 'Install node development files for the specified node version.'
 
@@ -23,7 +28,7 @@ var fs = require('graceful-fs')
   , processRelease = require('./process-release')
   , win = process.platform == 'win32'
 
-function install (gyp, argv, callback) {
+function install (fs, gyp, argv, callback) {
 
   var release = processRelease(argv, gyp, process.version, process.release)
 
@@ -82,7 +87,7 @@ function install (gyp, argv, callback) {
           log.verbose('install', 'version not already installed, continuing with install', release.version)
           go()
         } else if (err.code == 'EACCES') {
-          eaccesFallback()
+          eaccesFallback(err)
         } else {
           cb(err)
         }
@@ -127,7 +132,7 @@ function install (gyp, argv, callback) {
     mkdir(devDir, function (err, created) {
       if (err) {
         if (err.code == 'EACCES') {
-          eaccesFallback()
+          eaccesFallback(err)
         } else {
           cb(err)
         }
@@ -403,7 +408,9 @@ function install (gyp, argv, callback) {
    * the compilation will succeed...
    */
 
-  function eaccesFallback () {
+  function eaccesFallback (err) {
+    var noretry = '--node_gyp_internal_noretry'
+    if (-1 !== argv.indexOf(noretry)) return cb(err)
     var tmpdir = osenv.tmpdir()
     gyp.devDir = path.resolve(tmpdir, '.node-gyp')
     log.warn('EACCES', 'user "%s" does not have permission to access the dev dir "%s"', osenv.user(), devDir)
@@ -412,7 +419,7 @@ function install (gyp, argv, callback) {
       log.verbose('tmpdir == cwd', 'automatically will remove dev files after to save disk space')
       gyp.todo.push({ name: 'remove', args: argv })
     }
-    gyp.commands.install(argv, cb)
+    gyp.commands.install([noretry].concat(argv), cb)
   }
 
 }

--- a/test/test-install.js
+++ b/test/test-install.js
@@ -1,0 +1,37 @@
+'use strict'
+
+var test = require('tape')
+var install = require('../lib/install').test.install
+
+test('EACCES retry once', function (t) {
+  t.plan(3)
+
+  var fs = {}
+  fs.stat = function (path, cb) {
+    var err = new Error()
+    err.code = 'EACCES'
+    cb(err)
+    t.ok(true);
+  }
+
+
+  var gyp = {}
+  gyp.devDir = __dirname
+  gyp.opts = {}
+  gyp.opts.ensure = true
+  gyp.commands = {}
+  gyp.commands.install = function (argv, cb) {
+    install(fs, gyp, argv, cb)
+  }
+  gyp.commands.remove = function (argv, cb) {
+    cb()
+  }
+
+  gyp.commands.install([], function (err) {
+    t.ok(true)
+    if (/"pre" versions of node cannot be installed/.test(err.message)) {
+      t.ok(true)
+      t.ok(true)
+    }
+  })
+})


### PR DESCRIPTION
Retry the download+install dance only once after encountering an EACCES.

That only happens when both the devdir (usually: `$HOME/.node-gyp`) and
the current working directory aren't writable.  Users won't often hit
that except through `sudo npm install` because npm drops privileges
before executing node-gyp.

Fixes #1383.