### PR TITLE
src,win: add support for fetching arm64 node.lib

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -298,7 +298,7 @@ function install (fs, gyp, argv, callback) {
 
       function downloadNodeLib (done) {
         log.verbose('on Windows; need to download `' + release.name + '.lib`...')
-        var archs = [ 'ia32', 'x64' ]
+        var archs = [ 'ia32', 'x64', 'arm64' ]
         var async = archs.length
         archs.forEach(function (arch) {
           var dir = path.resolve(devDir, arch)
@@ -324,6 +324,11 @@ function install (fs, gyp, argv, callback) {
             req.on('error', done)
             req.on('response', function (res) {
               if (res.statusCode !== 200) {
+                if (res.statusCode === 404 && arch === 'arm64') {
+                  // Arm64 is a newer platform on Windows and not all node distributions provide it.
+                  log.verbose(res.statusCode + ' status code downloading ' + name)
+                  return
+                }
                 done(new Error(res.statusCode + ' status code downloading ' + name))
                 return
               }

--- a/lib/install.js
+++ b/lib/install.js
@@ -323,12 +323,15 @@ function install (fs, gyp, argv, callback) {
 
             req.on('error', done)
             req.on('response', function (res) {
-              if (res.statusCode !== 200) {
-                if (res.statusCode === 404 && arch === 'arm64') {
+              if (res.statusCode === 404) {
+                if (arch === 'arm64') {
                   // Arm64 is a newer platform on Windows and not all node distributions provide it.
-                  log.verbose(res.statusCode + ' status code downloading ' + name)
-                  return
+                  log.verbose(`${name} was not found in ${libUrl}`)
+                } else {
+                  log.warn(`${name} was not found in ${libUrl}`)
                 }
+                return
+              } else if (res.statusCode !== 200) {
                 done(new Error(res.statusCode + ' status code downloading ' + name))
                 return
               }

--- a/lib/process-release.js
+++ b/lib/process-release.js
@@ -25,6 +25,7 @@ function processRelease (argv, gyp, defaultVersion, defaultRelease) {
   var baseUrl
   var libUrl32
   var libUrl64
+  var libUrlArm64
   var tarballUrl
   var canGetHeaders
 
@@ -79,6 +80,7 @@ function processRelease (argv, gyp, defaultVersion, defaultRelease) {
     baseUrl = url.resolve(defaultRelease.headersUrl, './')
     libUrl32 = resolveLibUrl(name, defaultRelease.libUrl || baseUrl || distBaseUrl, 'x86', versionSemver.major)
     libUrl64 = resolveLibUrl(name, defaultRelease.libUrl || baseUrl || distBaseUrl, 'x64', versionSemver.major)
+    libUrlArm64 = resolveLibUrl(name, defaultRelease.libUrl || baseUrl || distBaseUrl, 'arm64', versionSemver.major)
     tarballUrl = defaultRelease.headersUrl
   } else {
     // older versions without process.release are captured here and we have to make
@@ -87,6 +89,7 @@ function processRelease (argv, gyp, defaultVersion, defaultRelease) {
     baseUrl = distBaseUrl
     libUrl32 = resolveLibUrl(name, baseUrl, 'x86', versionSemver.major)
     libUrl64 = resolveLibUrl(name, baseUrl, 'x64', versionSemver.major)
+    libUrlArm64 = resolveLibUrl(name, baseUrl, 'arm64', versionSemver.major)
 
     // making the bold assumption that anything with a version number >3.0.0 will
     // have a *-headers.tar.gz file in its dist location, even some frankenstein
@@ -110,6 +113,10 @@ function processRelease (argv, gyp, defaultVersion, defaultRelease) {
     x64: {
       libUrl: libUrl64,
       libPath: normalizePath(path.relative(url.parse(baseUrl).path, url.parse(libUrl64).path))
+    },
+    arm64: {
+      libUrl: libUrlArm64,
+      libPath: normalizePath(path.relative(url.parse(baseUrl).path, url.parse(libUrlArm64).path))
     }
   }
 }
@@ -128,7 +135,7 @@ function resolveLibUrl (name, defaultUrl, arch, versionMajor) {
       return url.resolve(base, 'win-' + arch + '/' + name + '.lib')
     }
     // prior to io.js@1.0.0 32-bit node.lib lives in /, 64-bit lives in /x64/
-    return url.resolve(base, (arch === 'x64' ? 'x64/' : '') + name + '.lib')
+    return url.resolve(base, (arch === 'x86' ? '' : arch + '/') + name + '.lib')
   }
 
   // else we have a proper url to a .lib, just make sure it's the right arch

--- a/lib/process-release.js
+++ b/lib/process-release.js
@@ -7,7 +7,7 @@ const log = require('npmlog')
 
 // versions where -headers.tar.gz started shipping
 const headersTarballRange = '>= 3.0.0 || ~0.12.10 || ~0.10.42'
-const bitsre = /\/win-(x86|x64)\//
+const bitsre = /\/win-(x86|x64|arm64)\//
 const bitsreV3 = /\/win-(x86|ia32|x64)\// // io.js v3.x.x shipped with "ia32" but should
 // have been "x86"
 

--- a/test/test-process-release.js
+++ b/test/test-process-release.js
@@ -181,6 +181,58 @@ test('test process release - process.release ~ node@4.1.23 / corp build', functi
   })
 })
 
+test('test process release - process.release ~ node@12.8.0 Windows', function (t) {
+  t.plan(2)
+
+  var release = processRelease([], { opts: {} }, 'v12.8.0', {
+    name: 'node',
+    sourceUrl: 'https://nodejs.org/download/release/v12.8.0/node-v12.8.0.tar.gz',
+    headersUrl: 'https://nodejs.org/download/release/v12.8.0/node-v12.8.0-headers.tar.gz',
+    libUrl: 'https://nodejs.org/download/release/v12.8.0/win-x64/node.lib'
+  })
+
+  t.equal(release.semver.version, '12.8.0')
+  delete release.semver
+
+  t.deepEqual(release, {
+    version: '12.8.0',
+    name: 'node',
+    baseUrl: 'https://nodejs.org/download/release/v12.8.0/',
+    tarballUrl: 'https://nodejs.org/download/release/v12.8.0/node-v12.8.0-headers.tar.gz',
+    shasumsUrl: 'https://nodejs.org/download/release/v12.8.0/SHASUMS256.txt',
+    versionDir: '12.8.0',
+    ia32: { libUrl: 'https://nodejs.org/download/release/v12.8.0/win-x86/node.lib', libPath: 'win-x86/node.lib' },
+    x64: { libUrl: 'https://nodejs.org/download/release/v12.8.0/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+    arm64: { libUrl: 'https://nodejs.org/download/release/v12.8.0/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
+  })
+})
+
+test('test process release - process.release ~ node@12.8.0 Windows ARM64', function (t) {
+  t.plan(2)
+
+  var release = processRelease([], { opts: {} }, 'v12.8.0', {
+    name: 'node',
+    sourceUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/node-v12.8.0.tar.gz',
+    headersUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/node-v12.8.0-headers.tar.gz',
+    libUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/win-arm64/node.lib'
+  })
+
+  t.equal(release.semver.version, '12.8.0')
+  delete release.semver
+
+  t.deepEqual(release, {
+    version: '12.8.0',
+    name: 'node',
+    baseUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/',
+    tarballUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/node-v12.8.0-headers.tar.gz',
+    shasumsUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/SHASUMS256.txt',
+    versionDir: '12.8.0',
+    ia32: { libUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/win-x86/node.lib', libPath: 'win-x86/node.lib' },
+    x64: { libUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+    arm64: { libUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
+  })
+})
+
 test('test process release - process.release ~ node@4.1.23 --target=0.10.40', function (t) {
   t.plan(2)
 

--- a/test/test-process-release.js
+++ b/test/test-process-release.js
@@ -19,7 +19,8 @@ test('test process release - process.version = 0.8.20', function (t) {
     shasumsUrl: 'https://nodejs.org/dist/v0.8.20/SHASUMS256.txt',
     versionDir: '0.8.20',
     ia32: { libUrl: 'https://nodejs.org/dist/v0.8.20/node.lib', libPath: 'node.lib' },
-    x64: { libUrl: 'https://nodejs.org/dist/v0.8.20/x64/node.lib', libPath: 'x64/node.lib' }
+    x64: { libUrl: 'https://nodejs.org/dist/v0.8.20/x64/node.lib', libPath: 'x64/node.lib' },
+    arm64: { libUrl: 'https://nodejs.org/dist/v0.8.20/arm64/node.lib', libPath: 'arm64/node.lib' }
   })
 })
 
@@ -39,7 +40,8 @@ test('test process release - process.version = 0.10.21', function (t) {
     shasumsUrl: 'https://nodejs.org/dist/v0.10.21/SHASUMS256.txt',
     versionDir: '0.10.21',
     ia32: { libUrl: 'https://nodejs.org/dist/v0.10.21/node.lib', libPath: 'node.lib' },
-    x64: { libUrl: 'https://nodejs.org/dist/v0.10.21/x64/node.lib', libPath: 'x64/node.lib' }
+    x64: { libUrl: 'https://nodejs.org/dist/v0.10.21/x64/node.lib', libPath: 'x64/node.lib' },
+    arm64: { libUrl: 'https://nodejs.org/dist/v0.10.21/arm64/node.lib', libPath: 'arm64/node.lib' }
   })
 })
 
@@ -60,7 +62,8 @@ test('test process release - process.version = 0.12.9', function (t) {
     shasumsUrl: 'https://nodejs.org/dist/v0.12.9/SHASUMS256.txt',
     versionDir: '0.12.9',
     ia32: { libUrl: 'https://nodejs.org/dist/v0.12.9/node.lib', libPath: 'node.lib' },
-    x64: { libUrl: 'https://nodejs.org/dist/v0.12.9/x64/node.lib', libPath: 'x64/node.lib' }
+    x64: { libUrl: 'https://nodejs.org/dist/v0.12.9/x64/node.lib', libPath: 'x64/node.lib' },
+    arm64: { libUrl: 'https://nodejs.org/dist/v0.12.9/arm64/node.lib', libPath: 'arm64/node.lib' }
   })
 })
 
@@ -81,7 +84,8 @@ test('test process release - process.version = 0.10.41', function (t) {
     shasumsUrl: 'https://nodejs.org/dist/v0.10.41/SHASUMS256.txt',
     versionDir: '0.10.41',
     ia32: { libUrl: 'https://nodejs.org/dist/v0.10.41/node.lib', libPath: 'node.lib' },
-    x64: { libUrl: 'https://nodejs.org/dist/v0.10.41/x64/node.lib', libPath: 'x64/node.lib' }
+    x64: { libUrl: 'https://nodejs.org/dist/v0.10.41/x64/node.lib', libPath: 'x64/node.lib' },
+    arm64: { libUrl: 'https://nodejs.org/dist/v0.10.41/arm64/node.lib', libPath: 'arm64/node.lib' }
   })
 })
 
@@ -102,7 +106,8 @@ test('test process release - process.release ~ node@0.10.42', function (t) {
     shasumsUrl: 'https://nodejs.org/dist/v0.10.42/SHASUMS256.txt',
     versionDir: '0.10.42',
     ia32: { libUrl: 'https://nodejs.org/dist/v0.10.42/node.lib', libPath: 'node.lib' },
-    x64: { libUrl: 'https://nodejs.org/dist/v0.10.42/x64/node.lib', libPath: 'x64/node.lib' }
+    x64: { libUrl: 'https://nodejs.org/dist/v0.10.42/x64/node.lib', libPath: 'x64/node.lib' },
+    arm64: { libUrl: 'https://nodejs.org/dist/v0.10.42/arm64/node.lib', libPath: 'arm64/node.lib' }
   })
 })
 
@@ -123,7 +128,8 @@ test('test process release - process.release ~ node@0.12.10', function (t) {
     shasumsUrl: 'https://nodejs.org/dist/v0.12.10/SHASUMS256.txt',
     versionDir: '0.12.10',
     ia32: { libUrl: 'https://nodejs.org/dist/v0.12.10/node.lib', libPath: 'node.lib' },
-    x64: { libUrl: 'https://nodejs.org/dist/v0.12.10/x64/node.lib', libPath: 'x64/node.lib' }
+    x64: { libUrl: 'https://nodejs.org/dist/v0.12.10/x64/node.lib', libPath: 'x64/node.lib' },
+    arm64: { libUrl: 'https://nodejs.org/dist/v0.12.10/arm64/node.lib', libPath: 'arm64/node.lib' }
   })
 })
 
@@ -146,7 +152,8 @@ test('test process release - process.release ~ node@4.1.23', function (t) {
     shasumsUrl: 'https://nodejs.org/dist/v4.1.23/SHASUMS256.txt',
     versionDir: '4.1.23',
     ia32: { libUrl: 'https://nodejs.org/dist/v4.1.23/win-x86/node.lib', libPath: 'win-x86/node.lib' },
-    x64: { libUrl: 'https://nodejs.org/dist/v4.1.23/win-x64/node.lib', libPath: 'win-x64/node.lib' }
+    x64: { libUrl: 'https://nodejs.org/dist/v4.1.23/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+    arm64: { libUrl: 'https://nodejs.org/dist/v4.1.23/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
   })
 })
 
@@ -169,7 +176,8 @@ test('test process release - process.release ~ node@4.1.23 / corp build', functi
     shasumsUrl: 'https://some.custom.location/SHASUMS256.txt',
     versionDir: '4.1.23',
     ia32: { libUrl: 'https://some.custom.location/win-x86/node.lib', libPath: 'win-x86/node.lib' },
-    x64: { libUrl: 'https://some.custom.location/win-x64/node.lib', libPath: 'win-x64/node.lib' }
+    x64: { libUrl: 'https://some.custom.location/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+    arm64: { libUrl: 'https://some.custom.location/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
   })
 })
 
@@ -192,7 +200,8 @@ test('test process release - process.release ~ node@4.1.23 --target=0.10.40', fu
     shasumsUrl: 'https://nodejs.org/dist/v0.10.40/SHASUMS256.txt',
     versionDir: '0.10.40',
     ia32: { libUrl: 'https://nodejs.org/dist/v0.10.40/node.lib', libPath: 'node.lib' },
-    x64: { libUrl: 'https://nodejs.org/dist/v0.10.40/x64/node.lib', libPath: 'x64/node.lib' }
+    x64: { libUrl: 'https://nodejs.org/dist/v0.10.40/x64/node.lib', libPath: 'x64/node.lib' },
+    arm64: { libUrl: 'https://nodejs.org/dist/v0.10.40/arm64/node.lib', libPath: 'arm64/node.lib' }
   })
 })
 
