### PR TITLE
gyp: rm semicolons (Python != JavaScript)

### DIFF
--- a/gyp/pylib/gyp/common_test.py
+++ b/gyp/pylib/gyp/common_test.py
@@ -59,10 +59,10 @@ class TestGetFlavor(unittest.TestCase):
     self.assertFlavor('freebsd', 'freebsd9' , {})
     self.assertFlavor('freebsd', 'freebsd10', {})
     self.assertFlavor('openbsd', 'openbsd5' , {})
-    self.assertFlavor('solaris', 'sunos5'   , {});
-    self.assertFlavor('solaris', 'sunos'    , {});
-    self.assertFlavor('linux'  , 'linux2'   , {});
-    self.assertFlavor('linux'  , 'linux3'   , {});
+    self.assertFlavor('solaris', 'sunos5'   , {})
+    self.assertFlavor('solaris', 'sunos'    , {})
+    self.assertFlavor('linux'  , 'linux2'   , {})
+    self.assertFlavor('linux'  , 'linux3'   , {})
 
   def test_param(self):
     self.assertFlavor('foobar', 'linux2' , {'flavor': 'foobar'})

--- a/gyp/pylib/gyp/generator/analyzer.py
+++ b/gyp/pylib/gyp/generator/analyzer.py
@@ -615,7 +615,7 @@ class TargetCalculator(object):
 
   def _supplied_target_names_no_all(self):
     """Returns the supplied test targets without 'all'."""
-    result = self._supplied_target_names();
+    result = self._supplied_target_names()
     result.discard('all')
     return result
 
@@ -668,7 +668,7 @@ class TargetCalculator(object):
 
   def find_matching_compile_target_names(self):
     """Returns the set of output compile targets."""
-    assert self.is_build_impacted();
+    assert self.is_build_impacted()
     # Compile targets are found by searching up from changed targets.
     # Reset the visited status for _GetBuildTargets.
     for target in self._name_to_target.values():

--- a/gyp/pylib/gyp/generator/cmake.py
+++ b/gyp/pylib/gyp/generator/cmake.py
@@ -681,7 +681,7 @@ def WriteTarget(namer, qualified_target, target_dicts, build_dir, config_to_use,
   for src in srcs:
     _, ext = os.path.splitext(src)
     src_type = COMPILABLE_EXTENSIONS.get(ext, None)
-    src_norm_path = NormjoinPath(path_from_cmakelists_to_gyp, src);
+    src_norm_path = NormjoinPath(path_from_cmakelists_to_gyp, src)
 
     if src_type == 's':
       s_sources.append(src_norm_path)

--- a/gyp/pylib/gyp/generator/make.py
+++ b/gyp/pylib/gyp/generator/make.py
@@ -1225,16 +1225,16 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
         cflags_c = config.get('cflags_c')
         cflags_cc = config.get('cflags_cc')
 
-      self.WriteLn("# Flags passed to all source files.");
+      self.WriteLn("# Flags passed to all source files.")
       self.WriteList(cflags, 'CFLAGS_%s' % configname)
-      self.WriteLn("# Flags passed to only C files.");
+      self.WriteLn("# Flags passed to only C files.")
       self.WriteList(cflags_c, 'CFLAGS_C_%s' % configname)
-      self.WriteLn("# Flags passed to only C++ files.");
+      self.WriteLn("# Flags passed to only C++ files.")
       self.WriteList(cflags_cc, 'CFLAGS_CC_%s' % configname)
       if self.flavor == 'mac':
-        self.WriteLn("# Flags passed to only ObjC files.");
+        self.WriteLn("# Flags passed to only ObjC files.")
         self.WriteList(cflags_objc, 'CFLAGS_OBJC_%s' % configname)
-        self.WriteLn("# Flags passed to only ObjC++ files.");
+        self.WriteLn("# Flags passed to only ObjC++ files.")
         self.WriteList(cflags_objcc, 'CFLAGS_OBJCC_%s' % configname)
       includes = config.get('include_dirs')
       if includes:
@@ -1779,7 +1779,7 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
       cmddigest = hashlib.sha1(command if command else self.target).hexdigest()
       intermediate = "%s.intermediate" % cmddigest
       self.WriteLn('%s: %s' % (' '.join(outputs), intermediate))
-      self.WriteLn('\t%s' % '@:');
+      self.WriteLn('\t%s' % '@:')
       self.WriteLn('%s: %s' % ('.INTERMEDIATE', intermediate))
       self.WriteLn('%s: %s%s' %
                    (intermediate, ' '.join(inputs), force_append))

--- a/gyp/pylib/gyp/generator/xcode.py
+++ b/gyp/pylib/gyp/generator/xcode.py
@@ -246,7 +246,7 @@ class XcodeProject(object):
         targets_for_all.append(xcode_target)
 
       if target_name.lower() == 'all':
-        has_custom_all = True;
+        has_custom_all = True
 
       # If this target has a 'run_as' attribute, add its target to the
       # targets, and add it to the test targets.
@@ -637,7 +637,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
     pbxp = xcp.project
 
     # Set project-level attributes from multiple options
-    project_attributes = {};
+    project_attributes = {}
     if parallel_builds:
       project_attributes['BuildIndependentTargetsInParallel'] = 'YES'
     if upgrade_check_project_version:
@@ -776,7 +776,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
     # logic all happens in ninja.  Don't bother creating the extra targets in
     # that case.
     if type != 'none' and (spec_actions or spec_rules) and not ninja_wrapper:
-      support_xccl = CreateXCConfigurationList(configuration_names);
+      support_xccl = CreateXCConfigurationList(configuration_names)
       support_target_suffix = generator_flags.get(
           'support_target_suffix', ' Support')
       support_target_properties = {
@@ -1171,7 +1171,7 @@ exit 1
         dest = '$(SRCROOT)/' + dest
 
       code_sign = int(copy_group.get('xcode_code_sign', 0))
-      settings = (None, '{ATTRIBUTES = (CodeSignOnCopy, ); }')[code_sign];
+      settings = (None, '{ATTRIBUTES = (CodeSignOnCopy, ); }')[code_sign]
 
       # Coalesce multiple "copies" sections in the same target with the same
       # "destination" property into the same PBXCopyFilesBuildPhase, otherwise


### PR DESCRIPTION
##### Checklist

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change

Originally part of https://github.com/nodejs/node/pull/29120 - Removes semicolons from python scripts following the [E703](https://lintlyci.github.io/Flake8Rules/rules/E703.html) rule.

