### PR TITLE
Add support for HTTPS_PROXY

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Some additional resources for addons and writing `gyp` files:
 | `--devdir=$path`                  | SDK download directory (default is OS cache directory)
 | `--ensure`                        | Don't reinstall headers if already present
 | `--dist-url=$url`                 | Download header tarball from custom URL
-| `--proxy=$url`                    | Set HTTP proxy for downloading header tarball
+| `--proxy=$url`                    | Set HTTP(S) proxy for downloading header tarball
 | `--cafile=$cafile`                | Override default CA chain (to download tarball)
 | `--nodedir=$path`                 | Set the path to the node source code
 | `--python=$path`                  | Set path to the Python 2 binary

--- a/lib/install.js
+++ b/lib/install.js
@@ -14,6 +14,7 @@ var fs = require('graceful-fs')
   , os = require('os')
   , tar = require('tar')
   , path = require('path')
+  , url = require('url')
   , crypto = require('crypto')
   , log = require('npmlog')
   , semver = require('semver')
@@ -413,11 +414,11 @@ function install (fs, gyp, argv, callback) {
 
 }
 
-function download (gyp, env, url) {
-  log.http('GET', url)
+function download (gyp, env, uri) {
+  log.http('GET', uri)
 
   var requestOpts = {
-      uri: url
+      uri
     , headers: {
         'User-Agent': 'node-gyp v' + gyp.version + ' (node ' + process.version + ')'
       }
@@ -429,10 +430,22 @@ function download (gyp, env, url) {
   }
 
   // basic support for a proxy server
-  var proxyUrl = gyp.opts.proxy
-              || env.http_proxy
-              || env.HTTP_PROXY
-              || env.npm_config_proxy
+  var proxyUrl = gyp.opts.proxy;
+
+  // prefer HTTPS proxy if contacting an HTTPS uri
+  if (!proxyUrl && url.parse(uri).protocol === 'https:') {
+    proxyUrl = env.https_proxy
+            || env.HTTPS_PROXY
+            || env.npm_config_https_proxy
+  }
+
+  // but fallback to an HTTP proxy as needed
+  if (!proxyUrl) {
+    proxyUrl = env.http_proxy
+            || env.HTTP_PROXY
+            || env.npm_config_proxy
+  }
+
   if (proxyUrl) {
     if (/^https?:\/\//i.test(proxyUrl)) {
       log.verbose('download', 'using proxy url: "%s"', proxyUrl)


### PR DESCRIPTION
##### Checklist

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change

See #1749. If the requested URI is HTTPS, attempt to use an HTTPS proxy, if configured, and fallback to the HTTP proxy if one isn't found. This change should be backwards-compatible except in the case where someone is using a broken HTTPS proxy (in which case I would argue that that isn't node-gyp's problem anyway).

If desired, I can remove the `url` require and substring the uri to detect if it's HTTPS.

No tests were added because there aren't any existing proxy tests.