### PR TITLE
Travis CI: Add standalone parallel Node tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 dist: xenial
 language: python
 cache: pip
-python:
-    - 2.7
-    - 3.7
+
 matrix:
+    include:
+        - language: node_js
+        - python: 2.7
+        - python: 3.7
     allow_failures:
         - python: 3.7
 install:


### PR DESCRIPTION
Add a separate, parallel test run so that we can see the Node results even when the Python tests fail.
* https://docs.travis-ci.com/user/languages/javascript-with-nodejs/

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

