### PR TITLE
win: fix delay-load hook for electron 4

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -1,6 +1,7 @@
 {
   'variables' : {
     'node_engine_include_dir%': 'deps/v8/include',
+    'node_host_binary%': 'node'
   },
   'target_defaults': {
     'type': 'loadable_module',
@@ -62,12 +63,13 @@
         # is named node.exe, iojs.exe, or something else.
         'conditions': [
           [ 'OS=="win"', {
+            'defines': [ 'HOST_BINARY=\"<(node_host_binary)<(EXECUTABLE_SUFFIX)\"', ],
             'sources': [
               '<(node_gyp_dir)/src/win_delay_load_hook.cc',
             ],
             'msvs_settings': {
               'VCLinkerTool': {
-                'DelayLoadDLLs': [ 'iojs.exe', 'node.exe' ],
+                'DelayLoadDLLs': [ '<(node_host_binary)<(EXECUTABLE_SUFFIX)' ],
                 # Don't print a linker warning when no imports from either .exe
                 # are used.
                 'AdditionalOptions': [ '/ignore:4199' ],

--- a/src/win_delay_load_hook.cc
+++ b/src/win_delay_load_hook.cc
@@ -1,10 +1,10 @@
 /*
  * When this file is linked to a DLL, it sets up a delay-load hook that
- * intervenes when the DLL is trying to load 'node.exe' or 'iojs.exe'
- * dynamically. Instead of trying to locate the .exe file it'll just return
- * a handle to the process image.
+ * intervenes when the DLL is trying to load the host executable
+ * dynamically. Instead of trying to locate the .exe file it'll just
+ * return a handle to the process image.
  *
- * This allows compiled addons to work when node.exe or iojs.exe is renamed.
+ * This allows compiled addons to work when the host executable is renamed.
  */
 
 #ifdef _MSC_VER
@@ -23,8 +23,7 @@ static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
   if (event != dliNotePreLoadLibrary)
     return NULL;
 
-  if (_stricmp(info->szDll, "iojs.exe") != 0 &&
-      _stricmp(info->szDll, "node.exe") != 0)
+  if (_stricmp(info->szDll, HOST_BINARY) != 0)
     return NULL;
 
   m = GetModuleHandle(NULL);


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
Electron, starting with major version 4, ships a `node.lib` import library referencing `electron.exe` (`node` is statically linked) so it is no longer possible to freely rename `electron.exe` and have native modules work out of the box.

Is `node-gyp` interested in a change like this? or is this be something that the Electron team should work around themselves?