### PR TITLE
test: configure proper devDir for invoking configure()

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,3 @@
+const envPaths = require('env-paths')
+
+module.exports.devDir = () => envPaths('node-gyp', { suffix: '' }).cache

--- a/test/test-configure-python.js
+++ b/test/test-configure-python.js
@@ -2,6 +2,7 @@
 
 const test = require('tap').test
 const path = require('path')
+const devDir = require('./common').devDir()
 const gyp = require('../lib/node-gyp')
 const requireInject = require('require-inject')
 const configure = requireInject('../lib/configure', {

--- a/test/test-configure-python.js
+++ b/test/test-configure-python.js
@@ -30,6 +30,7 @@ test('configure PYTHONPATH with no existing env', function (t) {
     t.equal(process.env.PYTHONPATH, EXPECTED_PYPATH)
     return SPAWN_RESULT
   }
+  prog.devDir = devDir
   configure(prog, [], t.fail)
 })
 
@@ -49,6 +50,7 @@ test('configure PYTHONPATH with existing env of one dir', function (t) {
 
     return SPAWN_RESULT
   }
+  prog.devDir = devDir
   configure(prog, [], t.fail)
 })
 
@@ -70,5 +72,6 @@ test('configure PYTHONPATH with existing env of multiple dirs', function (t) {
 
     return SPAWN_RESULT
   }
+  prog.devDir = devDir
   configure(prog, [], t.fail)
 })


### PR DESCRIPTION
test/test-configure-python.js downloads a fresh set of headers to the package directory each time. By setting to the default global cache dir we get to re-use cached headers and skip the download step. Speeds up tests and prevents the creation of a new directory with headers in it in the package root each test run.