### PR TITLE
Clean-up python detection

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,5 +1,6 @@
 ---
   env:
     node: true
+    es6: true
   rules:
     no-unused-vars: error

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,7 +1,7 @@
 {
   "asi": true,
   "laxcomma": true,
-  "es5": true,
+  "esversion": 6,
   "node": true,
   "strict": false
 }

--- a/bin/node-gyp.js
+++ b/bin/node-gyp.js
@@ -79,8 +79,12 @@ function run () {
   prog.commands[command.name](command.args, function (err) {
     if (err) {
       log.error(command.name + ' error')
-      log.error('stack', err.stack)
-      errorMessage()
+      if (err.noPython) {
+        log.error(err.message)
+      } else {
+        log.error('stack', err.stack)
+        errorMessage()
+      }
       log.error('not ok')
       return process.exit(1)
     }

--- a/bin/node-gyp.js
+++ b/bin/node-gyp.js
@@ -79,12 +79,8 @@ function run () {
   prog.commands[command.name](command.args, function (err) {
     if (err) {
       log.error(command.name + ' error')
-      if (err.noPython) {
-        log.error(err.message)
-      } else {
-        log.error('stack', err.stack)
-        errorMessage()
-      }
+      log.error('stack', err.stack)
+      errorMessage()
       log.error('not ok')
       return process.exit(1)
     }

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -9,7 +9,6 @@ var fs = require('graceful-fs')
   , path = require('path')
   , log = require('npmlog')
   , os = require('os')
-  , which = require('which')
   , semver = require('semver')
   , mkdirp = require('mkdirp')
   , cp = require('child_process')
@@ -24,14 +23,14 @@ if (win)
 exports.usage = 'Generates ' + (win ? 'MSVC project files' : 'a Makefile') + ' for the current module'
 
 function configure (gyp, argv, callback) {
-  var python = gyp.opts.python || process.env.PYTHON || 'python2'
+  var python
     , buildDir = path.resolve('build')
     , configNames = [ 'config.gypi', 'common.gypi' ]
     , configs = []
     , nodeDir
     , release = processRelease(argv, gyp, process.version, process.release)
 
-  findPython(python, function (err, found) {
+  findPython(gyp.opts.python, function (err, found) {
     if (err) {
       callback(err)
     } else {
@@ -363,48 +362,156 @@ function findAccessibleSync (logprefix, dir, candidates) {
   return undefined
 }
 
-function PythonFinder(python, callback) {
+function PythonFinder(configPython, callback) {
   this.callback = callback
-  this.python = python
+  this.configPython = configPython
+  this.errorLog = []
 }
 
 PythonFinder.prototype = {
-  checkPythonLauncherDepth: 0,
-  env: process.env,
-  execFile: cp.execFile,
-  log: log,
-  resolve: path.win32 && path.win32.resolve || path.resolve,
-  stat: fs.stat,
-  which: which,
-  win: win,
+  log: logWithPrefix(log, 'find Python'),
+  argsExecutable: ['-c', 'import sys; print(sys.executable);'],
+  argsVersion: ['-c', 'import sys; print("%s.%s.%s" % sys.version_info[:3]);'],
+  semverRange: '>=2.6.0 <3.0.0',
 
-  checkPython: function checkPython () {
-    this.log.verbose('check python',
-                     'checking for Python executable "%s" in the PATH',
-                     this.python)
-    this.which(this.python, function (err, execPath) {
-      if (err) {
-        this.log.verbose('`which` failed', this.python, err)
-        if (this.python === 'python2') {
-          this.python = 'python'
-          return this.checkPython()
-        }
-        if (this.win) {
-          this.checkPythonLauncher()
-        } else {
-          this.failNoPython()
-        }
-      } else {
-        this.log.verbose('`which` succeeded', this.python, execPath)
-        // Found the `python` executable, and from now on we use it explicitly.
-        // This solves #667 and #750 (`execFile` won't run batch files
-        // (*.cmd, and *.bat))
-        this.python = execPath
-        this.checkPythonVersion()
+  // These can be overridden for testing:
+  execFile: cp.execFile,
+  env: process.env,
+  win: win,
+  pyLauncher: 'py.exe',
+  defaultLocation: path.join(process.env.SystemDrive || 'C:', 'Python27',
+                             'python.exe'),
+
+  // Logs a message at verbose level, but also saves it to be displayed later
+  // at error level if an error occurs. This should help diagnose the problem.
+  addLog: function addLog(message) {
+    this.log.verbose(message)
+    this.errorLog.push(message)
+  },
+
+
+  // Find Python by trying a sequence of possibilities.
+  // Ignore errors, keep trying until Python is found.
+  findPython: function findPython() {
+    const SKIP=0, FAIL=1
+    const toCheck = [
+      {
+        before: () => {
+          if (!this.configPython) {
+            this.addLog(
+              'Python is not set from command line or npm configuration')
+            return SKIP
+          }
+          this.addLog('checking Python explicitly set from command line or ' +
+            'npm configuration')
+          this.addLog('- "--python=" or "npm config get python" is ' +
+            `"${this.configPython}"`)
+        },
+        check: this.checkCommand,
+        arg: this.configPython,
+      },
+      {
+        before: () => {
+          if (!this.env.PYTHON) {
+            this.addLog('Python is not set from environment variable PYTHON')
+            return SKIP
+          }
+          this.addLog(
+            'checking Python explicitly set from environment variable PYTHON')
+          this.addLog(`- process.env.PYTHON is "${this.env.PYTHON}"`)
+        },
+        check: this.checkCommand,
+        arg: this.env.PYTHON,
+      },
+      {
+        before: () => { this.addLog('checking if "python2" can be used') },
+        check: this.checkCommand,
+        arg: 'python2',
+      },
+      {
+        before: () => { this.addLog('checking if "python" can be used') },
+        check: this.checkCommand,
+        arg: 'python',
+      },
+      {
+        before: () => {
+          if (!this.win) {
+            // Everything after this is Windows specific
+            return FAIL
+          }
+          this.addLog(
+            'checking if the py launcher can be used to find Python 2')
+        },
+        check: this.checkPyLauncher,
+      },
+      {
+        before: () => {
+          this.addLog(
+            'checking if Python 2 is installed in the default location')
+        },
+        check: this.checkExecPath,
+        arg: this.defaultLocation,
+      },
+    ]
+
+    function runChecks(err) {
+      this.log.silly('runChecks: err = %j', err && err.stack || err)
+
+      const check = toCheck.shift()
+      if (!check) {
+        return this.fail()
       }
+
+      const before = check.before.apply(this)
+      if (before === SKIP) {
+        return runChecks.apply(this)
+      }
+      if (before === FAIL) {
+        return this.fail()
+      }
+
+      const args = [ runChecks.bind(this) ]
+      if (check.arg) {
+        args.unshift(check.arg)
+      }
+      check.check.apply(this, args)
+    }
+
+    runChecks.apply(this)
+  },
+
+
+  // Check if command is a valid Python to use.
+  // Will exit the Python finder on success.
+  // If on Windows, run in a CMD shell to support BAT/CMD launchers.
+  checkCommand: function checkCommand (command, errorCallback) {
+    var exec = command
+    var args = this.argsExecutable
+    var shell = false
+    if (this.win) {
+      // Arguments have to be manually quoted
+      exec = `"${exec}"`
+      args = args.map(a => `"${a}"`)
+      shell = true
+    }
+
+    this.log.verbose(`- executing "${command}" to get executable path`)
+    this.run(exec, args, shell, function (err, execPath) {
+      // Possible outcomes:
+      // - Error: not in PATH, not executable or execution fails
+      // - Gibberish: the next command to check version will fail
+      // - Absolute path to executable
+      if (err) {
+        this.addLog(`- "${command}" is not in PATH or produced an error`)
+        return errorCallback(err)
+      }
+      this.addLog(`- executable path is "${execPath}"`)
+      this.checkExecPath(execPath, errorCallback)
     }.bind(this))
   },
 
+  // Check if the py launcher can find a valid Python to use.
+  // Will exit the Python finder on success.
   // Distributions of Python on Windows by default install with the "py.exe"
   // Python launcher which is more likely to exist than the Python executable
   // being in the $PATH.
@@ -413,114 +520,137 @@ PythonFinder.prototype = {
   // the first command line argument. Since "py.exe -2" would be an invalid
   // executable for "execFile", we have to use the launcher to figure out
   // where the actual "python.exe" executable is located.
-  checkPythonLauncher: function checkPythonLauncher () {
-    this.checkPythonLauncherDepth += 1
-
+  checkPyLauncher: function checkPyLauncher (errorCallback) {
     this.log.verbose(
-        'could not find "' + this.python + '". checking python launcher')
-    var env = extend({}, this.env)
-    env.TERM = 'dumb'
-
-    var launcherArgs = ['-2', '-c', 'import sys; print sys.executable']
-    this.execFile('py.exe', launcherArgs, { env: env }, function (err, stdout) {
+      `- executing "${this.pyLauncher}" to get Python 2 executable path`)
+    this.run(this.pyLauncher, ['-2', ...this.argsExecutable], false,
+             function (err, execPath) {
+      // Possible outcomes: same as checkCommand
       if (err) {
-        this.guessPython()
-      } else {
-        this.python = stdout.trim()
-        this.log.verbose('check python launcher',
-                         'python executable found: %j',
-                         this.python)
-        this.checkPythonVersion()
+        this.addLog(
+          `- "${this.pyLauncher}" is not in PATH or produced an error`)
+        return errorCallback(err)
       }
-      this.checkPythonLauncherDepth -= 1
+      this.addLog(`- executable path is "${execPath}"`)
+      this.checkExecPath(execPath, errorCallback)
     }.bind(this))
   },
 
-  checkPythonVersion: function checkPythonVersion () {
-    var args = ['-c', 'import sys; print("%s.%s.%s" % sys.version_info[:3]);']
-    var env = extend({}, this.env)
-    env.TERM = 'dumb'
-
-    this.execFile(this.python, args, { env: env }, function (err, stdout) {
+  // Check if a Python executable is the correct version to use.
+  // Will exit the Python finder on success.
+  checkExecPath: function checkExecPath (execPath, errorCallback) {
+    this.log.verbose(`- executing "${execPath}" to get version`)
+    this.run(execPath, this.argsVersion, false, function (err, version) {
+      // Possible outcomes:
+      // - Error: executable can not be run (likely meaning the command wasn't
+      //   a Python executable and the previous command produced gibberish)
+      // - Gibberish: somehow the last command produced an executable path,
+      //   this will fail when verifying the version
+      // - Version of the Python executable
       if (err) {
-        return this.callback(err)
+        this.addLog(`- "${execPath}" could not be run`)
+        return errorCallback(err)
       }
-      this.log.verbose('check python version',
-                       '`%s -c "' + args[1] + '"` returned: %j',
-                       this.python, stdout)
-      var version = stdout.trim()
-      var range = semver.Range('>=2.6.0 <3.0.0')
+      this.addLog(`- version is "${version}"`)
+
+      const range = semver.Range(this.semverRange)
       var valid = false
       try {
         valid = range.test(version)
-      } catch (e) {
-        this.log.silly('range.test() error', e)
+      } catch (err) {
+        this.log.silly('range.test() threw:\n%s', err.stack)
+        this.addLog(`- "${execPath}" does not have a valid version`)
+        this.addLog('- is it a Python executable?')
+        return errorCallback(err)
       }
-      if (valid) {
-        this.callback(null, this.python)
-      } else if (this.win && this.checkPythonLauncherDepth === 0) {
-        this.checkPythonLauncher()
-      } else {
-        this.failPythonVersion(version)
+
+      if (!valid) {
+        this.addLog(`- version is ${version} - should be ${this.semverRange}`)
+        this.addLog('- THIS VERSION OF PYTHON IS NOT SUPPORTED')
+        return errorCallback(new Error(
+          `Found unsupported Python version ${version}`))
       }
+      this.succeed(execPath, version)
     }.bind(this))
   },
 
-  failNoPython: function failNoPython () {
-    const err = new Error(
-      '\n******************************************************************\n' +
-      `node-gyp can't use "${this.python}",\n` +
-      'It is recommended that you install python 2.7, set the PYTHON env,\n' +
-      'or use the --python switch to point to a Python >= v2.6.0 & < 3.0.0.\n' +
-      'For more information consult the documentation at:\n' +
-      'https://github.com/nodejs/node-gyp#installation\n' +
-      '***********************************************************************'
-    );
-    err.noPython = true;
-    this.callback(err)
-  },
+  // Run an executable or shell command, trimming the output.
+  run: function run(exec, args, shell, callback) {
+    var env = extend({}, this.env)
+    env.TERM = 'dumb'
+    const opts = { env: env, shell: shell }
 
-  failPythonVersion: function failPythonVersion (badVersion) {
-    const err = new Error(
-      '\n******************************************************************\n' +
-      `Python executable "${this.python}" is v${badVersion}\n` +
-      'this version is not supported by GYP and hence by node-gyp.\n' +
-      'It is recommended that you install python 2.7, set the PYTHON env,\n' +
-      'or use the --python switch to point to a Python >= v2.6.0 & < 3.0.0.\n' +
-      'For more information consult the documentation at:\n' +
-      'https://github.com/nodejs/node-gyp#installation\n' +
-      '***********************************************************************'
-    );
-    err.noPython = true;
-    this.callback(err)
-  },
-
-  // Called on Windows when "python" isn't available in the current $PATH.
-  // We are going to check if "%SystemDrive%\python27\python.exe" exists.
-  guessPython: function guessPython () {
-    this.log.verbose('could not find "' + this.python + '". guessing location')
-    var rootDir = this.env.SystemDrive || 'C:\\'
-    if (rootDir[rootDir.length - 1] !== '\\') {
-      rootDir += '\\'
+    this.log.silly('execFile: exec = %j', exec)
+    this.log.silly('execFile: args = %j', args)
+    this.log.silly('execFile: opts = %j', opts)
+    try {
+      this.execFile(exec, args, opts, execFileCallback.bind(this))
+    } catch (err) {
+      this.log.silly('execFile: threw:\n%s', err.stack)
+      return callback(err)
     }
-    var pythonPath = this.resolve(rootDir, 'Python27', 'python.exe')
-    this.log.verbose('ensuring that file exists:', pythonPath)
-    this.stat(pythonPath, function (err) {
+
+    function execFileCallback(err, stdout, stderr) {
+      this.log.silly('execFile result: err = %j', err && err.stack || err)
+      this.log.silly('execFile result: stdout = %j', stdout)
+      this.log.silly('execFile result: stderr = %j', stderr)
       if (err) {
-        if (err.code == 'ENOENT') {
-          this.failNoPython()
-        } else {
-          this.callback(err)
-        }
-        return
+        return callback(err)
       }
-      this.python = pythonPath
-      this.checkPythonVersion()
-    }.bind(this))
+      const execPath = stdout.trim()
+      callback(null, execPath)
+    }
+  },
+
+
+  succeed: function succeed(execPath, version) {
+    this.log.info(`using Python version ${version} found at "${execPath}"`)
+    process.nextTick(this.callback.bind(null, null, execPath))
+  },
+
+  fail: function fail() {
+    const errorLog = this.errorLog.join('\n')
+
+    const pathExample = this.win ? 'C:\\Path\\To\\python.exe' :
+                                   '/path/to/pythonexecutable'
+    // For Windows 80 col console, use up to the column before the one marked
+    // with X (total 79 chars including logger prefix, 58 chars usable here):
+    //                                                           X
+    const info = [
+      '**********************************************************',
+      'You need to install the latest version of Python 2.7.',
+      'Node-gyp should be able to find and use Python. If not,',
+      'you can try one of the following options:',
+      `- Use the switch --python="${pathExample}"`,
+      '  (accepted by both node-gyp and npm)',
+      '- Set the environment variable PYTHON',
+      '- Set the npm configuration variable python:',
+      `  npm config set python "${pathExample}"`,
+      'For more information consult the documentation at:',
+      'https://github.com/nodejs/node-gyp#installation',
+      '**********************************************************',
+    ].join('\n')
+
+    this.log.error(`\n${errorLog}\n\n${info}\n`)
+    process.nextTick(this.callback.bind(null, new Error (
+      'Could not find any Python 2 installation to use')))
   },
 }
 
-function findPython (python, callback) {
-  var finder = new PythonFinder(python, callback)
-  finder.checkPython()
+function findPython (configPython, callback) {
+  var finder = new PythonFinder(configPython, callback)
+  finder.findPython()
+}
+
+function logWithPrefix (log, prefix) {
+  function setPrefix(logFunction) {
+    return (...args) => logFunction.apply(null, [prefix, ...args])
+  }
+  return {
+    silly: setPrefix(log.silly),
+    verbose: setPrefix(log.verbose),
+    info: setPrefix(log.info),
+    warn: setPrefix(log.warn),
+    error: setPrefix(log.error),
+  }
 }

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -449,7 +449,7 @@ PythonFinder.prototype = {
                        '`%s -c "' + args[1] + '"` returned: %j',
                        this.python, stdout)
       var version = stdout.trim()
-      var range = semver.Range('>=2.5.0 <3.0.0')
+      var range = semver.Range('>=2.6.0 <3.0.0')
       var valid = false
       try {
         valid = range.test(version)
@@ -467,19 +467,32 @@ PythonFinder.prototype = {
   },
 
   failNoPython: function failNoPython () {
-    var errmsg =
-        'Can\'t find Python executable "' + this.python +
-        '", you can set the PYTHON env variable.'
-    this.callback(new Error(errmsg))
+    const err = new Error(
+      '\n******************************************************************\n' +
+      `node-gyp can't use "${this.python}",\n` +
+      'It is recommended that you install python 2.7, set the PYTHON env,\n' +
+      'or use the --python switch to point to a Python >= v2.6.0 & < 3.0.0.\n' +
+      'For more information consult the documentation at:\n' +
+      'https://github.com/nodejs/node-gyp#installation\n' +
+      '***********************************************************************'
+    );
+    err.noPython = true;
+    this.callback(err)
   },
 
   failPythonVersion: function failPythonVersion (badVersion) {
-    var errmsg =
-        'Python executable "' + this.python +
-        '" is v' + badVersion + ', which is not supported by gyp.\n' +
-        'You can pass the --python switch to point to ' +
-        'Python >= v2.5.0 & < 3.0.0.'
-    this.callback(new Error(errmsg))
+    const err = new Error(
+      '\n******************************************************************\n' +
+      `Python executable "${this.python}" is v${badVersion}\n` +
+      'this version is not supported by GYP and hence by node-gyp.\n' +
+      'It is recommended that you install python 2.7, set the PYTHON env,\n' +
+      'or use the --python switch to point to a Python >= v2.6.0 & < 3.0.0.\n' +
+      'For more information consult the documentation at:\n' +
+      'https://github.com/nodejs/node-gyp#installation\n' +
+      '***********************************************************************'
+    );
+    err.noPython = true;
+    this.callback(err)
   },
 
   // Called on Windows when "python" isn't available in the current $PATH.

--- a/test/test-find-python.js
+++ b/test/test-find-python.js
@@ -74,7 +74,7 @@ test('find python - python', function (t) {
 })
 
 test('find python - python too old', function (t) {
-  t.plan(4)
+  t.plan(5)
 
   var f = new TestPythonFinder('python', done)
   f.which = function(program, cb) {
@@ -89,12 +89,13 @@ test('find python - python too old', function (t) {
   f.checkPython()
 
   function done(err) {
-    t.ok(/is not supported by gyp/.test(err))
+    t.ok(/this version is not supported by GYP/.test(err))
+    t.ok(/For more information consult the documentation/.test(err))
   }
 })
 
 test('find python - python too new', function (t) {
-  t.plan(4)
+  t.plan(5)
 
   var f = new TestPythonFinder('python', done)
   f.which = function(program, cb) {
@@ -109,7 +110,8 @@ test('find python - python too new', function (t) {
   f.checkPython()
 
   function done(err) {
-    t.ok(/is not supported by gyp/.test(err))
+    t.ok(/this version is not supported by GYP/.test(err))
+    t.ok(/For more information consult the documentation/.test(err))
   }
 })
 
@@ -124,7 +126,7 @@ test('find python - no python', function (t) {
   f.checkPython()
 
   function done(err) {
-    t.ok(/Can't find Python executable/.test(err))
+    t.ok(/For more information consult the documentation/.test(err))
   }
 })
 
@@ -171,7 +173,7 @@ test('find python - no python2, no python, unix', function (t) {
   f.checkPython()
 
   function done(err) {
-    t.ok(/Can't find Python executable/.test(err))
+    t.ok(/For more information consult the documentation/.test(err))
   }
 })
 
@@ -242,7 +244,7 @@ test('find python - python 3, use python launcher', function (t) {
 
 test('find python - python 3, use python launcher, python 2 too old',
      function (t) {
-  t.plan(9)
+  t.plan(10)
 
   var f = new TestPythonFinder('python', done)
   f.checkedPythonLauncher = false
@@ -272,7 +274,8 @@ test('find python - python 3, use python launcher, python 2 too old',
   f.checkPython()
 
   function done(err) {
-    t.ok(/is not supported by gyp/.test(err))
+    t.ok(/this version is not supported by GYP/.test(err))
+    t.ok(/For more information consult the documentation/.test(err))
   }
 })
 
@@ -334,6 +337,6 @@ test('find python - no python, no python launcher, bad guess', function (t) {
   f.checkPython()
 
   function done(err) {
-    t.ok(/Can't find Python executable/.test(err))
+    t.ok(/For more information consult the documentation/.test(err))
   }
 })

--- a/test/test-find-python.js
+++ b/test/test-find-python.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var test = require('tape')
-var path = require('path')
 var configure = require('../lib/configure')
 var execFile = require('child_process').execFile
 var PythonFinder = configure.test.PythonFinder
@@ -9,7 +8,7 @@ var PythonFinder = configure.test.PythonFinder
 test('find python', function (t) {
   t.plan(4)
 
-  configure.test.findPython('python', function (err, found) {
+  configure.test.findPython(null, function (err, found) {
     t.strictEqual(err, null)
     var proc = execFile(found, ['-V'], function (err, stdout, stderr) {
       t.strictEqual(err, null)
@@ -23,183 +22,188 @@ test('find python', function (t) {
 
 function poison(object, property) {
   function fail() {
-    throw new Error('Property ' + property + ' should not have been accessed.')
+    console.error(Error(`Property ${property} should not have been accessed.`))
+    process.abort()
   }
   var descriptor = {
-    configurable: true,
+    configurable: false,
     enumerable: false,
-    writable: true,
-    getter: fail,
-    setter: fail,
+    get: fail,
+    set: fail,
   }
   Object.defineProperty(object, property, descriptor)
 }
 
-// Work around a v0.10.x CI issue where path.resolve() on UNIX systems prefixes
-// Windows paths with the current working directory.  v0.12 and up are free of
-// this issue because they use path.win32.resolve() which does the right thing.
-var resolve = path.win32 && path.win32.resolve || function() {
-  function rstrip(s) { return s.replace(/\\+$/, '') }
-  return [].slice.call(arguments).map(rstrip).join('\\')
-}
-
 function TestPythonFinder() { PythonFinder.apply(this, arguments) }
 TestPythonFinder.prototype = Object.create(PythonFinder.prototype)
-poison(TestPythonFinder.prototype, 'env')
-poison(TestPythonFinder.prototype, 'execFile')
-poison(TestPythonFinder.prototype, 'resolve')
-poison(TestPythonFinder.prototype, 'stat')
-poison(TestPythonFinder.prototype, 'which')
-poison(TestPythonFinder.prototype, 'win')
+// Silence npmlog - remove for debugging
+TestPythonFinder.prototype.log = {
+  silly: () => {},
+  verbose: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+}
 
 test('find python - python', function (t) {
-  t.plan(5)
+  t.plan(6)
 
   var f = new TestPythonFinder('python', done)
-  f.which = function(program, cb) {
-    t.strictEqual(program, 'python')
-    cb(null, program)
-  }
   f.execFile = function(program, args, opts, cb) {
-    t.strictEqual(program, 'python')
-    t.ok(/import sys/.test(args[1]))
-    cb(null, '2.7.0')
+    f.execFile = function(program, args, opts, cb) {
+      poison(f, 'execFile')
+      t.strictEqual(program, '/path/python')
+      t.ok(/sys\.version_info/.test(args[1]))
+      cb(null, '2.7.15')
+    }
+    t.strictEqual(program,
+                  process.platform === 'win32' ? '"python"' : 'python')
+    t.ok(/sys\.executable/.test(args[1]))
+    cb(null, '/path/python')
   }
-  f.checkPython()
+  f.findPython()
 
   function done(err, python) {
     t.strictEqual(err, null)
-    t.strictEqual(python, 'python')
+    t.strictEqual(python, '/path/python')
   }
 })
 
 test('find python - python too old', function (t) {
-  t.plan(5)
+  t.plan(2)
 
-  var f = new TestPythonFinder('python', done)
-  f.which = function(program, cb) {
-    t.strictEqual(program, 'python')
-    cb(null, program)
-  }
+  var f = new TestPythonFinder(null, done)
   f.execFile = function(program, args, opts, cb) {
-    t.strictEqual(program, 'python')
-    t.ok(/import sys/.test(args[1]))
-    cb(null, '2.3.4')
+    if (/sys\.executable/.test(args[args.length-1])) {
+      cb(null, '/path/python')
+    } else if (/sys\.version_info/.test(args[args.length-1])) {
+      cb(null, '2.3.4')
+    } else {
+      t.fail()
+    }
   }
-  f.checkPython()
+  f.findPython()
 
   function done(err) {
-    t.ok(/this version is not supported by GYP/.test(err))
-    t.ok(/For more information consult the documentation/.test(err))
+    t.ok(/Could not find any Python/.test(err))
+    t.ok(/not supported/i.test(f.errorLog))
   }
 })
 
 test('find python - python too new', function (t) {
-  t.plan(5)
+  t.plan(2)
 
-  var f = new TestPythonFinder('python', done)
-  f.which = function(program, cb) {
-    t.strictEqual(program, 'python')
-    cb(null, program)
-  }
+  var f = new TestPythonFinder(null, done)
   f.execFile = function(program, args, opts, cb) {
-    t.strictEqual(program, 'python')
-    t.ok(/import sys/.test(args[1]))
-    cb(null, '3.0.0')
+    if (/sys\.executable/.test(args[args.length-1])) {
+      cb(null, '/path/python')
+    } else if (/sys\.version_info/.test(args[args.length-1])) {
+      cb(null, '3.0.0')
+    } else {
+      t.fail()
+    }
   }
-  f.checkPython()
+  f.findPython()
 
   function done(err) {
-    t.ok(/this version is not supported by GYP/.test(err))
-    t.ok(/For more information consult the documentation/.test(err))
+    t.ok(/Could not find any Python/.test(err))
+    t.ok(/not supported/i.test(f.errorLog))
   }
 })
 
 test('find python - no python', function (t) {
   t.plan(2)
 
-  var f = new TestPythonFinder('python', done)
-  f.which = function(program, cb) {
-    t.strictEqual(program, 'python')
-    cb(new Error('not found'))
+  var f = new TestPythonFinder(null, done)
+  f.execFile = function(program, args, opts, cb) {
+    if (/sys\.executable/.test(args[args.length-1])) {
+      cb(new Error('not found'))
+    } else if (/sys\.version_info/.test(args[args.length-1])) {
+      cb(new Error('not a Python executable'))
+    } else {
+      t.fail()
+    }
   }
-  f.checkPython()
+  f.findPython()
 
   function done(err) {
-    t.ok(/For more information consult the documentation/.test(err))
+    t.ok(/Could not find any Python/.test(err))
+    t.ok(/not in PATH/.test(f.errorLog))
   }
 })
 
 test('find python - no python2', function (t) {
-  t.plan(6)
+  t.plan(2)
 
-  var f = new TestPythonFinder('python2', done)
-  f.which = function(program, cb) {
-    f.which = function(program, cb) {
-      t.strictEqual(program, 'python')
-      cb(null, program)
-    }
-    t.strictEqual(program, 'python2')
-    cb(new Error('not found'))
-  }
+  var f = new TestPythonFinder(null, done)
   f.execFile = function(program, args, opts, cb) {
-    t.strictEqual(program, 'python')
-    t.ok(/import sys/.test(args[1]))
-    cb(null, '2.7.0')
+    if (/sys\.executable/.test(args[args.length-1])) {
+      if (program == 'python2') {
+        cb(new Error('not found'))
+      } else {
+        cb(null, '/path/python')
+      }
+    } else if (/sys\.version_info/.test(args[args.length-1])) {
+      cb(null, '2.7.14')
+    } else {
+      t.fail()
+    }
   }
-  f.checkPython()
+  f.findPython()
 
   function done(err, python) {
     t.strictEqual(err, null)
-    t.strictEqual(python, 'python')
+    t.strictEqual(python, '/path/python')
   }
 })
 
 test('find python - no python2, no python, unix', function (t) {
-  t.plan(3)
+  t.plan(2)
 
-  var f = new TestPythonFinder('python2', done)
-  poison(f, 'checkPythonLauncher')
+  var f = new TestPythonFinder(null, done)
+  f.checkPyLauncher = t.fail
   f.win = false
 
-  f.which = function(program, cb) {
-    f.which = function(program, cb) {
-      t.strictEqual(program, 'python')
+  f.execFile = function(program, args, opts, cb) {
+    if (/sys\.executable/.test(args[args.length-1])) {
       cb(new Error('not found'))
+    } else {
+      t.fail()
     }
-    t.strictEqual(program, 'python2')
-    cb(new Error('not found'))
   }
-  f.checkPython()
+  f.findPython()
 
   function done(err) {
-    t.ok(/For more information consult the documentation/.test(err))
+    t.ok(/Could not find any Python/.test(err))
+    t.ok(/not in PATH/.test(f.errorLog))
   }
 })
 
 test('find python - no python, use python launcher', function (t) {
-  t.plan(8)
+  t.plan(4)
 
-  var f = new TestPythonFinder('python', done)
-  f.env = {}
+  var f = new TestPythonFinder(null, done)
   f.win = true
 
-  f.which = function(program, cb) {
-    t.strictEqual(program, 'python')
-    cb(new Error('not found'))
-  }
   f.execFile = function(program, args, opts, cb) {
-    f.execFile = function(program, args, opts, cb) {
-      t.strictEqual(program, 'Z:\\snake.exe')
-      t.ok(/import sys/.test(args[1]))
-      cb(null, '2.7.0')
+    if (program === 'py.exe') {
+      t.notEqual(args.indexOf('-2'), -1)
+      t.notEqual(args.indexOf('-c'), -1)
+      return cb(null, 'Z:\\snake.exe')
     }
-    t.strictEqual(program, 'py.exe')
-    t.notEqual(args.indexOf('-2'), -1)
-    t.notEqual(args.indexOf('-c'), -1)
-    cb(null, 'Z:\\snake.exe')
+    if (/sys\.executable/.test(args[args.length-1])) {
+      cb(new Error('not found'))
+    } else if (/sys\.version_info/.test(args[args.length-1])) {
+      if (program === 'Z:\\snake.exe') {
+        cb(null, '2.7.14')
+      } else {
+        t.fail()
+      }
+    } else {
+      t.fail()
+    }
   }
-  f.checkPython()
+  f.findPython()
 
   function done(err, python) {
     t.strictEqual(err, null)
@@ -208,33 +212,34 @@ test('find python - no python, use python launcher', function (t) {
 })
 
 test('find python - python 3, use python launcher', function (t) {
-  t.plan(10)
+  t.plan(4)
 
-  var f = new TestPythonFinder('python', done)
-  f.env = {}
+  var f = new TestPythonFinder(null, done)
   f.win = true
 
-  f.which = function(program, cb) {
-    t.strictEqual(program, 'python')
-    cb(null, program)
-  }
   f.execFile = function(program, args, opts, cb) {
-    f.execFile = function(program, args, opts, cb) {
+    if (program === 'py.exe') {
       f.execFile = function(program, args, opts, cb) {
-        t.strictEqual(program, 'Z:\\snake.exe')
-        t.ok(/import sys/.test(args[1]))
-        cb(null, '2.7.0')
+        poison(f, 'execFile')
+        if (/sys\.version_info/.test(args[args.length-1])) {
+          cb(null, '2.7.14')
+        } else {
+          t.fail()
+        }
       }
-      t.strictEqual(program, 'py.exe')
       t.notEqual(args.indexOf('-2'), -1)
       t.notEqual(args.indexOf('-c'), -1)
-      cb(null, 'Z:\\snake.exe')
+      return cb(null, 'Z:\\snake.exe')
     }
-    t.strictEqual(program, 'python')
-    t.ok(/import sys/.test(args[1]))
-    cb(null, '3.0.0')
+    if (/sys\.executable/.test(args[args.length-1])) {
+      cb(null, '/path/python')
+    } else if (/sys\.version_info/.test(args[args.length-1])) {
+      cb(null, '3.0.0')
+    } else {
+      t.fail()
+    }
   }
-  f.checkPython()
+  f.findPython()
 
   function done(err, python) {
     t.strictEqual(err, null)
@@ -244,99 +249,100 @@ test('find python - python 3, use python launcher', function (t) {
 
 test('find python - python 3, use python launcher, python 2 too old',
      function (t) {
-  t.plan(10)
+  t.plan(6)
 
-  var f = new TestPythonFinder('python', done)
-  f.checkedPythonLauncher = false
-  f.env = {}
+  var f = new TestPythonFinder(null, done)
   f.win = true
 
-  f.which = function(program, cb) {
-    t.strictEqual(program, 'python')
-    cb(null, program)
-  }
   f.execFile = function(program, args, opts, cb) {
-    f.execFile = function(program, args, opts, cb) {
+    if (program === 'py.exe') {
       f.execFile = function(program, args, opts, cb) {
-        t.strictEqual(program, 'Z:\\snake.exe')
-        t.ok(/import sys/.test(args[1]))
-        cb(null, '2.3.4')
+        if (/sys\.version_info/.test(args[args.length-1])) {
+          f.execFile = function(program, args, opts, cb) {
+            if (/sys\.version_info/.test(args[args.length-1])) {
+              poison(f, 'execFile')
+              t.strictEqual(program, f.defaultLocation)
+              cb(new Error('not found'))
+            } else {
+              t.fail()
+            }
+          }
+          t.strictEqual(program, 'Z:\\snake.exe')
+          cb(null, '2.3.4')
+        } else {
+          t.fail()
+        }
       }
-      t.strictEqual(program, 'py.exe')
       t.notEqual(args.indexOf('-2'), -1)
       t.notEqual(args.indexOf('-c'), -1)
-      cb(null, 'Z:\\snake.exe')
+      return cb(null, 'Z:\\snake.exe')
     }
-    t.strictEqual(program, 'python')
-    t.ok(/import sys/.test(args[1]))
-    cb(null, '3.0.0')
+    if (/sys\.executable/.test(args[args.length-1])) {
+      cb(null, '/path/python')
+    } else if (/sys\.version_info/.test(args[args.length-1])) {
+      cb(null, '3.0.0')
+    } else {
+      t.fail()
+    }
   }
-  f.checkPython()
+  f.findPython()
 
   function done(err) {
-    t.ok(/this version is not supported by GYP/.test(err))
-    t.ok(/For more information consult the documentation/.test(err))
+    t.ok(/Could not find any Python/.test(err))
+    t.ok(/not supported/i.test(f.errorLog))
   }
 })
 
 test('find python - no python, no python launcher, good guess', function (t) {
-  t.plan(6)
+  t.plan(4)
 
   var re = /C:[\\\/]Python27[\\\/]python[.]exe/
-  var f = new TestPythonFinder('python', done)
-  f.env = {}
+  var f = new TestPythonFinder(null, done)
   f.win = true
 
-  f.which = function(program, cb) {
-    t.strictEqual(program, 'python')
-    cb(new Error('not found'))
-  }
   f.execFile = function(program, args, opts, cb) {
-    f.execFile = function(program, args, opts, cb) {
-      t.ok(re.test(program))
-      t.ok(/import sys/.test(args[1]))
-      cb(null, '2.7.0')
+    if (program === 'py.exe') {
+      f.execFile = function(program, args, opts, cb) {
+        poison(f, 'execFile')
+        t.ok(re.test(program))
+        t.ok(/sys\.version_info/.test(args[args.length-1]))
+        cb(null, '2.7.14')
+      }
+      return cb(new Error('not found'))
     }
-    t.strictEqual(program, 'py.exe')
-    cb(new Error('not found'))
+    if (/sys\.executable/.test(args[args.length-1])) {
+      cb(new Error('not found'))
+    } else {
+      t.fail()
+    }
   }
-  f.resolve = resolve
-  f.stat = function(path, cb) {
-    t.ok(re.test(path))
-    cb(null, {})
-  }
-  f.checkPython()
+  f.findPython()
 
   function done(err, python) {
+    t.strictEqual(err, null)
     t.ok(re.test(python))
   }
 })
 
 test('find python - no python, no python launcher, bad guess', function (t) {
-  t.plan(4)
+  t.plan(2)
 
-  var f = new TestPythonFinder('python', done)
-  f.env = { SystemDrive: 'Z:\\' }
+  var f = new TestPythonFinder(null, done)
   f.win = true
 
-  f.which = function(program, cb) {
-    t.strictEqual(program, 'python')
-    cb(new Error('not found'))
-  }
   f.execFile = function(program, args, opts, cb) {
-    t.strictEqual(program, 'py.exe')
-    cb(new Error('not found'))
+    if (/sys\.executable/.test(args[args.length-1])) {
+      cb(new Error('not found'))
+    } else if (/sys\.version_info/.test(args[args.length-1])) {
+      cb(new Error('not a Python executable'))
+    } else {
+      t.fail()
+    }
   }
-  f.resolve = resolve
-  f.stat = function(path, cb) {
-    t.ok(/Z:[\\\/]Python27[\\\/]python.exe/.test(path))
-    var err = new Error('not found')
-    err.code = 'ENOENT'
-    cb(err)
-  }
-  f.checkPython()
+  f.findPython()
 
   function done(err) {
-    t.ok(/For more information consult the documentation/.test(err))
+    t.ok(/Could not find any Python/.test(err))
+    t.ok(/not in PATH/.test(f.errorLog))
   }
 })


### PR DESCRIPTION
This changes Python detection to make it try a sequence of possibilities. Every possibility will be tried discarding errors along the way, only giving up when there's nothing else to try. This should make Python detection more robust.

This stops using `which` to find the executable, instead relying on the mechanism that was already used for the py launcher: run Python and print `sys.executable`. This means that BAT files can be used, making node-gyp work when depot_tools is the first thing in the path.

![image](https://user-images.githubusercontent.com/134460/47537048-86fcd280-d8bb-11e8-80a0-1b8d95ddf018.png)

@refack I based this on your commit from https://github.com/nodejs/node-gyp/pull/1269 . Ended up changing much of it, but I used some of the info text so I include your commit for proper credit. Let me know if I should remove it or if you want to land https://github.com/nodejs/node-gyp/pull/1269 separately. I rebased it on master and included `es6: true` in `.eslintrc` to make linting work (since ES6 was already there for `.jshintrc`).

Error output when no Python is installed:
![image](https://user-images.githubusercontent.com/134460/47536756-de01a800-d8b9-11e8-84d0-3c71cae4744c.png)


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
