### PR TITLE
configure.js: escape '<'

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -273,9 +273,16 @@ function configure (gyp, argv, callback) {
         // Windows expects an absolute path
         output_dir = buildDir
       }
+      
+      var target_arch_gyp_variable = '<(target_arch)'
+      if (process.platform === 'win32' && python.toLowerCase().endsWith('.bat')) {
+        // Windows will interpret python as a batch file, so we need to escape the '<' character
+        target_arch_gyp_variable = '^^^<(target_arch)'
+      }
+      
       var nodeGypDir = path.resolve(__dirname, '..')
       var nodeLibFile = path.join(nodeDir,
-        !gyp.opts.nodedir ? '<(target_arch)' : '$(Configuration)',
+        !gyp.opts.nodedir ? target_arch_gyp_variable : '$(Configuration)',
         release.name + '.lib')
 
       argv.push('-I', addon_gypi)


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node-gyp/issues/1501

On windows invoking spawn on a batch file results in additional
argument processing. Special characters need to be escaped (twice).

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

Fixes issue where npm install fails if python is a batch file. This occurs because the batch file tries to interpret the '<' specially.

I tested this change on my windows machine (with and without python.bat in my path). I don't think this change will impact other platforms, as it only applies changes when the platform is win32, and when python is a batch file (which would have broken anyway).