### PR TITLE
Add node-gyp builtin config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ __`node-gyp` responds to environment variables or `npm` configuration__
  This way only works when `node-gyp` is executed by `npm`:  
  `$ npm config set [--global] devdir /tmp/.gyp`  
  `$ npm i buffertools`
+3. `node-gyp` builtin config file at `/path/to/node-gyp/node-gyp.rc`. This is an
+ unchangeable "builtin" configuration file. Set fields in INI format here. This
+ is primarily for distribution maintainers to override default configs such
+ as `--nodedir` option in a standard and consistent manner.
  
 
 

--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -10,6 +10,7 @@ module.exports = exports = gyp
  */
 
 var fs = require('graceful-fs')
+  , ini = require('ini')
   , path = require('path')
   , nopt = require('nopt')
   , log = require('npmlog')
@@ -161,6 +162,20 @@ proto.parseArgv = function parseOpts (argv) {
       if (name) this.opts[name] = val
     }
   }, this)
+
+  try {
+    var parsedIni = ini.parse(fs.readFileSync(path.resolve(__dirname, '..', 'node-gyp.rc'), 'utf-8'))
+    Object.keys(parsedIni).forEach(function (name) {
+      var val = parsedIni[name]
+      if (name === 'loglevel') {
+        log.level = val
+      } else {
+        this.opts[name] = val
+      }
+    }, this)
+  } catch (e) {
+    // node-gyp.rc is optional.
+  }
 
   if (this.opts.loglevel) {
     log.level = this.opts.loglevel

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "glob": "^7.0.3",
     "graceful-fs": "^4.1.2",
+    "ini": "^1.3.5",
     "minimatch": "^3.0.2",
     "mkdirp": "^0.5.0",
     "nopt": "2 || 3",


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm install && npm test` passes
- [X] tests are included <!-- Bug fixes and new features should include tests -->
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->
--nodedir is distribution-dependent. For example, some distribution may
ship Node.js with OpenSSL 1.1.0. ts maintainer would want to use OpenSSL
1.1.0 headers rahter than prebuilt OpenSSL 1.0.2 headers in such a case.

This change allows to provide such an option with builtin config file,
as npm does.