### PR TITLE
win: use msbuild from the configure stage

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -95,6 +95,13 @@ function build (gyp, argv, callback) {
    */
 
   function doWhich () {
+    // On Windows use msbuild provided by node-gyp configure
+    if (win && config.variables.msbuild_path) {
+      command = config.variables.msbuild_path
+      log.verbose('using MSBuild:', command)
+      doBuild()
+      return
+    }
     // First make sure we have the build command in the PATH
     which(command, function (err, execPath) {
       if (err) {
@@ -117,13 +124,6 @@ function build (gyp, argv, callback) {
    */
 
   function findMsbuild () {
-    if (config.variables.msbuild_path) {
-      command = config.variables.msbuild_path
-      log.verbose('using MSBuild:', command)
-      doBuild()
-      return
-    }
-
     log.verbose('could not find "msbuild.exe" in PATH - finding location in registry')
     var notfoundErr = 'Can\'t find "msbuild.exe". Do you have Microsoft Visual Studio C++ 2008+ installed?'
     var cmd = 'reg query "HKLM\\Software\\Microsoft\\MSBuild\\ToolsVersions" /s'


### PR DESCRIPTION


<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
If node-gyp configure has set up MSBuild location use it instead the one that happens to be first on the PATH.

Fixes: https://github.com/nodejs/node-gyp/issues/1653
