### PR TITLE
test: fix addon test for Node.js 12 and V8 7.4

### DIFF
--- a/test/node_modules/hello_world/hello.cc
+++ b/test/node_modules/hello_world/hello.cc
@@ -1,12 +1,11 @@
 #include <nan.h>
 
-void Method(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+NAN_METHOD(Method) {
   info.GetReturnValue().Set(Nan::New("world").ToLocalChecked());
 }
 
-void Init(v8::Local<v8::Object> exports) {
-  exports->Set(Nan::New("hello").ToLocalChecked(),
-               Nan::New<v8::FunctionTemplate>(Method)->GetFunction());
+NAN_MODULE_INIT(Init) {
+  Nan::SetMethod(target, "hello", Method);
 }
 
 NODE_MODULE(hello, Init)


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

V8 7.4 removes some API functions. Replace those with their NAN
counterparts.

Example current failure: https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/1781/nodes=debian9-64/testReport/junit/(root)/citgm/node_gyp_v3_8_0/

```console
      undefinedadded 121 packages from 83 contributors and audited 228 packages in 5.603s
 found 0 vulnerabilities
 > node-gyp@3.8.0 test /home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp
 > tape test/test-*
 TAP version 13
 # build simple addon
 not ok 1 should be equal
   ---
     operator: equal
     expected: |-
       null
     actual: |-
       { [Error: Command failed: /home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/smoker/bin/node /home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/bin/node-gyp.js rebuild -C /home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/test/node_modules/hello_world --loglevel=verbose
 gyp info it worked if it ends with ok
 gyp verb cli [ '/home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/smoker/bin/node',
 gyp verb cli   '/home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/bin/node-gyp.js',
 gyp verb cli   'rebuild',
 gyp verb cli   '-C',
 gyp verb cli   '/home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/test/node_modules/hello_world',
 gyp verb cli   '--loglevel=verbose' ]
 gyp info using node-gyp@3.8.0
 gyp info using node@12.0.0-pre | linux | x64
 gyp info chdir /home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/test/node_modules/hello_world
 gyp verb command rebuild []
 gyp verb command clean []
 gyp verb clean removing "build" directory
 gyp verb command configure []
 gyp verb check python checking for Python executable "python2" in the PATH
 gyp verb `which` succeeded python2 /usr/bin/python2
 gyp verb check python version `/usr/bin/python2 -c "import sys; print "2.7.13
 gyp verb check python version .%s.%s" % sys.version_info[:3];"` returned: %j
 gyp verb get node dir compiling against specified --nodedir dev files: /home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/node
 gyp verb build dir attempting to create "build" dir: /home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/test/node_modules/hello_world/build
 gyp verb build dir "build" dir needed to be created? /home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/test/node_modules/hello_world/build
 gyp verb build/config.gypi creating config file
 gyp verb build/config.gypi writing out config file: /home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/test/node_modules/hello_world/build/config.gypi
 gyp verb config.gypi checking for gypi file: /home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/test/node_modules/hello_world/config.gypi
 gyp verb common.gypi checking for gypi file: /home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/test/node_modules/hello_world/common.gypi
 gyp verb gyp gyp format was not specified; forcing "make"
 gyp info spawn /usr/bin/python2
 gyp info spawn args [ '/home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/gyp/gyp_main.py',
 gyp info spawn args   'binding.gyp',
 gyp info spawn args   '-f',
 gyp info spawn args   'make',
 gyp info spawn args   '-I',
 gyp info spawn args   '/home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/test/node_modules/hello_world/build/config.gypi',
 gyp info spawn args   '-I',
 gyp info spawn args   '/home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/addon.gypi',
 gyp info spawn args   '-I',
 gyp info spawn args   '/home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/node/common.gypi',
 gyp info spawn args   '-Dlibrary=shared_library',
 gyp info spawn args   '-Dvisibility=default',
 gyp info spawn args   '-Dnode_root_dir=/home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/node',
 gyp info spawn args   '-Dnode_gyp_dir=/home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp',
 gyp info spawn args   '-Dnode_lib_file=/home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/node/$(Configuration)/node.lib',
 gyp info spawn args   '-Dmodule_root_dir=/home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/test/node_modules/hello_world',
 gyp info spawn args   '-Dnode_engine=v8',
 gyp info spawn args   '--depth=.',
 gyp info spawn args   '--no-parallel',
 gyp info spawn args   '--generator-output',
 gyp info spawn args   'build',
 gyp info spawn args   '-Goutput_dir=.' ]
 gyp verb command build []
 gyp verb build type Release
 gyp verb architecture x64
 gyp verb node dev dir /home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/node
 gyp verb `which` succeeded for `make` /usr/bin/make
 gyp info spawn make
 gyp info spawn args [ 'V=1', 'BUILDTYPE=Release', '-C', 'build', '--jobs', 2 ]
 ../hello.cc: In function 'void Init(v8::Local<v8::Object>)':
 ../hello.cc:9:68: error: no matching function for call to 'v8::FunctionTemplate::GetFunction()'
                 Nan::New<v8::FunctionTemplate>(Method)->GetFunction());
                                                                     ^
 In file included from /home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/node/src/node.h:63:0,
                  from ../../../../node_modules/nan/nan.h:53,
                  from ../hello.cc:1:
 /home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/node/deps/v8/include/v8.h:5950:46: note: candidate: v8::MaybeLocal<v8::Function> v8::FunctionTemplate::GetFunction(v8::Local<v8::Context>)
    V8_WARN_UNUSED_RESULT MaybeLocal<Function> GetFunction(
                                               ^~~~~~~~~~~
 /home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/node/deps/v8/include/v8.h:5950:46: note:   candidate expects 1 argument, 0 provided
 make: *** [Release/obj.target/hello/hello.o] Error 1
 gyp ERR! build error 
 gyp ERR! stack Error: `make` failed with exit code: 2
 gyp ERR! stack     at ChildProcess.onExit (/home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/lib/build.js:262:23)
 gyp ERR! stack     at ChildProcess.emit (events.js:194:13)
 gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:254:12)
 gyp ERR! System Linux 4.9.0-6-amd64
 gyp ERR! command "/home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/smoker/bin/node" "/home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/bin/node-gyp.js" "rebuild" "-C" "/home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/test/node_modules/hello_world" "--loglevel=verbose"
 gyp ERR! cwd /home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/test/node_modules/hello_world
 gyp ERR! node -v v12.0.0-pre
 gyp ERR! node-gyp -v v3.8.0
 gyp ERR! not ok 
 ] killed: false, code: 1, signal: null, cmd: '/home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/smoker/bin/node /home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/bin/node-gyp.js rebuild -C /home/iojs/build/workspace/citgm-smoker/nodes/debian9-64/citgm_tmp/98118c6b-7f61-4357-abfd-24950d89737d/node-gyp/test/node_modules/hello_world --loglevel=verbose' }
     at: maybeClose (internal/child_process.js:1000:16)
   ...
```
