### PR TITLE
fix: the usage instructions

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -7,8 +7,6 @@ const log = require('npmlog')
 const which = require('which')
 const win = process.platform === 'win32'
 
-exports.usage = 'Invokes `' + (win ? 'msbuild' : 'make') + '` and builds the module'
-
 function build (gyp, argv, callback) {
   var platformMake = 'make'
   if (process.platform === 'aix') {
@@ -203,3 +201,4 @@ function build (gyp, argv, callback) {
 }
 
 module.exports = build
+module.exports.usage = 'Invokes `' + (win ? 'msbuild' : 'make') + '` and builds the module'

--- a/lib/list.js
+++ b/lib/list.js
@@ -24,4 +24,4 @@ function list (gyp, args, callback) {
 }
 
 module.exports = list
-exports.usage = 'Prints a listing of the currently installed node development files'
+module.exports.usage = 'Prints a listing of the currently installed node development files'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
The descriptions of build and list commands are undefined on the usage instruction. This is happening because an error was made while exporting `usage` variable. 

![image](https://user-images.githubusercontent.com/13641726/65531446-2d9d8900-defa-11e9-8f45-9caeb214c73f.png)

<!-- Provide a description of the change -->

