### PR TITLE
update deps to roughly match current npm@6

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,26 +22,26 @@
   "bin": "./bin/node-gyp.js",
   "main": "./lib/node-gyp.js",
   "dependencies": {
-    "env-paths": "^1.0.0",
-    "glob": "^7.0.3",
-    "graceful-fs": "^4.1.2",
-    "mkdirp": "^0.5.0",
-    "nopt": "2 || 3",
-    "npmlog": "0 || 1 || 2 || 3 || 4",
-    "request": "^2.87.0",
-    "rimraf": "2",
-    "semver": "~5.3.0",
+    "env-paths": "^2.2.0",
+    "glob": "^7.1.4",
+    "graceful-fs": "^4.2.2",
+    "mkdirp": "^0.5.1",
+    "nopt": "^4.0.1",
+    "npmlog": "^4.1.2",
+    "request": "^2.88.0",
+    "rimraf": "^2.6.3",
+    "semver": "^5.7.1",
     "tar": "^4.4.12",
-    "which": "1"
+    "which": "^1.3.1"
   },
   "engines": {
     "node": ">= 6.0.0"
   },
   "devDependencies": {
-    "bindings": "~1.2.1",
-    "nan": "^2.0.0",
-    "require-inject": "~1.3.0",
-    "standard": "~14.3.1",
+    "bindings": "^1.5.0",
+    "nan": "^2.14.0",
+    "require-inject": "^1.4.4",
+    "standard": "^14.3.1",
     "tap": "~12.7.0"
   },
   "scripts": {


### PR DESCRIPTION
Some overdue dependency updates. I've had a look through the details of most of these updates and I'm not finding anything that would likely impact us. I'm also removing the broad dependency options (`||`) which used to be useful when npm was shipping very different versions. I believe they're just shipping version 6 now. Most of the changes here are matching the dependencies that the current npm master is using. I think with these changes, `env-paths` might be the only thing we're pulling in to npm when bundled.

There's newer versions of some of these, like tar (this update was prompted by #1918), but npm isn't shipping that yet. I suspect npm is holding back on a lot of updates to maintain older Node compatibility (the README says v6 but .travis.yml says v8).

I believe these changes can be safely backported to v5.x.