@@ -215,7 +224,8 @@ test('test process release - process.release ~ node@4.1.23 --dist-url=https://fo
     shasumsUrl: 'https://foo.bar/baz/v4.1.23/SHASUMS256.txt',
     versionDir: '4.1.23',
     ia32: { libUrl: 'https://foo.bar/baz/v4.1.23/win-x86/node.lib', libPath: 'win-x86/node.lib' },
-    x64: { libUrl: 'https://foo.bar/baz/v4.1.23/win-x64/node.lib', libPath: 'win-x64/node.lib' }
+    x64: { libUrl: 'https://foo.bar/baz/v4.1.23/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+    arm64: { libUrl: 'https://foo.bar/baz/v4.1.23/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
   })
 })
 
@@ -238,7 +248,8 @@ test('test process release - process.release ~ frankenstein@4.1.23', function (t
     shasumsUrl: 'https://frankensteinjs.org/dist/v4.1.23/SHASUMS256.txt',
     versionDir: 'frankenstein-4.1.23',
     ia32: { libUrl: 'https://frankensteinjs.org/dist/v4.1.23/win-x86/frankenstein.lib', libPath: 'win-x86/frankenstein.lib' },
-    x64: { libUrl: 'https://frankensteinjs.org/dist/v4.1.23/win-x64/frankenstein.lib', libPath: 'win-x64/frankenstein.lib' }
+    x64: { libUrl: 'https://frankensteinjs.org/dist/v4.1.23/win-x64/frankenstein.lib', libPath: 'win-x64/frankenstein.lib' },
+    arm64: { libUrl: 'https://frankensteinjs.org/dist/v4.1.23/win-arm64/frankenstein.lib', libPath: 'win-arm64/frankenstein.lib' }
   })
 })
 
