### PR TITLE
build: import StringIO on both Python 2 and Python 3

### DIFF
--- a/gyp/pylib/gyp/MSVSSettings_test.py
+++ b/gyp/pylib/gyp/MSVSSettings_test.py
@@ -6,7 +6,11 @@
 
 """Unit tests for the MSVSSettings.py file."""
 
-import StringIO
+try:
+  from cStringIO import StringIO
+except ImportError:
+  from io import StringIO
+
 import unittest
 import gyp.MSVSSettings as MSVSSettings
 
@@ -14,7 +18,7 @@ import gyp.MSVSSettings as MSVSSettings
 class TestSequenceFunctions(unittest.TestCase):
 
   def setUp(self):
-    self.stderr = StringIO.StringIO()
+    self.stderr = StringIO()
 
   def _ExpectedWarnings(self, expected):
     """Compares recorded lines to expected warnings."""

--- a/gyp/pylib/gyp/easy_xml_test.py
+++ b/gyp/pylib/gyp/easy_xml_test.py
@@ -8,13 +8,16 @@
 
 import gyp.easy_xml as easy_xml
 import unittest
-import StringIO
+try:
+  from cStringIO import StringIO
+except ImportError:
+  from io import StringIO
 
 
 class TestSequenceFunctions(unittest.TestCase):
 
   def setUp(self):
-    self.stderr = StringIO.StringIO()
+    self.stderr = StringIO()
 
   def test_EasyXml_simple(self):
     self.assertEqual(

--- a/gyp/pylib/gyp/generator/msvs_test.py
+++ b/gyp/pylib/gyp/generator/msvs_test.py
@@ -7,13 +7,16 @@
 
 import gyp.generator.msvs as msvs
 import unittest
-import StringIO
+try:
+  from cStringIO import StringIO
+except ImportError:
+  from io import StringIO
 
 
 class TestSequenceFunctions(unittest.TestCase):
 
   def setUp(self):
-    self.stderr = StringIO.StringIO()
+    self.stderr = StringIO()
 
   def test_GetLibraries(self):
     self.assertEqual(

--- a/gyp/pylib/gyp/generator/ninja.py
+++ b/gyp/pylib/gyp/generator/ninja.py
@@ -19,7 +19,10 @@ from gyp.common import OrderedSet
 import gyp.msvs_emulation
 import gyp.MSVSUtil as MSVSUtil
 import gyp.xcode_emulation
-from cStringIO import StringIO
+try:
+  from cStringIO import StringIO
+except ImportError:
+  from io import StringIO
 
 from gyp.common import GetEnvironFallback
 import gyp.ninja_syntax as ninja_syntax

--- a/gyp/pylib/gyp/generator/ninja_test.py
+++ b/gyp/pylib/gyp/generator/ninja_test.py
@@ -8,7 +8,6 @@
 
 import gyp.generator.ninja as ninja
 import unittest
-import StringIO
 import sys
 import TestCommon
 


### PR DESCRIPTION
This change supports access to __StringIO__ on both Python 2 and Python 3.  Without this change the import fails on Python 3.

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

