### PR TITLE
more decode stdout on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
       before_install: nvm install 12
     - name: "Python 3.7 on macOS"
       os: osx
-      osx_image: xcode11
+      #osx_image: xcode11
       language: shell  # 'language: python' is not yet supported on macOS
       env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
       before_install: HOMEBREW_NO_AUTO_UPDATE=1 brew install npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
       before_install: nvm install 12
     - name: "Python 3.7 on macOS"
       os: osx
-      #osx_image: xcode11
+      osx_image: xcode11
       language: shell  # 'language: python' is not yet supported on macOS
       env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
       before_install: HOMEBREW_NO_AUTO_UPDATE=1 brew install npm

--- a/gyp/gyp_main.py
+++ b/gyp/gyp_main.py
@@ -8,13 +8,17 @@ import os
 import sys
 import subprocess
 
+PY3 = bytes != str
+
 # Below IsCygwin() function copied from pylib/gyp/common.py
 def IsCygwin():
   try:
     out = subprocess.Popen("uname",
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT)
-    stdout,stderr = out.communicate()
+    stdout, stderr = out.communicate()
+    if PY3:
+      stdout = stdout.decode("utf-8")
     return "CYGWIN" in str(stdout)
   except Exception:
     return False
@@ -27,7 +31,9 @@ def UnixifyPath(path):
     out = subprocess.Popen(["cygpath", "-u", path],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT)
-    stdout,stderr = out.communicate()
+    stdout, stderr = out.communicate()
+    if PY3:
+      stdout = stdout.decode("utf-8")
     return str(stdout)
   except Exception:
     return path

--- a/gyp/pylib/gyp/common.py
+++ b/gyp/pylib/gyp/common.py
@@ -11,6 +11,8 @@ import tempfile
 import sys
 import subprocess
 
+PY3 = bytes != str
+
 
 # A minimal memoizing decorator. It'll blow up if the args aren't immutable,
 # among other "problems".
@@ -623,7 +625,9 @@ def IsCygwin():
     out = subprocess.Popen("uname",
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT)
-    stdout,stderr = out.communicate()
+    stdout, stderr = out.communicate()
+    if PY3:
+      stdout = stdout.decode("utf-8")
     return "CYGWIN" in str(stdout)
   except Exception:
     return False


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->
Python 2 does not make a distinction between bytes and str but Python 3 does. When we make calls to subprocess.Popen() on Python 3 we should stdout.decode("utf8") before performing string manipulations on it.

Like #1890 

Addresses the code review comments at https://github.com/nodejs/node-gyp/pull/1893#pullrequestreview-293495919
