### PR TITLE
Remove unused variable to fix linting on master

### DIFF
--- a/test/process-exec-sync.js
+++ b/test/process-exec-sync.js
@@ -10,7 +10,7 @@ if (!String.prototype.startsWith) {
 }
 
 function processExecSync(file, args, options) {
-  var child, error, timeout, tmpdir, command, quote
+  var child, error, timeout, tmpdir, command
   command = makeCommand(file, args)
 
   /*


### PR DESCRIPTION
Currently linting fails on master because of an unused variable. This seems to have been caused by two PRs, each was run in CI without including the other: https://github.com/nodejs/node-gyp/pull/1497 landed first, but https://github.com/nodejs/node-gyp/pull/1521 was based on an older commit.

cc @maclover7 @gibfahn @rvagg 

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
