### PR TITLE
gyp: fix IPHONEOS_DEPLOYMENT_TARGET

### DIFF
--- a/gyp/pylib/gyp/xcode_emulation.py
+++ b/gyp/pylib/gyp/xcode_emulation.py
@@ -458,7 +458,6 @@ class XcodeSettings(object):
     return XcodeSettings._sdk_path_cache[sdk_root]
 
   def _AppendPlatformVersionMinFlags(self, lst):
-    self._Appendf(lst, 'MACOSX_DEPLOYMENT_TARGET', '-mmacosx-version-min=%s')
     if 'IPHONEOS_DEPLOYMENT_TARGET' in self._Settings():
       # TODO: Implement this better?
       sdk_path_basename = os.path.basename(self._SdkPath())
@@ -468,6 +467,8 @@ class XcodeSettings(object):
       else:
         self._Appendf(lst, 'IPHONEOS_DEPLOYMENT_TARGET',
                       '-miphoneos-version-min=%s')
+    else:
+      self._Appendf(lst, 'MACOSX_DEPLOYMENT_TARGET', '-mmacosx-version-min=%s')
 
   def GetCflags(self, configname, arch=None):
     """Returns flags that need to be added to .c, .cc, .m, and .mm


### PR DESCRIPTION
If IPHONEOS_DEPLOYMENT_TARGET is specified, don't append MACOSX_DEPLOYMENT_TARGET flags.

When building for iOS, it's an error to have both `-mmacosx-version-min=...` and `-miphoneos-version-min=...` compiler flags.

This PR ensures that if IPHONEOS_DEPLOYMENT_TARGET is specified, no `-mmacosx-version-min=...` flags will be emitted.

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

