### PR TITLE
Bug fix/fix error handling

### DIFF
--- a/gyp/pylib/gyp/generator/make.py
+++ b/gyp/pylib/gyp/generator/make.py
@@ -1776,7 +1776,6 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
       # - The multi-output rule will have an do-nothing recipe.
 
       # Hash the target name to avoid generating overlong filenames.
-
       cmddigest = hashlib.sha1((command or self.target).encode('utf-8')).hexdigest()
       intermediate = "%s.intermediate" % cmddigest
       self.WriteLn('%s: %s' % (' '.join(outputs), intermediate))

--- a/gyp/pylib/gyp/generator/make.py
+++ b/gyp/pylib/gyp/generator/make.py
@@ -1776,7 +1776,7 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
       # - The multi-output rule will have an do-nothing recipe.
 
       # Hash the target name to avoid generating overlong filenames.
-      cmddigest = hashlib.sha1(command if command else self.target).hexdigest()
+      cmddigest = hashlib.sha1(command.encode('utf-8') if command else self.target.encode('utf-8')).hexdigest()
       intermediate = "%s.intermediate" % cmddigest
       self.WriteLn('%s: %s' % (' '.join(outputs), intermediate))
       self.WriteLn('\t%s' % '@:')

--- a/gyp/pylib/gyp/generator/make.py
+++ b/gyp/pylib/gyp/generator/make.py
@@ -1776,7 +1776,8 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
       # - The multi-output rule will have an do-nothing recipe.
 
       # Hash the target name to avoid generating overlong filenames.
-      cmddigest = hashlib.sha1(command.encode('utf-8') if command else self.target.encode('utf-8')).hexdigest()
+
+      cmddigest = hashlib.sha1((command or self.target).encode('utf-8')).hexdigest()
       intermediate = "%s.intermediate" % cmddigest
       self.WriteLn('%s: %s' % (' '.join(outputs), intermediate))
       self.WriteLn('\t%s' % '@:')

--- a/gyp/pylib/gyp/input.py
+++ b/gyp/pylib/gyp/input.py
@@ -911,9 +911,6 @@ def ExpandVariables(input, phase, variables, build_file):
           p_stdout, p_stderr = p.communicate('')
 
           if p.wait() != 0 or p_stderr:
-            sys.stderr.write(p_stderr)
-            # Simulate check_call behavior, since check_call only exists
-            # in python 2.5 and later.
             raise GypError("Call to '%s' returned exit status %d while in %s." %
                            (contents, p.returncode, build_file))
           replacement = p_stdout.rstrip()

--- a/gyp/pylib/gyp/input.py
+++ b/gyp/pylib/gyp/input.py
@@ -239,7 +239,7 @@ def LoadOneBuildFile(build_file_path, data, aux_data, includes,
     if check:
       build_file_data = CheckedEval(build_file_contents)
     else:
-      build_file_data = eval(build_file_contents, {'__builtins__': None},
+      build_file_data = eval(build_file_contents, {'__builtins__': {}},
                              None)
   except SyntaxError as e:
     e.filename = build_file_path
@@ -1087,7 +1087,7 @@ def EvalSingleCondition(
     else:
       ast_code = compile(cond_expr_expanded, '<string>', 'eval')
       cached_conditions_asts[cond_expr_expanded] = ast_code
-    if eval(ast_code, {'__builtins__': None}, variables):
+    if eval(ast_code, {'__builtins__': {}}, variables):
       return true_dict
     return false_dict
   except SyntaxError as e:

--- a/gyp/pylib/gyp/input.py
+++ b/gyp/pylib/gyp/input.py
@@ -911,7 +911,9 @@ def ExpandVariables(input, phase, variables, build_file):
           p_stdout, p_stderr = p.communicate('')
 
           if p.wait() != 0 or p_stderr:
-            sys.stderr.write(p_stderr.decode('utf-8'))
+            sys.stderr.write(p_stderr)
+            # Simulate check_call behavior, since check_call only exists
+            # in python 2.5 and later.
             raise GypError("Call to '%s' returned exit status %d while in %s." %
                            (contents, p.returncode, build_file))
           replacement = p_stdout.rstrip()

--- a/gyp/pylib/gyp/input.py
+++ b/gyp/pylib/gyp/input.py
@@ -911,6 +911,7 @@ def ExpandVariables(input, phase, variables, build_file):
           p_stdout, p_stderr = p.communicate('')
 
           if p.wait() != 0 or p_stderr:
+            sys.stderr.write(p_stderr.decode('utf-8'))
             raise GypError("Call to '%s' returned exit status %d while in %s." %
                            (contents, p.returncode, build_file))
           replacement = p_stdout.rstrip()


### PR DESCRIPTION
these 3 changes seem to be related to the python 3 migration, the parameter types aren't compatible. 

`sys.stderr.write(p_stderr)` will throw with: `TypeError: write() argument must be str, not bytes` ; the followup comment references python 2.5, raising the error gives the correct behaviour. 

I ran into this error by a gyp line spawning a process exiting errnously. 

The `None` as a parameter to eval `__builtins__` leads to the exception `Exception: 'NoneType' object is not subscriptable`. 