@@ -261,7 +272,8 @@ test('test process release - process.release ~ frankenstein@4.1.23 --dist-url=ht
     shasumsUrl: 'http://foo.bar/baz/v4.1.23/SHASUMS256.txt',
     versionDir: 'frankenstein-4.1.23',
     ia32: { libUrl: 'http://foo.bar/baz/v4.1.23/win-x86/frankenstein.lib', libPath: 'win-x86/frankenstein.lib' },
-    x64: { libUrl: 'http://foo.bar/baz/v4.1.23/win-x64/frankenstein.lib', libPath: 'win-x64/frankenstein.lib' }
+    x64: { libUrl: 'http://foo.bar/baz/v4.1.23/win-x64/frankenstein.lib', libPath: 'win-x64/frankenstein.lib' },
+    arm64: { libUrl: 'http://foo.bar/baz/v4.1.23/win-arm64/frankenstein.lib', libPath: 'win-arm64/frankenstein.lib' }
   })
 })
 
@@ -284,7 +296,8 @@ test('test process release - process.release ~ node@4.0.0-rc.4', function (t) {
     shasumsUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/SHASUMS256.txt',
     versionDir: '4.0.0-rc.4',
     ia32: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x86/node.lib', libPath: 'win-x86/node.lib' },
-    x64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x64/node.lib', libPath: 'win-x64/node.lib' }
+    x64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+    arm64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
   })
 })
 
