### PR TITLE
WIP: Python 3 on Linux passes Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,51 +28,44 @@ matrix:
         PATH=/c/Python27:/c/Python27/Scripts:$PATH
         NODE_GYP_FORCE_PYTHON=/c/Python27/python.exe
       before_install: choco install python2
-    - name: "Node.js 6 & Python 3.7 on Linux"
-      python: 3.7
-      env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
-      before_install: nvm install 6
-    - name: "Node.js 8 & Python 3.7 on Linux"
-      python: 3.7
-      env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
-      before_install: nvm install 8
-    - name: "Node.js 10 & Python 3.7 on Linux"
-      python: 3.7
-      env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
-      before_install: nvm install 10
-    - name: "Node.js 12 & Python 3.7 on Linux"
-      python: 3.7
-      env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
-      before_install: nvm install 12
-    - name: "Node.js 12 & Python 3.7 on Windows"
+    - name: "Python 3.6 on Linux"
+      env: NODE_GYP_FORCE_PYTHON=python3.6 EXPERIMENTAL_NODE_GYP_PYTHON3=1
+      python: 3.6
+    - name: "Python 3.6 on macOS"
+      os: osx
+      language: cpp
+      env: NODE_GYP_FORCE_PYTHON=python3.6 EXPERIMENTAL_NODE_GYP_PYTHON3=1
+    - name: "Python 3.6 on Windows"
       os: windows
-      language: node_js
-      node_js: 12  # node
+      language: cpp
+      # language: node_js
+      # node_js: 12  # node
       env: >-
-        PATH=/c/Python37:/c/Python37/Scripts:$PATH
-        NODE_GYP_FORCE_PYTHON=/c/Python37/python.exe
+        PATH=/c/Python36:/c/Python36/Scripts:$PATH
+        NODE_GYP_FORCE_PYTHON=/c/Python36/python.exe
         EXPERIMENTAL_NODE_GYP_PYTHON3=1
-      before_install: choco install python
+      before_install: choco install python --version 3.6.8
   allow_failures:
-    - env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
+    - env: NODE_GYP_FORCE_PYTHON=python3.6 EXPERIMENTAL_NODE_GYP_PYTHON3=1
     - env: >-
-        PATH=/c/Python37:/c/Python37/Scripts:$PATH
-        NODE_GYP_FORCE_PYTHON=/c/Python37/python.exe
+        PATH=/c/Python36:/c/Python36/Scripts:$PATH
+        NODE_GYP_FORCE_PYTHON=/c/Python36/python.exe
         EXPERIMENTAL_NODE_GYP_PYTHON3=1
 install:
   #- pip install -r requirements.txt
-  - pip install flake8  # pytest  # add another testing frameworks later
+  - pip install flake8
 before_script:
   - flake8 --version
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   # exit-zero treats all errors as warnings.  Two space indentation is OK.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --ignore=E111,E114,W503 --max-complexity=10 --max-line-length=127 --statistics
+  - echo "EXPERIMENTAL_NODE_GYP_PYTHON3 is ${EXPERIMENTAL_NODE_GYP_PYTHON3}"
+  - ${NODE_GYP_FORCE_PYTHON} --version || true
   - npm install
 script:
   - node -e 'require("npmlog").level="verbose"; require("./lib/find-python")(null,()=>{})'
   - npm test
-  #- pytest --capture=sys  # add other tests here
 notifications:
   on_success: change
   on_failure: change  # `always` will be the setting once code changes slow down

--- a/gyp/pylib/gyp/generator/ninja.py
+++ b/gyp/pylib/gyp/generator/ninja.py
@@ -19,7 +19,10 @@ from gyp.common import OrderedSet
 import gyp.msvs_emulation
 import gyp.MSVSUtil as MSVSUtil
 import gyp.xcode_emulation
-from cStringIO import StringIO
+try:
+  from cStringIO import StringIO
+except ImportError:
+  from io import StringIO
 
 from gyp.common import GetEnvironFallback
 import gyp.ninja_syntax as ninja_syntax

--- a/test/test-find-python.js
+++ b/test/test-find-python.js
@@ -17,8 +17,8 @@ test('find python', function (t) {
     t.strictEqual(err, null)
     var proc = execFile(found, ['-V'], function (err, stdout, stderr) {
       t.strictEqual(err, null)
-      t.strictEqual(stdout, '')
-      t.ok(/Python 2/.test(stderr))
+      t.strictEqual(stderr, '')
+      t.ok(/Python 3/.test(stdout))
     })
     proc.stdout.setEncoding('utf-8')
     proc.stderr.setEncoding('utf-8')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->
The goal was to make our Travis CI tests pass on Python 3.6 on Linux pass.  -- Success.

Unfortunately, __test/test-find-python.js__ is so fragile that I can not find a way to do this without [__breaking ALL Python 2 tests__](https://travis-ci.com/nodejs/node-gyp/builds/120139936).  Hopefully someone else can __help to make the Python 2 tests pass again__.  #1826

I tried without success:
```javascript
      if (process.env.NODE_GYP_FORCE_PYTHON === '1') {
        t.strictEqual(stderr, '')
        t.ok(/Python 3/.test(stdout)) // Python 3 writes the version to stdout
      } else {
        t.strictEqual(stdout, '')
        t.ok(/Python 2/.test(stderr)) // Python 2 writes the version to stderr
      }

```

The change to __gyp/pylib/gyp/generator/ninja.py__ is lifted right out of #1836 and should be uncontroversial.

The changes to __.travis.yml__ shift to:
1. focus from Python 3.7 to 3.6 because __async__ and __await__ are reserved words in Python >= 3.7.
2. perform a single test run each on Linux, macOS, and Windows.