### PR TITLE
zos: update compiler options and default compiler

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -106,7 +106,14 @@
         'cflags': [
           '-q64',
           '-Wc,DLL',
-          '-qlonglong'
+          '-qlonglong',
+          '-qenum=int',
+          '-qxclang=-fexec-charset=ISO8859-1'
+        ],
+        'defines': [
+          '_ALL_SOURCE=1',
+          'MAP_FAILED=-1',
+          '_UNIX03_SOURCE=1'
         ],
         'ldflags': [
           '-q64',

--- a/gyp/pylib/gyp/generator/make.py
+++ b/gyp/pylib/gyp/generator/make.py
@@ -2059,6 +2059,14 @@ def GenerateOutput(target_list, target_dicts, data, params):
       'srcdir': srcdir,
       'copy_archive_args': copy_archive_arguments,
       'makedep_args': makedep_arguments,
+      'CC.target':   GetEnvironFallback(('CC_target', 'CC'), '$(CC)'),
+      'AR.target':   GetEnvironFallback(('AR_target', 'AR'), '$(AR)'),
+      'CXX.target':  GetEnvironFallback(('CXX_target', 'CXX'), '$(CXX)'),
+      'LINK.target': GetEnvironFallback(('LINK_target', 'LINK'), '$(LINK)'),
+      'CC.host':     GetEnvironFallback(('CC_host', 'CC'), 'gcc'),
+      'AR.host':     GetEnvironFallback(('AR_host', 'AR'), 'ar'),
+      'CXX.host':    GetEnvironFallback(('CXX_host', 'CXX'), 'g++'),
+      'LINK.host':   GetEnvironFallback(('LINK_host', 'LINK'), '$(CXX.host)'),
     }
   if flavor == 'mac':
     flock_command = './gyp-mac-tool flock'
@@ -2079,6 +2087,10 @@ def GenerateOutput(target_list, target_dicts, data, params):
         'copy_archive_args': copy_archive_arguments,
         'makedep_args': makedep_arguments,
         'link_commands': LINK_COMMANDS_OS390,
+        'CC.target':   GetEnvironFallback(('CC_target', 'CC'), 'njsc'),
+        'CXX.target':  GetEnvironFallback(('CXX_target', 'CXX'), 'njsc++'),
+        'CC.host':     GetEnvironFallback(('CC_host', 'CC'), 'njsc'),
+        'CXX.host':    GetEnvironFallback(('CXX_host', 'CXX'), 'njsc++'),
     })
   elif flavor == 'solaris':
     header_params.update({
@@ -2103,17 +2115,6 @@ def GenerateOutput(target_list, target_dicts, data, params):
         'flock': './gyp-flock-tool flock',
         'flock_index': 2,
     })
-
-  header_params.update({
-    'CC.target':   GetEnvironFallback(('CC_target', 'CC'), '$(CC)'),
-    'AR.target':   GetEnvironFallback(('AR_target', 'AR'), '$(AR)'),
-    'CXX.target':  GetEnvironFallback(('CXX_target', 'CXX'), '$(CXX)'),
-    'LINK.target': GetEnvironFallback(('LINK_target', 'LINK'), '$(LINK)'),
-    'CC.host':     GetEnvironFallback(('CC_host', 'CC'), 'gcc'),
-    'AR.host':     GetEnvironFallback(('AR_host', 'AR'), 'ar'),
-    'CXX.host':    GetEnvironFallback(('CXX_host', 'CXX'), 'g++'),
-    'LINK.host':   GetEnvironFallback(('LINK_host', 'LINK'), '$(CXX.host)'),
-  })
 
   build_file, _, _ = gyp.common.ParseQualifiedTarget(target_list[0])
   make_global_settings_array = data[build_file].get('make_global_settings', [])


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

- updated the z/OS compiler options to support the latest version of Node.js on z/OS
- on z/OS, the default compiler is njsc/njsc++ instead of gcc/g++,  so the parameters in gyp have been updated accordingly