### PR TITLE
msvs: Add support for Windows on Arm

### DIFF
--- a/gyp/pylib/gyp/MSVSSettings.py
+++ b/gyp/pylib/gyp/MSVSSettings.py
@@ -973,7 +973,9 @@ _Same(_midl, 'TargetEnvironment',
       _Enumeration(['NotSet',
                     'Win32',  # /env win32
                     'Itanium',  # /env ia64
-                    'X64']))  # /env x64
+                    'X64',  # /env x64
+                    'ARM64',  # /env arm64
+                    ]))
 _Same(_midl, 'EnableErrorChecks',
       _Enumeration(['EnableCustom',
                     'None',  # /error none

--- a/gyp/pylib/gyp/generator/msvs.py
+++ b/gyp/pylib/gyp/generator/msvs.py
@@ -1887,6 +1887,8 @@ def _InitNinjaFlavor(params, target_list, target_dicts):
       configuration = '$(Configuration)'
       if params.get('target_arch') == 'x64':
         configuration += '_x64'
+      if params.get('target_arch') == 'arm64':
+        configuration += '_arm64'
       spec['msvs_external_builder_out_dir'] = os.path.join(
           gyp.common.RelativePath(params['options'].toplevel_dir, gyp_dir),
           ninja_generator.ComputeOutputDir(params),

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -134,6 +134,9 @@ function configure (gyp, argv, callback) {
 
     // set the target_arch variable
     variables.target_arch = gyp.opts.arch || process.arch || 'ia32'
+    if (variables.target_arch == 'arm64') {
+      defaults['msvs_configuration_platform'] = 'ARM64'
+    }
 
     // set the node development directory
     variables.nodedir = nodeDir


### PR DESCRIPTION
Cherry-pick of https://github.com/refack/GYP/pull/33, supersedes https://github.com/nodejs/node-gyp/pull/1678 until GYP3 is merged.

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

Cherry-pick of https://github.com/refack/GYP/pull/33 which enables cross-compilation of modules for Windows on Arm in node-gyp 5.x.x. This is useful for electron applications. 