### PR TITLE
configure: Enable ARM64 single-toolchain build on Windows

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -134,6 +134,9 @@ function configure (gyp, argv, callback) {
 
     // set the target_arch variable
     variables.target_arch = gyp.opts.arch || process.arch || 'ia32'
+    if (variables.target_arch == 'arm64') {
+      defaults['msvs_configuration_platform'] = 'ARM64'
+    }
 
     // set the node development directory
     variables.nodedir = nodeDir


### PR DESCRIPTION
Adds ARM64 targets to generated .sln/.vcxproj files for cross-compiling
node modules to Windows on Arm, 64-bit. To use, run
`set npm_config_arch=arm64` on the command prompt before `npm install`.

Change-Id: Idbe401437e58d13c815c02f7b5b45247daabbe65

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
This change is intent to enable cross-compiling for ARM64 Windows.

