### PR TITLE
travis: add Windows + Python 3.8 to the mix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,14 @@ matrix:
       env: >-
         PATH=/c/Python37:/c/Python37/Scripts:$PATH
         NODE_GYP_FORCE_PYTHON=/c/Python37/python.exe
+      before_install: choco install python --version=3.7.4
+    - name: "Node.js 12 & Python 3.8 on Windows"
+      os: windows
+      language: node_js
+      node_js: 12  # node
+      env: >-
+        PATH=/c/Python38:/c/Python38/Scripts:$PATH
+        NODE_GYP_FORCE_PYTHON=/c/Python38/python.exe
       before_install: choco install python
 
 install:


### PR DESCRIPTION
Windows Python 3 tests are currently failing in travis because choco has switched `python` to 3.8 but we're setting the PATH for 3.7. So I've fixed the 3.7 tests to the last 3.7 version and introduced a 3.8 test for Windows.

Python 3.8 isn't currently available on the other platforms, easily anyway, so they're not added in this.