### PR TITLE
Update configure.js

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -83,7 +83,7 @@ function configure (gyp, argv, callback) {
     mkdirp(buildDir, function (err, isNew) {
       if (err) return callback(err)
       log.verbose('build dir', '"build" dir needed to be created?', isNew)
-      if (win && (!gyp.opts.msvs_version || gyp.opts.msvs_version === '2017')) {
+      if (win && (!gyp.opts.msvs_version && gyp.opts.msvs_version === '2017')) {
         findVS2017(function (err, vsSetup) {
           if (err) {
             log.verbose('Not using VS2017:', err.message)


### PR DESCRIPTION
If i set msvs_version to number other than 2017 in my npm config. It will try to use vs2017.

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

