### PR TITLE
build: raise the minimum Python version from 2.6 to 2.7

### DIFF
--- a/lib/find-python.js
+++ b/lib/find-python.js
@@ -19,7 +19,7 @@ PythonFinder.prototype = {
   argsExecutable: [ '-c', 'import sys; print(sys.executable);' ],
   argsVersion: [ '-c', 'import sys; print("%s.%s.%s" % sys.version_info[:3]);' ],
   semverRange: process.env.EXPERIMENTAL_NODE_GYP_PYTHON3 ? '2.7.x || >=3.5.0'
-    : '>=2.6.0 <3.0.0',
+    : '>=2.7.0 <3.0.0',
 
   // These can be overridden for testing:
   execFile: cp.execFile,


### PR DESCRIPTION
As discussed in #1811, this change aligns our code with our docs.

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->
Raise the minimum acceptable Python version from 2.6 to 2.7.
* Python 2.6 EOL was in 2013  https://devguide.python.org/devcycle/#end-of-life-branches

@nodejs/python 
