### PR TITLE
Add arm64 asm

### DIFF
--- a/gyp/pylib/gyp/MSVSSettings.py
+++ b/gyp/pylib/gyp/MSVSSettings.py
@@ -543,6 +543,7 @@ _rc = _Tool('VCResourceCompilerTool', 'ResourceCompile')
 _lib = _Tool('VCLibrarianTool', 'Lib')
 _manifest = _Tool('VCManifestTool', 'Manifest')
 _masm = _Tool('MASM', 'MASM')
+_armasm = _Tool('ARMASM', 'ARMASM')
 
 
 _AddTool(_compile)
@@ -552,6 +553,7 @@ _AddTool(_rc)
 _AddTool(_lib)
 _AddTool(_manifest)
 _AddTool(_masm)
+_AddTool(_armasm)
 # Add sections only found in the MSBuild settings.
 _msbuild_validators[''] = {}
 _msbuild_validators['ProjectReference'] = {}

--- a/gyp/pylib/gyp/generator/msvs.py
+++ b/gyp/pylib/gyp/generator/msvs.py
@@ -2037,7 +2037,8 @@ def GenerateOutput(target_list, target_dicts, data, params):
 
 
 def _GenerateMSBuildFiltersFile(filters_path, source_files,
-                                rule_dependencies, extension_to_rule_name):
+                                rule_dependencies, extension_to_rule_name,
+                                platforms):
   """Generate the filters file.
 
   This file is used by Visual Studio to organize the presentation of source
@@ -2051,7 +2052,8 @@ def _GenerateMSBuildFiltersFile(filters_path, source_files,
   filter_group = []
   source_group = []
   _AppendFiltersForMSBuild('', source_files, rule_dependencies,
-                           extension_to_rule_name, filter_group, source_group)
+                           extension_to_rule_name, platforms,
+                           filter_group, source_group)
   if filter_group:
     content = ['Project',
                {'ToolsVersion': '4.0',
@@ -2067,7 +2069,7 @@ def _GenerateMSBuildFiltersFile(filters_path, source_files,
 
 
 def _AppendFiltersForMSBuild(parent_filter_name, sources, rule_dependencies,
-                             extension_to_rule_name,
+                             extension_to_rule_name, platforms,
                              filter_group, source_group):
   """Creates the list of filters and sources to be added in the filter file.
 
@@ -2093,11 +2095,12 @@ def _AppendFiltersForMSBuild(parent_filter_name, sources, rule_dependencies,
       # Recurse and add its dependents.
       _AppendFiltersForMSBuild(filter_name, source.contents,
                                rule_dependencies, extension_to_rule_name,
-                               filter_group, source_group)
+                               platforms, filter_group, source_group)
     else:
       # It's a source.  Create a source entry.
       _, element = _MapFileToMsBuildSourceType(source, rule_dependencies,
-                                               extension_to_rule_name)
+                                               extension_to_rule_name,
+                                               platforms)
       source_entry = [element, {'Include': source}]
       # Specify the filter it is part of, if any.
       if parent_filter_name:
@@ -2106,7 +2109,7 @@ def _AppendFiltersForMSBuild(parent_filter_name, sources, rule_dependencies,
 
 
 def _MapFileToMsBuildSourceType(source, rule_dependencies,
-                                extension_to_rule_name):
+                                extension_to_rule_name, platforms):
   """Returns the group and element type of the source file.
 
   Arguments:
@@ -2132,6 +2135,9 @@ def _MapFileToMsBuildSourceType(source, rule_dependencies,
   elif ext == '.asm':
     group = 'masm'
     element = 'MASM'
+    for platform in platforms:
+      if platform.lower() in ['arm', 'arm64']:
+       element = 'MARMASM'
   elif ext == '.idl':
     group = 'midl'
     element = 'Midl'
@@ -3225,7 +3231,8 @@ def _AddSources2(spec, sources, exclusions, grouped_sources,
                 detail.append(['ForcedIncludeFiles', ''])
 
         group, element = _MapFileToMsBuildSourceType(source, rule_dependencies,
-                                                     extension_to_rule_name)
+                                                     extension_to_rule_name,
+                                                     _GetUniquePlatforms(spec))
         grouped_sources[group].append([element, {'Include': source}] + detail)
 
 
@@ -3308,7 +3315,7 @@ def _GenerateMSBuildProject(project, options, version, generator_flags):
 
   _GenerateMSBuildFiltersFile(project.path + '.filters', sources,
                               rule_dependencies,
-                              extension_to_rule_name)
+                              extension_to_rule_name, _GetUniquePlatforms(spec))
   missing_sources = _VerifySourcesExist(sources, project_dir)
 
   for configuration in configurations.itervalues():
@@ -3328,6 +3335,12 @@ def _GenerateMSBuildProject(project, options, version, generator_flags):
   import_masm_targets_section = [
       ['Import',
         {'Project': r'$(VCTargetsPath)\BuildCustomizations\masm.targets'}]]
+  import_marmasm_props_section = [
+      ['Import',
+        {'Project': r'$(VCTargetsPath)\BuildCustomizations\marmasm.props'}]]
+  import_marmasm_targets_section = [
+      ['Import',
+        {'Project': r'$(VCTargetsPath)\BuildCustomizations\marmasm.targets'}]]
   macro_section = [['PropertyGroup', {'Label': 'UserMacros'}]]
 
   content = [
@@ -3347,6 +3360,7 @@ def _GenerateMSBuildProject(project, options, version, generator_flags):
    content += _GetMSBuildLocalProperties(project.msbuild_toolset)
   content += import_cpp_props_section
   content += import_masm_props_section
+  content += import_marmasm_props_section
   content += _GetMSBuildExtensions(props_files_of_rules)
   content += _GetMSBuildPropertySheets(configurations)
   content += macro_section
@@ -3359,6 +3373,7 @@ def _GenerateMSBuildProject(project, options, version, generator_flags):
   content += _GetMSBuildProjectReferences(project)
   content += import_cpp_targets_section
   content += import_masm_targets_section
+  content += import_marmasm_targets_section
   content += _GetMSBuildExtensionTargets(targets_files_of_rules)
 
   if spec.get('msvs_external_builder'):


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- tests are included <!-- Bug fixes and new features should include tests -->
    - No GYP tests seem to be in node-gyp
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change

This is a port of https://github.com/nodejs/node/pull/26020 (see also https://github.com/refack/GYP/pull/23) to the `node-gyp` copy of GYP. It is important when building Node.js itself (V8 has ASM bits; hence the other PR) and when building native modules with ASM (fairly rare, as I understand it).