### PR TITLE
build: default to max jobs

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -24,7 +24,7 @@ function build (gyp, argv, callback) {
 
   var makeCommand = gyp.opts.make || process.env.MAKE || platformMake
     , command = win ? 'msbuild' : makeCommand
-    , jobs = gyp.opts.jobs || process.env.JOBS
+    , jobs = gyp.opts.jobs || process.env.JOBS || 'max'
     , buildType
     , config
     , arch


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

This PR probably needs a little discussion on potential ramifications of the change.

Currently, `node-gyp` defaults to a single job, which means it only uses a single core out of the box. This causes unnecessarily slow builds on machines with multiple cores. While any given project can manually use this setting, I personally think a more reasonable default is to use all available cores. Otherwise build times are just longer than they need to be, especially with 4+ cores becoming more common. Applying this change will speed up builds for a lot of people.

Any arguments for why this may not be a reasonable change? Is using more CPU during install an adverse change for some users?