### PR TITLE
src,win: allow 403 errors for arm64 node.lib

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -323,7 +323,7 @@ function install (fs, gyp, argv, callback) {
 
             req.on('error', done)
             req.on('response', function (res) {
-              if (res.statusCode === 404) {
+              if (res.statusCode === 403 || res.statusCode === 404) {
                 if (arch === 'arm64') {
                   // Arm64 is a newer platform on Windows and not all node distributions provide it.
                   log.verbose(`${name} was not found in ${libUrl}`)


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->
The servers hosting the header packages for Electron return 403
instead of 404 for the constructed URL for arm64 node.lib for
older releases that do not support arm64.

Fixes: https://github.com/nodejs/node-gyp/issues/1933
