### PR TITLE
install: always download SHA sums on Windows

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -224,8 +224,8 @@ function install (fs, gyp, argv, callback) {
         var installVersionPath = path.resolve(devDir, 'installVersion')
         fs.writeFile(installVersionPath, gyp.package.installVersion + '\n', deref)
 
-        // Only download SHASUMS.txt if not using tarPath override
-        if (!tarPath) {
+        // Only download SHASUMS.txt if we downloaded something in need of SHA verification
+        if (!tarPath || win) {
           // download SHASUMS.txt
           async++
           downloadShasums(deref)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

Fixes #1924. Mitigates #1002.

On Windows, we download `node.lib` and check its SHA256 sum. That means that on Windows, we also need to download the expected SHA256 sums to check against, always.