### PR TITLE
lib: add .json suffix for explicit require

### DIFF
--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -51,7 +51,7 @@ var proto = Gyp.prototype
  * Export the contents of the package.json.
  */
 
-proto.package = require('../package')
+proto.package = require('../package.json')
 
 /**
  * nopt configuration definitions


### PR DESCRIPTION
Multiple reports of this failing, seems to be due to node wrapping tools that mess with the require extensions. So let's be explicit about it.