### PR TITLE
Fix space in deps

### DIFF
--- a/gyp/pylib/gyp/generator/make.py
+++ b/gyp/pylib/gyp/generator/make.py
@@ -642,7 +642,7 @@ def Sourceify(path):
 def QuoteSpaces(s, quote=r'\ '):
   return s.replace(' ', quote)
 
-def SourceifyAndQuoteSpace(path):
+def SourceifyAndQuoteSpaces(path):
   """Convert a path to its source directory form and quote spaces."""
   return QuoteSpaces(Sourceify(path))
 

--- a/gyp/pylib/gyp/generator/make.py
+++ b/gyp/pylib/gyp/generator/make.py
@@ -642,6 +642,9 @@ def Sourceify(path):
 def QuoteSpaces(s, quote=r'\ '):
   return s.replace(' ', quote)
 
+def SourceifyAndQuoteSpace(path):
+  """Convert a path to its source directory form and quote spaces."""
+  return QuoteSpaces(Sourceify(path))
 
 # TODO: Avoid code duplication with _ValidateSourcesForMSVSProject in msvs.py.
 def _ValidateSourcesForOSX(spec, all_sources):
@@ -1964,7 +1967,7 @@ def WriteAutoRegenerationRule(params, root_makefile, makefile_name,
       "%(makefile_name)s: %(deps)s\n"
       "\t$(call do_cmd,regen_makefile)\n\n" % {
           'makefile_name': makefile_name,
-          'deps': ' '.join(map(Sourceify, build_files)),
+          'deps': ' '.join(map(SourceifyAndQuoteSpaces, build_files)),
           'cmd': gyp.common.EncodePOSIXShellList(
                      [gyp_binary, '-fmake'] +
                      gyp.RegenerateFlags(options) +


### PR DESCRIPTION
##### Checklist

- [x] `npm install && npm test` passes
xxx- [ ] tests are included 
(Note: I'm unsure how to test this case without a lengthy exercise)
- [x] commit message follows [commit guidelines]

##### Description of change
Fixes a narrow issue when spaces are found in paths in the computed dependencies of the Makefile. This occurs in the unusual circumstance that the username and/or home directory has a space

