### PR TITLE
configure: use sys.version_info to get python version

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -448,7 +448,7 @@ PythonFinder.prototype = {
   },
 
   checkPythonVersion: function checkPythonVersion () {
-    var args = ['-c', 'import platform; print(platform.python_version());']
+    var args = ['-c', 'import sys; print "%s.%s.%s" % sys.version_info[:3];']
     var env = extend({}, this.env)
     env.TERM = 'dumb'
 
@@ -460,14 +460,6 @@ PythonFinder.prototype = {
                        '`%s -c "' + args[1] + '"` returned: %j',
                        this.python, stdout)
       var version = stdout.trim()
-      if (~version.indexOf('+')) {
-        this.log.silly('stripping "+" sign(s) from version')
-        version = version.replace(/\+/g, '')
-      }
-      if (~version.indexOf('rc')) {
-        this.log.silly('stripping "rc" identifier from version')
-        version = version.replace(/rc(.*)$/ig, '')
-      }
       var range = semver.Range('>=2.5.0 <3.0.0')
       var valid = false
       try {

--- a/test/test-find-python.js
+++ b/test/test-find-python.js
@@ -62,7 +62,7 @@ test('find python - python', function (t) {
   }
   f.execFile = function(program, args, opts, cb) {
     t.strictEqual(program, 'python')
-    t.ok(/import platform/.test(args[1]))
+    t.ok(/import sys/.test(args[1]))
     cb(null, '2.7.0')
   }
   f.checkPython()
@@ -83,7 +83,7 @@ test('find python - python too old', function (t) {
   }
   f.execFile = function(program, args, opts, cb) {
     t.strictEqual(program, 'python')
-    t.ok(/import platform/.test(args[1]))
+    t.ok(/import sys/.test(args[1]))
     cb(null, '2.3.4')
   }
   f.checkPython()
@@ -103,7 +103,7 @@ test('find python - python too new', function (t) {
   }
   f.execFile = function(program, args, opts, cb) {
     t.strictEqual(program, 'python')
-    t.ok(/import platform/.test(args[1]))
+    t.ok(/import sys/.test(args[1]))
     cb(null, '3.0.0')
   }
   f.checkPython()
@@ -142,7 +142,7 @@ test('find python - no python2', function (t) {
   }
   f.execFile = function(program, args, opts, cb) {
     t.strictEqual(program, 'python')
-    t.ok(/import platform/.test(args[1]))
+    t.ok(/import sys/.test(args[1]))
     cb(null, '2.7.0')
   }
   f.checkPython()
@@ -189,7 +189,7 @@ test('find python - no python, use python launcher', function (t) {
   f.execFile = function(program, args, opts, cb) {
     f.execFile = function(program, args, opts, cb) {
       t.strictEqual(program, 'Z:\\snake.exe')
-      t.ok(/import platform/.test(args[1]))
+      t.ok(/import sys/.test(args[1]))
       cb(null, '2.7.0')
     }
     t.strictEqual(program, 'py.exe')
@@ -220,7 +220,7 @@ test('find python - python 3, use python launcher', function (t) {
     f.execFile = function(program, args, opts, cb) {
       f.execFile = function(program, args, opts, cb) {
         t.strictEqual(program, 'Z:\\snake.exe')
-        t.ok(/import platform/.test(args[1]))
+        t.ok(/import sys/.test(args[1]))
         cb(null, '2.7.0')
       }
       t.strictEqual(program, 'py.exe')
@@ -229,7 +229,7 @@ test('find python - python 3, use python launcher', function (t) {
       cb(null, 'Z:\\snake.exe')
     }
     t.strictEqual(program, 'python')
-    t.ok(/import platform/.test(args[1]))
+    t.ok(/import sys/.test(args[1]))
     cb(null, '3.0.0')
   }
   f.checkPython()
@@ -257,7 +257,7 @@ test('find python - python 3, use python launcher, python 2 too old',
     f.execFile = function(program, args, opts, cb) {
       f.execFile = function(program, args, opts, cb) {
         t.strictEqual(program, 'Z:\\snake.exe')
-        t.ok(/import platform/.test(args[1]))
+        t.ok(/import sys/.test(args[1]))
         cb(null, '2.3.4')
       }
       t.strictEqual(program, 'py.exe')
@@ -266,7 +266,7 @@ test('find python - python 3, use python launcher, python 2 too old',
       cb(null, 'Z:\\snake.exe')
     }
     t.strictEqual(program, 'python')
-    t.ok(/import platform/.test(args[1]))
+    t.ok(/import sys/.test(args[1]))
     cb(null, '3.0.0')
   }
   f.checkPython()
@@ -291,7 +291,7 @@ test('find python - no python, no python launcher, good guess', function (t) {
   f.execFile = function(program, args, opts, cb) {
     f.execFile = function(program, args, opts, cb) {
       t.ok(re.test(program))
-      t.ok(/import platform/.test(args[1]))
+      t.ok(/import sys/.test(args[1]))
       cb(null, '2.7.0')
     }
     t.strictEqual(program, 'py.exe')


### PR DESCRIPTION
Instead of parsing the string returned by `platform.python_version()`, it is easier to use the integers in `sys.version_info`. This avoids the need to pattern match and remove extra characters.

This is necessary because V8's infrastructure uses a Python that includes "chromium" in the version string, which would have needed to be filtered out too.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

