### PR TITLE
Update request dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "nopt": "2 || 3",
     "npmlog": "0 || 1 || 2 || 3 || 4",
     "osenv": "0",
-    "request": "2",
+    "request": "^2.86",
     "rimraf": "2",
     "semver": "~5.3.0",
     "tar": "^3.1.3",


### PR DESCRIPTION
##### Checklist
- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Description of change
Update the version of request, to use 2.86 or higher. Starting from 2.86.0, request has its dependency on [StringStream](https://github.com/mhart/StringStream) removed. The latter package has a [vulnerability](https://hackerone.com/reports/321670) that shows up via `npm audit`.

