### PR TITLE
Raise the lower limit on Python version to 2.7.9

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -372,7 +372,7 @@ PythonFinder.prototype = {
   log: logWithPrefix(log, 'find Python'),
   argsExecutable: ['-c', 'import sys; print(sys.executable);'],
   argsVersion: ['-c', 'import sys; print("%s.%s.%s" % sys.version_info[:3]);'],
-  semverRange: '>=2.6.0 <3.0.0',
+  semverRange: '>=2.7.9 <3.0.0',
 
   // These can be overridden for testing:
   execFile: cp.execFile,


### PR DESCRIPTION
Python 2.6 end of life was more than five years ago and Python < 2.7.9 have ___known security flaws___ and therefore should not be trusted.

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