@@ -309,7 +322,8 @@ test('test process release - process.release ~ node@4.0.0-rc.4 passed as argv[0]
     shasumsUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/SHASUMS256.txt',
     versionDir: '4.0.0-rc.4',
     ia32: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x86/node.lib', libPath: 'win-x86/node.lib' },
-    x64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x64/node.lib', libPath: 'win-x64/node.lib' }
+    x64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+    arm64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
   })
 })
 
@@ -334,7 +348,8 @@ test('test process release - process.release ~ node@4.0.0-rc.4 - bogus string pa
     shasumsUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/SHASUMS256.txt',
     versionDir: '4.0.0-rc.4',
     ia32: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x86/node.lib', libPath: 'win-x86/node.lib' },
-    x64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x64/node.lib', libPath: 'win-x64/node.lib' }
+    x64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+    arm64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
   })
 })
 
@@ -359,7 +374,8 @@ test('test process release - NODEJS_ORG_MIRROR', function (t) {
     shasumsUrl: 'http://foo.bar/v4.1.23/SHASUMS256.txt',
     versionDir: '4.1.23',
     ia32: { libUrl: 'http://foo.bar/v4.1.23/win-x86/node.lib', libPath: 'win-x86/node.lib' },
-    x64: { libUrl: 'http://foo.bar/v4.1.23/win-x64/node.lib', libPath: 'win-x64/node.lib' }
+    x64: { libUrl: 'http://foo.bar/v4.1.23/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+    arm64: { libUrl: 'http://foo.bar/v4.1.23/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
   })
 
   delete process.env.NODEJS_ORG_MIRROR


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->
Windows on Arm support is available in some versions of Node.js v12 and Electron v6. This update allows node-gyp to fetch the appropriate node.lib to build native modules. If an arm64 binary is not available for the target node version, it's logged but ignored.

arm64 is not expected to work in very old node.lib distribution formats, the test URLs in these cases are added to be consistent with x64.

