### PR TITLE
Fix Travis runs with Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
       before_install: nvm install 12
     - name: "Python 3.7 on macOS"
       os: osx
-      osx_image: xcode11
+      #osx_image: xcode11
       language: shell  # 'language: python' is not yet supported on macOS
       env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
       before_install: HOMEBREW_NO_AUTO_UPDATE=1 brew install npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
       python: 2.7
     - name: "Python 2.7 on macOS"
       os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11
       language: shell  # 'language: python' is not yet supported on macOS
       env: NODE_GYP_FORCE_PYTHON=python2
       before_install: HOMEBREW_NO_AUTO_UPDATE=1 brew install npm
@@ -28,6 +28,7 @@ matrix:
         PATH=/c/Python27:/c/Python27/Scripts:$PATH
         NODE_GYP_FORCE_PYTHON=/c/Python27/python.exe
       before_install: choco install python2
+
     - name: "Node.js 6 & Python 3.7 on Linux"
       python: 3.7
       env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
@@ -44,6 +45,12 @@ matrix:
       python: 3.7
       env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
       before_install: nvm install 12
+    - name: "Node.js 12 & Python 3.7 on macOS"
+      os: osx
+      osx_image: xcode11
+      language: shell  # 'language: python' is not yet supported on macOS
+      env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
+      before_install: HOMEBREW_NO_AUTO_UPDATE=1 brew install npm
     - name: "Node.js 12 & Python 3.7 on Windows"
       os: windows
       language: node_js
@@ -53,6 +60,7 @@ matrix:
         NODE_GYP_FORCE_PYTHON=/c/Python37/python.exe
         EXPERIMENTAL_NODE_GYP_PYTHON3=1
       before_install: choco install python
+
   allow_failures:
     - env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
     - env: >-

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
       python: 3.7
       env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
       before_install: nvm install 12
-    - name: "Node.js 12 & Python 3.7 on macOS"
+    - name: "Python 3.7 on macOS"
       os: osx
       osx_image: xcode11
       language: shell  # 'language: python' is not yet supported on macOS

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,8 @@ matrix:
       before_install: choco install python
 
   allow_failures:
-    - env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
+    - os: osx
+      env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
     - env: >-
         PATH=/c/Python37:/c/Python37/Scripts:$PATH
         NODE_GYP_FORCE_PYTHON=/c/Python37/python.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,10 +64,6 @@ matrix:
   allow_failures:
     - os: osx
       env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
-    - env: >-
-        PATH=/c/Python37:/c/Python37/Scripts:$PATH
-        NODE_GYP_FORCE_PYTHON=/c/Python37/python.exe
-        EXPERIMENTAL_NODE_GYP_PYTHON3=1
 install:
   #- pip install -r requirements.txt
   - pip install flake8  # pytest  # add another testing frameworks later

