### PR TITLE
Updated win_delay_load_hook.cc to work with /clr

### DIFF
--- a/src/win_delay_load_hook.cc
+++ b/src/win_delay_load_hook.cc
@@ -6,7 +6,7 @@
  *
  * This allows compiled addons to work when the host executable is renamed.
  */
-
+#pragma unmanaged
 #ifdef _MSC_VER
 
 #ifndef WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
Added support for native managed modules with delay load

To support native modules that use managed code(/clr) with delay load 
we need to compile win_delay_load_hook.cc as unmanaged  by setting
```#pragma unmanaged```
