### PR TITLE
Re-introduce duplicate symbol check

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -90,10 +90,14 @@
 
     'conditions': [
       [ 'OS=="mac"', {
+        'cflags': [
+          '-fvisibility=hidden'
+        ],
         'defines': [
           '_DARWIN_USE_64_BIT_INODE=1'
         ],
         'xcode_settings': {
+          'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES', # -fvisibility=hidden
           'DYLIB_INSTALL_NAME_BASE': '@rpath'
         },
       }],

--- a/test/node_modules/duplicate_symbols/binding.cc
+++ b/test/node_modules/duplicate_symbols/binding.cc
@@ -2,9 +2,9 @@
 #include "common.h"
 
 void Init(v8::Local<v8::Object> exports) {
-  exports->Set(Nan::New("pointerCheck").ToLocalChecked(),
-               Nan::New<v8::FunctionTemplate>(Something::PointerCheck)
-      ->GetFunction());
+  Nan::Set(exports, Nan::New("pointerCheck").ToLocalChecked(),
+    Nan::GetFunction(
+      Nan::New<v8::FunctionTemplate>(Something::PointerCheck)).ToLocalChecked());
 }
 
 NODE_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/node_modules/duplicate_symbols/binding.cc
+++ b/test/node_modules/duplicate_symbols/binding.cc
@@ -1,0 +1,10 @@
+#include <nan.h>
+#include "common.h"
+
+void Init(v8::Local<v8::Object> exports) {
+  exports->Set(Nan::New("pointerCheck").ToLocalChecked(),
+               Nan::New<v8::FunctionTemplate>(Something::PointerCheck)
+      ->GetFunction());
+}
+
+NODE_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/node_modules/duplicate_symbols/binding.gyp
+++ b/test/node_modules/duplicate_symbols/binding.gyp
@@ -1,0 +1,19 @@
+{
+  "target_defaults": {
+    "include_dirs": [
+      "<!(node -e \"require('nan')\")"
+    ],
+    "sources": [
+      "binding.cc",
+      "extra.cc"
+    ]
+  },
+  "targets": [
+    {
+      "target_name": "binding1",
+    },
+    {
+      "target_name": "binding2",
+    }
+  ]
+}

--- a/test/node_modules/duplicate_symbols/common.h
+++ b/test/node_modules/duplicate_symbols/common.h
@@ -1,0 +1,37 @@
+#ifndef DUPLICATE_SYMBOLS_COMMON_H_
+#define DUPLICATE_SYMBOLS_COMMON_H_
+
+#include <nan.h>
+
+class Something {
+ public:
+  static void PointerCheck(const Nan::FunctionCallbackInfo<v8::Value>& info);
+};
+
+// Removing the inline keyword below will result in the addon failing to link
+// on OSX because of a duplicate symbol.
+inline void
+Something::PointerCheck(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  v8::Local<v8::Value> v8result;
+
+  if (info.Length() > 0) {
+    // If an argument was passed in, it is a pointer to the `PointerCheck`
+    // method from the other addon. So, we compare it to the value of the
+    // pointer to the `PointerCheck` method in this addon, and return
+    // `"equal"` if they are equal, and `"not equal"` otherwise".
+
+    const char* result =
+      (reinterpret_cast<void*>(Something::PointerCheck) ==
+          info[0].As<v8::External>()->Value()) ?
+              "equal" : "not equal";
+    v8result = Nan::New(result).ToLocalChecked();
+  } else {
+    // If no argument was passed in, we wrap the pointer to the `PointerCheck`
+    // method in this addon into a `v8::External` and pass it into JavaScript.
+    v8result = Nan::New<v8::External>(
+        reinterpret_cast<void*>(Something::PointerCheck));
+  }
+  info.GetReturnValue().Set(v8result);
+}
+
+#endif  // DUPLICATE_SYMBOLS_COMMON_H_

--- a/test/node_modules/duplicate_symbols/extra.cc
+++ b/test/node_modules/duplicate_symbols/extra.cc
@@ -1,0 +1,6 @@
+#include "common.h"
+
+// It is important that common.h be included from two different translation
+// units, because doing so can create duplicate symbols in some instances. If
+// it does so and fails to build because of it, that is considered a test
+// failure.

--- a/test/node_modules/duplicate_symbols/index.js
+++ b/test/node_modules/duplicate_symbols/index.js
@@ -1,0 +1,5 @@
+'use strict'
+module.exports = {
+  pointerCheck1: require('bindings')('binding1').pointerCheck,
+  pointerCheck2: require('bindings')('binding2').pointerCheck
+};

--- a/test/node_modules/duplicate_symbols/package.json
+++ b/test/node_modules/duplicate_symbols/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "bindings": "~1.2.1",
-    "nan": "^2.0.0"
+    "nan": "^2.14.0"
   },
   "scripts": {
     "test": "node index.js"

--- a/test/node_modules/duplicate_symbols/package.json
+++ b/test/node_modules/duplicate_symbols/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "duplicate_symbols",
+  "version": "0.0.0",
+  "description": "Duplicate Symbols Test",
+  "main": "index.js",
+  "private": true,
+  "dependencies": {
+    "bindings": "~1.2.1",
+    "nan": "^2.0.0"
+  },
+  "scripts": {
+    "test": "node index.js"
+  }
+}

--- a/test/test-addon.js
+++ b/test/test-addon.js
@@ -23,6 +23,15 @@ function getEncoding () {
   return execFileSync('python', ['-c', code]).toString().trim()
 }
 
+function runDuplicateBindings () {
+  const hostProcess = process.execPath
+  const testCode =
+    'console.log((function(bindings) {' +
+    'return bindings.pointerCheck1(bindings.pointerCheck2());' +
+    "})(require('duplicate_symbols')))"
+  return execFileSync(hostProcess, ['-e', testCode], { cwd: __dirname }).toString()
+}
+
 function checkCharmapValid () {
   var data
   try {
@@ -49,6 +58,21 @@ test('build simple addon', function (t) {
   })
   proc.stdout.setEncoding('utf-8')
   proc.stderr.setEncoding('utf-8')
+})
+
+test('make sure addon symbols do not overlap', function (t) {
+  t.plan(3)
+
+  var addonPath = path.resolve(__dirname, 'node_modules', 'duplicate_symbols')
+  // Set the loglevel otherwise the output disappears when run via 'npm test'
+  var cmd = [nodeGyp, 'rebuild', '-C', addonPath, '--loglevel=verbose']
+  execFile(process.execPath, cmd, function (err, stdout, stderr) {
+    var logLines = stderr.trim().split(/\r?\n/)
+    var lastLine = logLines[logLines.length - 1]
+    t.strictEqual(err, null)
+    t.strictEqual(lastLine, 'gyp info ok', 'should end in ok')
+    t.strictEqual(runDuplicateBindings().trim(), 'not equal')
+  })
 })
 
 test('build simple addon in path with non-ascii characters', function (t) {


### PR DESCRIPTION
Originally in #1689 and was reverted in #1828, we decided in https://github.com/nodejs/node/pull/28647#issuecomment-511715968 it was "breaking" as far as Node was concerned.

Given the dependency chain to get to Node I'm not sure what to do about this. Is it enough to put a semver-major label on it? It's still likely to bubble up to Node 12 (and maybe 10) through their regular npm updates though. Is there a rule in place that would prevent certain versions of npm getting into Node 12? And how do we couple that with our moves to get to Python 3 support and the semver-major nature of them? Do we then prevent Node 12 from getting Python 3 support if we block a semver-major release of node-gyp getting back in to older versions of Node?

/cc @gabrielschulhof @bnoordhuis @nodejs/npm