--- a/gyp/pylib/gyp/MSVSNew.py
+++ b/gyp/pylib/gyp/MSVSNew.py
@@ -45,7 +45,7 @@ def MakeGuid(name, seed='msvs_new'):
   not change when the project for a target is rebuilt.
   """
   # Calculate a MD5 signature for the seed and name.
-  d = hashlib.md5(str(seed) + str(name)).hexdigest().upper()
+  d = hashlib.md5((str(seed) + str(name)).encode('utf-8')).hexdigest().upper()
   # Convert most of the signature to GUID form (discard the rest)
   guid = ('{' + d[:8] + '-' + d[8:12] + '-' + d[12:16] + '-' + d[16:20]
           + '-' + d[20:32] + '}')

--- a/gyp/pylib/gyp/common.py
+++ b/gyp/pylib/gyp/common.py
@@ -394,6 +394,9 @@ def WriteOnDiff(filename):
         os.unlink(self.tmp_path)
         raise
 
+    def write(self, s):
+      self.tmp_file.write(s.encode('utf-8'))
+
   return Writer()
 
 

--- a/gyp/pylib/gyp/easy_xml.py
+++ b/gyp/pylib/gyp/easy_xml.py
@@ -120,7 +120,7 @@ def WriteXmlIfChanged(content, path, encoding='utf-8', pretty=False,
 
   default_encoding = locale.getdefaultlocale()[1]
   if default_encoding.upper() != encoding.upper():
-    xml_string = xml_string.decode(default_encoding).encode(encoding)
+    xml_string = xml_string.encode(encoding)
 
   # Get the old content
   try:
@@ -132,7 +132,7 @@ def WriteXmlIfChanged(content, path, encoding='utf-8', pretty=False,
 
   # It has changed, write it
   if existing != xml_string:
-    f = open(path, 'w')
+    f = open(path, 'wb')
     f.write(xml_string)
     f.close()
 

--- a/gyp/pylib/gyp/generator/msvs.py
+++ b/gyp/pylib/gyp/generator/msvs.py
@@ -1753,8 +1753,8 @@ def _CollapseSingles(parent, node):
   # such projects up one level.
   if (type(node) == dict and
       len(node) == 1 and
-      node.keys()[0] == parent + '.vcproj'):
-    return node[node.keys()[0]]
+      list(node)[0] == parent + '.vcproj'):
+    return node[list(node)[0]]
   if type(node) != dict:
     return node
   for child in node:
@@ -1773,8 +1773,8 @@ def _GatherSolutionFolders(sln_projects, project_objects, flat):
   # Walk down from the top until we hit a folder that has more than one entry.
   # In practice, this strips the top-level "src/" dir from the hierarchy in
   # the solution.
-  while len(root) == 1 and type(root[root.keys()[0]]) == dict:
-    root = root[root.keys()[0]]
+  while len(root) == 1 and type(root[list(root)[0]]) == dict:
+    root = root[list(root)[0]]
   # Collapse singles.
   root = _CollapseSingles('', root)
   # Merge buckets until everything is a root entry.

--- a/test/test-find-python.js
+++ b/test/test-find-python.js
@@ -1,12 +1,11 @@
 'use strict'
 
+delete process.env.PYTHON
+
 const test = require('tap').test
 const findPython = require('../lib/find-python')
 const execFile = require('child_process').execFile
 const PythonFinder = findPython.test.PythonFinder
-
-delete process.env.PYTHON
-delete process.env.NODE_GYP_FORCE_PYTHON
 
 require('npmlog').level = 'warn'
 
@@ -17,8 +16,13 @@ test('find python', function (t) {
     t.strictEqual(err, null)
     var proc = execFile(found, ['-V'], function (err, stdout, stderr) {
       t.strictEqual(err, null)
-      t.strictEqual(stdout, '')
-      t.ok(/Python 2/.test(stderr))
+      if (/Python 2/.test(stderr)) {
+        t.strictEqual(stdout, '')
+        t.ok(/Python 2/.test(stderr))
+      } else {
+        t.ok(/Python 3/.test(stdout))
+        t.strictEqual(stderr, '')
+      }
     })
     proc.stdout.setEncoding('utf-8')
     proc.stderr.setEncoding('utf-8')
@@ -51,6 +55,7 @@ TestPythonFinder.prototype.log = {
   warn: () => {},
   error: () => {}
 }
+delete TestPythonFinder.prototype.env.NODE_GYP_FORCE_PYTHON
 
 test('find python - python', function (t) {
   t.plan(6)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

This fixes the remaining issues with `test-find-python.js` and running on Windows when using Python 3. This makes node-gyp compatible with Python 3 for everything that we run in CI (which is not that much).

@cclauss the fixes here seemed logical to me, but I don't have much experience with Python, so a careful review would be very welcome.

This PR is semver-patch, using Python 3 still depends on `EXPERIMENTAL_NODE_GYP_PYTHON3`. I am preparing a different PR to address that.