### PR TITLE
fix: re-add support for iojs prefixed headers to support Electron 3

### DIFF
--- a/lib/process-release.js
+++ b/lib/process-release.js
@@ -17,6 +17,7 @@ function processRelease (argv, gyp, defaultVersion, defaultRelease) {
     , versionSemver = semver.parse(version)
     , overrideDistUrl = gyp.opts['dist-url'] || gyp.opts.disturl
     , isDefaultVersion
+    , isNamedForLegacyIojs
     , name
     , distBaseUrl
     , baseUrl
@@ -41,11 +42,17 @@ function processRelease (argv, gyp, defaultVersion, defaultRelease) {
 
   if (defaultRelease) {
     // v3 onward, has process.release
-    name = defaultRelease.name
+    name = defaultRelease.name.replace(/io\.js/, 'iojs') // remove the '.' for directory naming purposes
   } else {
     // old node or alternative --target=
     // semver.satisfies() doesn't like prerelease tags so test major directly
-    name = 'node'
+    isNamedForLegacyIojs = versionSemver.major >= 1 && versionSemver.major < 4
+    // isNamedForLegacyIojs is required to support Electron < 4 (in particular Electron 3)
+    // as previously this logic was used to ensure "iojs" was used to download iojs releases
+    // and "node" for node releases.  Unfortuantely the logic was broad enough that electron@3
+    // published release assets as "iojs" so that the node-gyp logic worked.  Once Electron@3 has
+    // been EOL for a while (late 2019) we should remove this hack.
+    name = isNamedForLegacyIojs ? 'iojs' : 'node'
   }
 
   // check for the nvm.sh standard mirror env variables

--- a/lib/process-release.js
+++ b/lib/process-release.js
@@ -49,7 +49,7 @@ function processRelease (argv, gyp, defaultVersion, defaultRelease) {
     isNamedForLegacyIojs = versionSemver.major >= 1 && versionSemver.major < 4
     // isNamedForLegacyIojs is required to support Electron < 4 (in particular Electron 3)
     // as previously this logic was used to ensure "iojs" was used to download iojs releases
-    // and "node" for node releases.  Unfortuantely the logic was broad enough that electron@3
+    // and "node" for node releases.  Unfortunately the logic was broad enough that electron@3
     // published release assets as "iojs" so that the node-gyp logic worked.  Once Electron@3 has
     // been EOL for a while (late 2019) we should remove this hack.
     name = isNamedForLegacyIojs ? 'iojs' : 'node'


### PR DESCRIPTION
This reverts commit 4748f6ab75e3aa661cc67de468c6cf19c4102384.

The original commit broke support for Electron 3 which is still a supported release line.  For more details please see https://github.com/nodejs/node-gyp/issues/1778

Please note I haven't yet tested if this revert functions, I just ran `git revert` at 2am and went to bed.  Hopefully we can get this landed and fixed tomorrow 👍 