### PR TITLE
Fix running Windows on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ matrix:
     - name: "Node.js 12 & Python 3.7 on Linux"
       python: 3.7
       before_install: nvm install 12
-  allow_failures:
-    - os: windows
 install:
   #- pip install -r requirements.txt
   - pip install flake8  # pytest  # add another testing frameworks later

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,13 @@ matrix:
       osx_image: xcode10.2
       language: shell  # 'language: python' is not yet supported on macOS
       before_install: HOMEBREW_NO_AUTO_UPDATE=1 brew install npm
-    - name: "Python 2.7 on Windows"
+    - name: "Node.js 6 & Python 2.7 on Windows"
+      os: windows
+      language: node_js
+      node_js: 6  # node
+      env: PATH=/c/Python27:/c/Python27/Scripts:$PATH
+      before_install: choco install python2
+    - name: "Node.js 12 & Python 2.7 on Windows"
       os: windows
       language: node_js
       node_js: 12  # node

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
   },
   "scripts": {
     "lint": "standard */*.js test/**/*.js",
-    "test": "npm run lint && tap test/test-*"
+    "test": "npm run lint && tap --timeout=120 test/test-*"
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

`test-addon.js` includes compiling code, making the default 30 second timeout not suitable. This increases the timeout for all platforms, which is a potential problem everywhere, fixing the timeout that happens on Windows. Currently, the test takes 53 seconds on Windows and 17 on OSX.

This also adds Node 6 on Windows to the matrix. There is a lot of platform-specific code, so running the oldest supported version seems reasonable.

Fixes: https://github.com/nodejs/node-gyp/issues/1801

cc @cclauss