### PR TITLE
Accept Python 3 by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,25 +31,25 @@ matrix:
 
     - name: "Node.js 6 & Python 3.7 on Linux"
       python: 3.7
-      env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
+      env: NODE_GYP_FORCE_PYTHON=python3
       before_install: nvm install 6
     - name: "Node.js 8 & Python 3.7 on Linux"
       python: 3.7
-      env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
+      env: NODE_GYP_FORCE_PYTHON=python3
       before_install: nvm install 8
     - name: "Node.js 10 & Python 3.7 on Linux"
       python: 3.7
-      env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
+      env: NODE_GYP_FORCE_PYTHON=python3
       before_install: nvm install 10
     - name: "Node.js 12 & Python 3.7 on Linux"
       python: 3.7
-      env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
+      env: NODE_GYP_FORCE_PYTHON=python3
       before_install: nvm install 12
     - name: "Python 3.7 on macOS"
       os: osx
       #osx_image: xcode11
       language: shell  # 'language: python' is not yet supported on macOS
-      env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
+      env: NODE_GYP_FORCE_PYTHON=python3
       before_install: HOMEBREW_NO_AUTO_UPDATE=1 brew install npm
     - name: "Node.js 12 & Python 3.7 on Windows"
       os: windows
@@ -58,7 +58,6 @@ matrix:
       env: >-
         PATH=/c/Python37:/c/Python37/Scripts:$PATH
         NODE_GYP_FORCE_PYTHON=/c/Python37/python.exe
-        EXPERIMENTAL_NODE_GYP_PYTHON3=1
       before_install: choco install python
 
 install:
@@ -71,6 +70,7 @@ before_script:
   # exit-zero treats all errors as warnings.  Two space indentation is OK.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --ignore=E111,E114,W503 --max-complexity=10 --max-line-length=127 --statistics
   - npm install
+  - npm list
 script:
   - node -e 'require("npmlog").level="verbose"; require("./lib/find-python")(null,()=>{})'
   - npm test

--- a/lib/find-python.js
+++ b/lib/find-python.js
@@ -18,8 +18,7 @@ PythonFinder.prototype = {
   log: logWithPrefix(log, 'find Python'),
   argsExecutable: [ '-c', 'import sys; print(sys.executable);' ],
   argsVersion: [ '-c', 'import sys; print("%s.%s.%s" % sys.version_info[:3]);' ],
-  semverRange: process.env.EXPERIMENTAL_NODE_GYP_PYTHON3 ? '2.7.x || >=3.5.0'
-    : '>=2.7.0 <3.0.0',
+  semverRange: '2.7.x || >=3.5.0',
 
   // These can be overridden for testing:
   execFile: cp.execFile,
@@ -92,6 +91,11 @@ PythonFinder.prototype = {
           before: () => { this.addLog('checking if "python" can be used') },
           check: this.checkCommand,
           arg: 'python'
+        },
+        {
+          before: () => { this.addLog('checking if "python3" can be used') },
+          check: this.checkCommand,
+          arg: 'python3'
         },
         {
           before: () => { this.addLog('checking if "python2" can be used') },
@@ -286,7 +290,7 @@ PythonFinder.prototype = {
     //                                                           X
     const info = [
       '**********************************************************',
-      'You need to install the latest version of Python 2.7.',
+      'You need to install the latest version of Python.',
       'Node-gyp should be able to find and use Python. If not,',
       'you can try one of the following options:',
       `- Use the switch --python="${pathExample}"`,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

~This depends on https://github.com/nodejs/node-gyp/pull/1843, I will rebase when that PR lands. Only https://github.com/nodejs/node-gyp/commit/a9719470c1d1bf4ab0bd29ce135c2b8027c87a7a needs to be reviewed here.~

This makes node-gyp accept Python 3 and look for it before looking for Python 2, making Python 3 the default.

@nodejs/node-gyp please not that we cover little more than a basic hello world in our tests, there are probably parts of Gyp that are not covered and are not compatible with Python 3. We will have to be extra careful shipping the node-gyp version that includes this.