### PR TITLE
lib: accept Python 3 after Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,25 +31,25 @@ matrix:
 
     - name: "Node.js 6 & Python 3.7 on Linux"
       python: 3.7
-      env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
+      env: NODE_GYP_FORCE_PYTHON=python3
       before_install: nvm install 6
     - name: "Node.js 8 & Python 3.7 on Linux"
       python: 3.7
-      env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
+      env: NODE_GYP_FORCE_PYTHON=python3
       before_install: nvm install 8
     - name: "Node.js 10 & Python 3.7 on Linux"
       python: 3.7
-      env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
+      env: NODE_GYP_FORCE_PYTHON=python3
       before_install: nvm install 10
     - name: "Node.js 12 & Python 3.7 on Linux"
       python: 3.7
-      env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
+      env: NODE_GYP_FORCE_PYTHON=python3
       before_install: nvm install 12
     - name: "Python 3.7 on macOS"
       os: osx
       #osx_image: xcode11
       language: shell  # 'language: python' is not yet supported on macOS
-      env: NODE_GYP_FORCE_PYTHON=python3 EXPERIMENTAL_NODE_GYP_PYTHON3=1
+      env: NODE_GYP_FORCE_PYTHON=python3
       before_install: HOMEBREW_NO_AUTO_UPDATE=1 brew install npm
     - name: "Node.js 12 & Python 3.7 on Windows"
       os: windows
@@ -58,7 +58,6 @@ matrix:
       env: >-
         PATH=/c/Python37:/c/Python37/Scripts:$PATH
         NODE_GYP_FORCE_PYTHON=/c/Python37/python.exe
-        EXPERIMENTAL_NODE_GYP_PYTHON3=1
       before_install: choco install python
 
 install:
@@ -71,6 +70,7 @@ before_script:
   # exit-zero treats all errors as warnings.  Two space indentation is OK.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --ignore=E111,E114,W503 --max-complexity=10 --max-line-length=127 --statistics
   - npm install
+  - npm list
 script:
   - node -e 'require("npmlog").level="verbose"; require("./lib/find-python")(null,()=>{})'
   - npm test

--- a/lib/find-python.js
+++ b/lib/find-python.js
@@ -18,8 +18,7 @@ PythonFinder.prototype = {
   log: logWithPrefix(log, 'find Python'),
   argsExecutable: ['-c', 'import sys; print(sys.executable);'],
   argsVersion: ['-c', 'import sys; print("%s.%s.%s" % sys.version_info[:3]);'],
-  semverRange: process.env.EXPERIMENTAL_NODE_GYP_PYTHON3 ? '2.7.x || >=3.5.0'
-    : '>=2.6.0 <3.0.0',
+  semverRange: '2.7.x || >=3.5.0',
 
   // These can be overridden for testing:
   execFile: cp.execFile,
@@ -97,6 +96,11 @@ PythonFinder.prototype = {
           before: () => { this.addLog('checking if "python2" can be used') },
           check: this.checkCommand,
           arg: 'python2'
+        },
+        {
+          before: () => { this.addLog('checking if "python3" can be used') },
+          check: this.checkCommand,
+          arg: 'python3'
         }
       ]
 
@@ -286,7 +290,7 @@ PythonFinder.prototype = {
     //                                                           X
     const info = [
       '**********************************************************',
-      'You need to install the latest version of Python 2.7.',
+      'You need to install the latest version of Python.',
       'Node-gyp should be able to find and use Python. If not,',
       'you can try one of the following options:',
       `- Use the switch --python="${pathExample}"`,


### PR DESCRIPTION
Python 3 is allowed as a compatible Python, but its looked for after
Python 2.

Backport-of: https://github.com/nodejs/node-gyp/pull/1844

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

