### PR TITLE
test: add duplicate symbol test

### DIFF
--- a/test/node_modules/duplicate_symbols/binding.cc
+++ b/test/node_modules/duplicate_symbols/binding.cc
@@ -2,9 +2,9 @@
 #include "common.h"
 
 void Init(v8::Local<v8::Object> exports) {
-  exports->Set(Nan::New("pointerCheck").ToLocalChecked(),
-               Nan::New<v8::FunctionTemplate>(Something::PointerCheck)
-      ->GetFunction());
+  Nan::Set(exports, Nan::New("pointerCheck").ToLocalChecked(),
+    Nan::GetFunction(
+      Nan::New<v8::FunctionTemplate>(Something::PointerCheck)).ToLocalChecked());
 }
 
 NODE_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/node_modules/duplicate_symbols/package.json
+++ b/test/node_modules/duplicate_symbols/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "bindings": "~1.2.1",
-    "nan": "^2.0.0"
+    "nan": "^2.14.0"
   },
   "scripts": {
     "test": "node index.js"


### PR DESCRIPTION
On OSX symbols are exported by default, and they overlap if two
different copies of the same symbol appear in a process. This change
ensures that, on OSX, symbols are hidden by default.

Re: https://github.com/nodejs/node-addon-api/pull/456

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

