### PR TITLE
v5.x: Add Python 3.5 and 3.6 tests on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,14 @@ matrix:
       python: 3.7
       env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
       before_install: nvm install 10
+    - name: "Node.js 12 & Python 3.5 on Linux"
+      python: 3.5
+      env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
+      before_install: nvm install 12
+    - name: "Node.js 12 & Python 3.6 on Linux"
+      python: 3.6
+      env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
+      before_install: nvm install 12
     - name: "Node.js 12 & Python 3.7 on Linux"
       python: 3.7
       env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ You will also need to install:
 
 ### On Unix
 
-   * `python v2.7, v3.5, v3.6, or v3.7`
+   * `python` (`v2.7` recommended, `v3.x.x` is __*not*__ supported)
    * `make`
    * A proper C/C++ compiler toolchain, like [GCC](https://gcc.gnu.org)
 
 ### On macOS
 
-   * `python v2.7, v3.5, v3.6, or v3.7`
+   * `python` (`v2.7` recommended, `v3.x.x` is __*not*__ supported) (already installed on macOS)
    * [Xcode](https://developer.apple.com/xcode/download/)
      * You also need to install the `XCode Command Line Tools` by running `xcode-select --install`. Alternatively, if you already have the full Xcode installed, you can find them under the menu `Xcode -> Open Developer Tool -> More Developer Tools...`. This step will install `clang`, `clang++`, and `make`.
 
@@ -62,7 +62,7 @@ If you have multiple Python versions installed, you can identify which Python
 version `node-gyp` uses by setting the `--python` variable:
 
 ``` bash
-$ node-gyp <command> --python /path/to/executable/python
+$ node-gyp <command> --python /path/to/executable/python2.7
 ```
 
 If `node-gyp` is called by way of `npm`, *and* you have multiple versions of
@@ -70,7 +70,7 @@ Python installed, then you can set `npm`'s 'python' config key to the appropriat
 value:
 
 ``` bash
-$ npm config set python /path/to/executable/python
+$ npm config set python /path/to/executable/python2.7
 ```
 
 ## How to Use

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ You will also need to install:
 
 ### On Unix
 
-   * `python` (`v2.7` recommended, `v3.x.x` is __*not*__ supported)
+   * `python v2.7, v3.5, v3.6, or v3.7`
    * `make`
    * A proper C/C++ compiler toolchain, like [GCC](https://gcc.gnu.org)
 
 ### On macOS
 
-   * `python` (`v2.7` recommended, `v3.x.x` is __*not*__ supported) (already installed on macOS)
+   * `python v2.7, v3.5, v3.6, or v3.7`
    * [Xcode](https://developer.apple.com/xcode/download/)
      * You also need to install the `XCode Command Line Tools` by running `xcode-select --install`. Alternatively, if you already have the full Xcode installed, you can find them under the menu `Xcode -> Open Developer Tool -> More Developer Tools...`. This step will install `clang`, `clang++`, and `make`.
 
@@ -62,7 +62,7 @@ If you have multiple Python versions installed, you can identify which Python
 version `node-gyp` uses by setting the `--python` variable:
 
 ``` bash
-$ node-gyp <command> --python /path/to/executable/python2.7
+$ node-gyp <command> --python /path/to/executable/python
 ```
 
 If `node-gyp` is called by way of `npm`, *and* you have multiple versions of
@@ -70,7 +70,7 @@ Python installed, then you can set `npm`'s 'python' config key to the appropriat
 value:
 
 ``` bash
-$ npm config set python /path/to/executable/python2.7
+$ npm config set python /path/to/executable/python
 ```
 
 ## How to Use


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->
As requested at https://github.com/nodejs/node-gyp/pull/1905#issue-324009245 this PR features #1903 -like changes but this PR is based on the v5.x branch and is intended to land in the v5.0.5 release.

The Travis changes mean that we are now testing on Python 2.7, 3.5, 3.6, and 3.7 os on Unix and macOS we will support all four.  On Windows, we are not recommending the use of Micorsoft's Python so this release will only support legacy Python on Windows.
