### PR TITLE
Follow XDG OS conventions for storing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Some additional resources for addons and writing `gyp` files:
 | `--thin=yes`                      | Enable thin static libraries
 | `--arch=$arch`                    | Set target architecture (e.g. ia32)
 | `--tarball=$path`                 | Get headers from a local tarball
-| `--devdir=$path`                  | SDK download directory (default is `~/.node-gyp`)
+| `--devdir=$path`                  | SDK download directory (default is OS cache directory)
 | `--ensure`                        | Don't reinstall headers if already present
 | `--dist-url=$url`                 | Download header tarball from custom URL
 | `--proxy=$url`                    | Set HTTP proxy for downloading header tarball

--- a/bin/node-gyp.js
+++ b/bin/node-gyp.js
@@ -2,10 +2,10 @@
 
 process.title = 'node-gyp'
 
+var envPaths = require('env-paths')
 var gyp = require('../')
 var log = require('npmlog')
 var os = require('os')
-var path = require('path')
 
 /**
  * Process and execute the selected commands.
@@ -20,7 +20,7 @@ var homeDir = os.homedir()
 if (prog.devDir) {
   prog.devDir = prog.devDir.replace(/^~/, homeDir)
 } else if (homeDir) {
-  prog.devDir = path.resolve(homeDir, '.node-gyp')
+  prog.devDir = envPaths('node-gyp', { suffix: '' }).cache
 } else {
   throw new Error(
     "node-gyp requires that the user's home directory is specified " +

--- a/bin/node-gyp.js
+++ b/bin/node-gyp.js
@@ -4,7 +4,7 @@ process.title = 'node-gyp'
 
 var gyp = require('../')
 var log = require('npmlog')
-var osenv = require('osenv')
+var os = require('os')
 var path = require('path')
 
 /**
@@ -16,7 +16,7 @@ var completed = false
 prog.parseArgv(process.argv)
 prog.devDir = prog.opts.devdir
 
-var homeDir = osenv.home()
+var homeDir = os.homedir()
 if (prog.devDir) {
   prog.devDir = prog.devDir.replace(/^~/, homeDir)
 } else if (homeDir) {

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -8,7 +8,7 @@ module.exports.test = {
 var fs = require('graceful-fs')
   , path = require('path')
   , log = require('npmlog')
-  , osenv = require('osenv')
+  , os = require('os')
   , which = require('which')
   , semver = require('semver')
   , mkdirp = require('mkdirp')
@@ -46,7 +46,7 @@ function configure (gyp, argv, callback) {
 
     if (gyp.opts.nodedir) {
       // --nodedir was specified. use that for the dev files
-      nodeDir = gyp.opts.nodedir.replace(/^~/, osenv.home())
+      nodeDir = gyp.opts.nodedir.replace(/^~/, os.homedir())
 
       log.verbose('get node dir', 'compiling against specified --nodedir dev files: %s', nodeDir)
       createBuildDir()

--- a/lib/install.js
+++ b/lib/install.js
@@ -11,7 +11,7 @@ module.exports.test = {
 exports.usage = 'Install node development files for the specified node version.'
 
 var fs = require('graceful-fs')
-  , osenv = require('osenv')
+  , os = require('os')
   , tar = require('tar')
   , path = require('path')
   , crypto = require('crypto')
@@ -400,9 +400,9 @@ function install (fs, gyp, argv, callback) {
   function eaccesFallback (err) {
     var noretry = '--node_gyp_internal_noretry'
     if (-1 !== argv.indexOf(noretry)) return cb(err)
-    var tmpdir = osenv.tmpdir()
+    var tmpdir = os.tmpdir()
     gyp.devDir = path.resolve(tmpdir, '.node-gyp')
-    log.warn('EACCES', 'user "%s" does not have permission to access the dev dir "%s"', osenv.user(), devDir)
+    log.warn('EACCES', 'user "%s" does not have permission to access the dev dir "%s"', os.userInfo().username, devDir)
     log.warn('EACCES', 'attempting to reinstall using temporary dev dir "%s"', gyp.devDir)
     if (process.cwd() == tmpdir) {
       log.verbose('tmpdir == cwd', 'automatically will remove dev files after to save disk space')

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "mkdirp": "^0.5.0",
     "nopt": "2 || 3",
     "npmlog": "0 || 1 || 2 || 3 || 4",
-    "osenv": "0",
     "request": "^2.87.0",
     "rimraf": "2",
     "semver": "~5.3.0",
@@ -35,7 +34,7 @@
     "which": "1"
   },
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 6.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.5",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "bin": "./bin/node-gyp.js",
   "main": "./lib/node-gyp.js",
   "dependencies": {
+    "env-paths": "^1.0.0",
     "glob": "^7.0.3",
     "graceful-fs": "^4.1.2",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->
Closes #175 and #1124. Besides changes to follow the XDG standard I took the liberty to:
- Fix a small current linter issue.
- Replace the `osenv` dependency with native `os` to decrease the amount of dependencies.
- Add a package lock.

Since `os.userInfo()` requires Node.js 6 or higher and the default data location is changed this would be a major version bump. I did not go for moving the old locations or falling back because it adds unneeded complexity not worth the trouble.