### PR TITLE
lib: use print() for python version detection

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -437,7 +437,7 @@ PythonFinder.prototype = {
   },
 
   checkPythonVersion: function checkPythonVersion () {
-    var args = ['-c', 'import sys; print "%s.%s.%s" % sys.version_info[:3];']
+    var args = ['-c', 'import sys; print("%s.%s.%s" % sys.version_info[:3]);']
     var env = extend({}, this.env)
     env.TERM = 'dumb'
 


### PR DESCRIPTION
This fixes an issue introduced by commit https://github.com/nodejs/node-gyp/commit/da5db4059f9d3628a9fcace262c482d585460002 specifically this line https://github.com/nodejs/node-gyp/commit/da5db4059f9d3628a9fcace262c482d585460002#diff-7ad6309831a48a234780b58baca65710R440

Namely, the bit that checks for python versions was changed and went from supporting both python2 and python3 to supporting only python2.

I understand there are other open issues/PRs in regards to python3 but this change specifically is a regression that broke windows builders with python3 in the path as python.

