### PR TITLE
win: make VS path match case-insensitive

### DIFF
--- a/lib/find-visualstudio.js
+++ b/lib/find-visualstudio.js
@@ -403,11 +403,13 @@ VisualStudioFinder.prototype = {
       this.addLog('- msvs_version does not match this version')
       return false
     }
-    if (this.configPath && this.configPath !== vsPath) {
+    if (this.configPath &&
+        path.relative(this.configPath, vsPath) !== '') {
       this.addLog('- msvs_version does not point to this installation')
       return false
     }
-    if (this.envVcInstallDir && this.envVcInstallDir !== vsPath) {
+    if (this.envVcInstallDir &&
+        path.relative(this.envVcInstallDir, vsPath) !== '') {
       this.addLog('- does not match this Visual Studio Command Prompt')
       return false
     }

--- a/test/test-find-visualstudio.js
+++ b/test/test-find-visualstudio.js
@@ -525,11 +525,26 @@ test('look for VS2019 by version number', function (t) {
   finder.findVisualStudio()
 })
 
-test('look for VS2017 by installation path', function (t) {
+test('look for VS2019 by installation path', function (t) {
   t.plan(2)
 
   const finder = new TestVisualStudioFinder(semverV1,
     'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools',
+    (err, info) => {
+      t.strictEqual(err, null)
+      t.deepEqual(info.path,
+        'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools')
+    })
+
+  allVsVersions(t, finder)
+  finder.findVisualStudio()
+})
+
+test('msvs_version match should be case insensitive', function (t) {
+  t.plan(2)
+
+  const finder = new TestVisualStudioFinder(semverV1,
+    'c:\\program files (x86)\\microsoft visual studio\\2019\\BUILDTOOLS',
     (err, info) => {
       t.strictEqual(err, null)
       t.deepEqual(info.path,
@@ -562,6 +577,22 @@ test('run on a usable VS Command Prompt', function (t) {
   const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
     t.strictEqual(err, null)
     t.deepEqual(info.path, 'C:\\VS2015')
+  })
+
+  allVsVersions(t, finder)
+  finder.findVisualStudio()
+})
+
+test('VCINSTALLDIR match should be case insensitive', function (t) {
+  t.plan(2)
+
+  process.env.VCINSTALLDIR =
+    'c:\\program files (x86)\\microsoft visual studio\\2019\\BUILDTOOLS\\VC'
+
+  const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
+    t.strictEqual(err, null)
+    t.deepEqual(info.path,
+      'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools')
   })
 
   allVsVersions(t, finder)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

Path comparison should be case-insensitive on Windows. As reported in https://github.com/nodejs/node-gyp/issues/1805, `VCINSTALLDIR` can have the drive letter in lowercase while the information about the installation has it in uppercase.

Fixes: https://github.com/nodejs/node-gyp/issues/1805

