### PR TITLE
src: add arm64 to Windows native module compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Install tools and configuration manually:
 
    If the above steps didn't work for you, please visit [Microsoft's Node.js Guidelines for Windows](https://github.com/Microsoft/nodejs-guidelines/blob/master/windows-environment.md#compiling-native-addon-modules) for additional tips.
 
+   To target native ARM64 Node.js on Windows 10 on ARM, add the components "Visual C++ compilers and libraries for ARM64" and "Visual C++ ATL for ARM64".
+
 ### Configuring Python Dependency
 
 If you have multiple Python versions installed, you can identify which Python

--- a/lib/build.js
+++ b/lib/build.js
@@ -200,9 +200,13 @@ function build (gyp, argv, callback) {
 
     // Specify the build type, Release by default
     if (win) {
+      // Convert .gypi config target_arch to MSBuild /Platform
+      // Since there are many ways to state '32-bit Intel', default to it.
+      // N.B. msbuild's Condition string equality tests are case-insensitive.
       var archLower = arch.toLowerCase()
       var p = archLower === 'x64' ? 'x64' :
-              (archLower === 'arm' ? 'ARM' : 'Win32')
+              (archLower === 'arm' ? 'ARM' :
+              (archLower === 'arm64' ? 'ARM64' : 'Win32'))
       argv.push('/p:Configuration=' + buildType + ';Platform=' + p)
       if (jobs) {
         var j = parseInt(jobs, 10)


### PR DESCRIPTION
##### Checklist
- [ ] `npm install && npm test` passes
    - I'm still working on how to bootstrap NPM on a new architecture.
- [ ] tests are included
    - I don't see any relevant tests to update.
- [x] documentation is changed or added
- [x] commit message follows guidelines

##### Description
Node.js ships with a number of native modules used for testing. This change is the minimum required for those modules to node-gyp to be able to build them. All Node.js unit tests pass.

