### PR TITLE
lib: try to find `python` after `python3`

### DIFF
--- a/lib/find-python.js
+++ b/lib/find-python.js
@@ -26,8 +26,8 @@ PythonFinder.prototype = {
   win: win,
   pyLauncher: 'py.exe',
   winDefaultLocations: [
-    path.join(process.env.SystemDrive || 'C:', 'Python27', 'python.exe'),
-    path.join(process.env.SystemDrive || 'C:', 'Python37', 'python.exe')
+    path.join(process.env.SystemDrive || 'C:', 'Python37', 'python.exe'),
+    path.join(process.env.SystemDrive || 'C:', 'Python27', 'python.exe')
   ],
 
   // Logs a message at verbose level, but also saves it to be displayed later
@@ -88,14 +88,14 @@ PythonFinder.prototype = {
           arg: this.env.PYTHON
         },
         {
-          before: () => { this.addLog('checking if "python" can be used') },
-          check: this.checkCommand,
-          arg: 'python'
-        },
-        {
           before: () => { this.addLog('checking if "python3" can be used') },
           check: this.checkCommand,
           arg: 'python3'
+        },
+        {
+          before: () => { this.addLog('checking if "python" can be used') },
+          check: this.checkCommand,
+          arg: 'python'
         },
         {
           before: () => { this.addLog('checking if "python2" can be used') },

--- a/lib/find-python.js
+++ b/lib/find-python.js
@@ -105,13 +105,6 @@ PythonFinder.prototype = {
       ]
 
       if (this.win) {
-        checks.push({
-          before: () => {
-            this.addLog(
-              'checking if the py launcher can be used to find Python 2')
-          },
-          check: this.checkPyLauncher
-        })
         for (var i = 0; i < this.winDefaultLocations.length; ++i) {
           const location = this.winDefaultLocations[i]
           checks.push({
@@ -123,6 +116,13 @@ PythonFinder.prototype = {
             arg: location
           })
         }
+        checks.push({
+          before: () => {
+            this.addLog(
+              'checking if the py launcher can be used to find Python 2')
+          },
+          check: this.checkPyLauncher
+        })
       }
 
       return checks

--- a/test/test-find-python.js
+++ b/test/test-find-python.js
@@ -159,6 +159,8 @@ test('find python - no python, use python launcher', function (t) {
     }
     if (/sys\.executable/.test(args[args.length - 1])) {
       cb(new Error('not found'))
+    } else if (f.winDefaultLocations.includes(program)) {
+      cb(new Error('not found'))
     } else if (/sys\.version_info/.test(args[args.length - 1])) {
       if (program === 'Z:\\snake.exe') {
         cb(null, '2.7.14')
@@ -178,7 +180,7 @@ test('find python - no python, use python launcher', function (t) {
 })
 
 test('find python - no python, no python launcher, good guess', function (t) {
-  t.plan(4)
+  t.plan(2)
 
   var re = /C:[\\/]Python37[\\/]python[.]exe/
   var f = new TestPythonFinder(null, done)
@@ -186,16 +188,13 @@ test('find python - no python, no python launcher, good guess', function (t) {
 
   f.execFile = function (program, args, opts, cb) {
     if (program === 'py.exe') {
-      f.execFile = function (program, args, opts, cb) {
-        poison(f, 'execFile')
-        t.ok(re.test(program))
-        t.ok(/sys\.version_info/.test(args[args.length - 1]))
-        cb(null, '2.7.14')
-      }
       return cb(new Error('not found'))
     }
     if (/sys\.executable/.test(args[args.length - 1])) {
       cb(new Error('not found'))
+    } else if (re.test(program) &&
+               /sys\.version_info/.test(args[args.length - 1])) {
+      cb(null, '3.7.3')
     } else {
       t.fail()
     }

--- a/test/test-find-python.js
+++ b/test/test-find-python.js
@@ -180,7 +180,7 @@ test('find python - no python, use python launcher', function (t) {
 test('find python - no python, no python launcher, good guess', function (t) {
   t.plan(4)
 
-  var re = /C:[\\/]Python27[\\/]python[.]exe/
+  var re = /C:[\\/]Python37[\\/]python[.]exe/
   var f = new TestPythonFinder(null, done)
   f.win = true
 


### PR DESCRIPTION
Unadorned `python` can be either Python 2 or Python 3, but it is likely
to be Python 2 for quite a while.

To find Python3, it is recommended to use the explicit name `python3`.

See:
- https://www.python.org/dev/peps/pep-0394/#for-python-runtime-distributors
- https://github.com/nodejs/node-gyp/pull/1892#issuecomment-537637433

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

