### PR TITLE
Update XcodeVersion() to support Xcode v10

### DIFF
--- a/gyp/pylib/gyp/xcode_emulation.py
+++ b/gyp/pylib/gyp/xcode_emulation.py
@@ -1270,7 +1270,10 @@ def XcodeVersion():
   version = version_list[0]
   build = version_list[-1]
   # Be careful to convert "4.2" to "0420":
-  version = version.split()[-1].replace('.', '')
+  version = version.split()[-1]
+  for digit in version.split('.')[0]:
+    version += '0'
+  version = version[:-1].replace('.', '')
   version = (version + '0' * (3 - len(version))).zfill(4)
   if build:
     build = build.split()[-1]


### PR DESCRIPTION
The way this file was previously set up, it evaluated v1 and v10 to be the same thing, so anything relying on this code would think that systems using xcode v10 was out of date

This resolves issue #1459
