### PR TITLE
Update Readme.md - windows-build-tools@4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You will also need to install:
 
 #### Option 1
 
-Install all the required tools and configurations using Microsoft's [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools) using `npm install --global --production windows-build-tools` from an elevated PowerShell or CMD.exe (run as Administrator).
+Install all the required tools and configurations using Microsoft's [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools) using `npm install --global --production windows-build-tools@4.0.0` from an elevated PowerShell or CMD.exe (run as Administrator).
 
 #### Option 2
 


### PR DESCRIPTION
npm install --global --production windows-build-tools is not working with the latest version but with 4.0.0. I am pretty sure everyone faces this problem.

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

