### PR TITLE
test: downgrade to tap@^12 for continued Node 6 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint": "^5.0.1",
     "nan": "^2.0.0",
     "require-inject": "~1.3.0",
-    "tap": "~14.2.4"
+    "tap": "~12.7.0"
   },
   "scripts": {
     "lint": "eslint bin lib test",


### PR DESCRIPTION
Fixes https://github.com/nodejs/node-gyp/pull/1795#issuecomment-508426193