### PR TITLE
Finish decode stdout on Python 3

### DIFF
--- a/gyp/pylib/gyp/MSVSVersion.py
+++ b/gyp/pylib/gyp/MSVSVersion.py
@@ -12,6 +12,8 @@ import sys
 import gyp
 import glob
 
+PY3 = bytes != str
+
 
 class VisualStudioVersion(object):
   """Information regarding a version of Visual Studio."""
@@ -132,6 +134,8 @@ def _RegistryQueryBase(sysdir, key, value):
   # Obtain the stdout from reg.exe, reading to the end so p.returncode is valid
   # Note that the error text may be in [1] in some cases
   text = p.communicate()[0]
+  if PY3:
+    text = text.decode('utf-8')
   # Check return code from reg.exe; officially 0==success and 1==error
   if p.returncode:
     return None
@@ -334,6 +338,8 @@ def _ConvertToCygpath(path):
   if sys.platform == 'cygwin':
     p = subprocess.Popen(['cygpath', path], stdout=subprocess.PIPE)
     path = p.communicate()[0].strip()
+    if PY3:
+      path = path.decode('utf-8')
   return path
 
 

--- a/gyp/pylib/gyp/generator/eclipse.py
+++ b/gyp/pylib/gyp/generator/eclipse.py
@@ -26,6 +26,8 @@ import gyp.msvs_emulation
 import shlex
 import xml.etree.cElementTree as ET
 
+PY3 = bytes != str
+
 generator_wants_static_library_dependencies_adjusted = False
 
 generator_default_variables = {
@@ -97,6 +99,8 @@ def GetAllIncludeDirectories(target_list, target_dicts,
     proc = subprocess.Popen(args=command, stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output = proc.communicate()[1]
+    if PY3:
+      output = output.decode('utf-8')
     # Extract the list of include dirs from the output, which has this format:
     #   ...
     #   #include "..." search starts here:
@@ -234,6 +238,8 @@ def GetAllDefines(target_list, target_dicts, data, config_name, params,
     cpp_proc = subprocess.Popen(args=command, cwd='.',
                                 stdin=subprocess.PIPE, stdout=subprocess.PIPE)
     cpp_output = cpp_proc.communicate()[0]
+    if PY3:
+      cpp_output = cpp_output.decode('utf-8')
     cpp_lines = cpp_output.split('\n')
     for cpp_line in cpp_lines:
       if not cpp_line.strip():

--- a/gyp/pylib/gyp/generator/msvs.py
+++ b/gyp/pylib/gyp/generator/msvs.py
@@ -25,6 +25,8 @@ import gyp.MSVSVersion as MSVSVersion
 from gyp.common import GypError
 from gyp.common import OrderedSet
 
+PY3 = bytes != str
+
 # TODO: Remove once bots are on 2.7, http://crbug.com/241769
 def _import_OrderedDict():
   import collections
@@ -124,6 +126,8 @@ def _GetDomainAndUserName():
       call = subprocess.Popen(['net', 'config', 'Workstation'],
                               stdout=subprocess.PIPE)
       config = call.communicate()[0]
+      if PY3:
+        config = config.decode('utf-8')
       username_re = re.compile(r'^User name\s+(\S+)', re.MULTILINE)
       username_match = username_re.search(config)
       if username_match:

--- a/gyp/pylib/gyp/input.py
+++ b/gyp/pylib/gyp/input.py
@@ -22,6 +22,7 @@ import traceback
 from gyp.common import GypError
 from gyp.common import OrderedSet
 
+PY3 = bytes != str
 
 # A list of types that are treated as linkable.
 linkable_types = [
@@ -909,6 +910,9 @@ def ExpandVariables(input, phase, variables, build_file):
                            (e, contents, build_file))
 
           p_stdout, p_stderr = p.communicate('')
+          if PY3:
+            p_stdout = p_stdout.decode('utf-8')
+            p_stderr = p_stderr.decode('utf-8')
 
           if p.wait() != 0 or p_stderr:
             sys.stderr.write(p_stderr)

--- a/gyp/pylib/gyp/mac_tool.py
+++ b/gyp/pylib/gyp/mac_tool.py
@@ -23,6 +23,8 @@ import subprocess
 import sys
 import tempfile
 
+PY3 = bytes != str
+
 
 def main(args):
   executor = MacTool()
@@ -243,6 +245,8 @@ class MacTool(object):
     env['ZERO_AR_DATE'] = '1'
     libtoolout = subprocess.Popen(cmd_list, stderr=subprocess.PIPE, env=env)
     _, err = libtoolout.communicate()
+    if PY3:
+      err = err.decode('utf-8')
     for line in err.splitlines():
       if not libtool_re.match(line) and not libtool_re5.match(line):
         print(line, file=sys.stderr)

--- a/gyp/pylib/gyp/msvs_emulation.py
+++ b/gyp/pylib/gyp/msvs_emulation.py
@@ -16,6 +16,7 @@ from gyp.common import OrderedSet
 import gyp.MSVSUtil
 import gyp.MSVSVersion
 
+PY3 = bytes != str
 
 windows_quoter_regex = re.compile(r'(\\*)"')
 
@@ -126,7 +127,10 @@ def _FindDirectXInstallation():
     # Setup params to pass to and attempt to launch reg.exe.
     cmd = ['reg.exe', 'query', r'HKLM\Software\Microsoft\DirectX', '/s']
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    for line in p.communicate()[0].splitlines():
+    stdout = p.communicate()[0]
+    if PY3:
+      stdout = stdout.decode('utf-8')
+    for line in stdout.splitlines():
       if 'InstallPath' in line:
         dxsdk_dir = line.split('    ')[3] + "\\"
 
@@ -1038,6 +1042,8 @@ def GenerateEnvironmentFiles(toplevel_build_dir, generator_flags,
     popen = subprocess.Popen(
         args, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     variables, _ = popen.communicate()
+    if PY3:
+      variables = variables.decode('utf-8')
     env = _ExtractImportantEnvironment(variables)
 
     # Inject system includes from gyp files into INCLUDE.
@@ -1057,6 +1063,8 @@ def GenerateEnvironmentFiles(toplevel_build_dir, generator_flags,
       'for', '%i', 'in', '(cl.exe)', 'do', '@echo', 'LOC:%~$PATH:i'))
     popen = subprocess.Popen(args, shell=True, stdout=subprocess.PIPE)
     output, _ = popen.communicate()
+    if PY3:
+      output = output.decode('utf-8')
     cl_paths[arch] = _ExtractCLPath(output)
   return cl_paths
 

--- a/gyp/pylib/gyp/win_tool.py
+++ b/gyp/pylib/gyp/win_tool.py
@@ -20,6 +20,7 @@ import string
 import sys
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+PY3 = bytes != str
 
 # A regex matching an argument corresponding to the output filename passed to
 # link.exe.
@@ -124,6 +125,8 @@ class WinTool(object):
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)
     out, _ = link.communicate()
+    if PY3:
+      out = out.decode('utf-8')
     for line in out.splitlines():
       if (not line.startswith('   Creating library ') and
           not line.startswith('Generating code') and
@@ -215,6 +218,8 @@ class WinTool(object):
     popen = subprocess.Popen(args, shell=True, env=env,
                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = popen.communicate()
+    if PY3:
+      out = out.decode('utf-8')
     for line in out.splitlines():
       if line and 'manifest authoring warning 81010002' not in line:
         print(line)
@@ -247,6 +252,8 @@ class WinTool(object):
     popen = subprocess.Popen(args, shell=True, env=env,
                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = popen.communicate()
+    if PY3:
+      out = out.decode('utf-8')
     # Filter junk out of stdout, and write filtered versions. Output we want
     # to filter is pairs of lines that look like this:
     # Processing C:\Program Files (x86)\Microsoft SDKs\...\include\objidl.idl
@@ -266,6 +273,8 @@ class WinTool(object):
     popen = subprocess.Popen(args, shell=True, env=env,
                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = popen.communicate()
+    if PY3:
+      out = out.decode('utf-8')
     for line in out.splitlines():
       if (not line.startswith('Copyright (C) Microsoft Corporation') and
           not line.startswith('Microsoft (R) Macro Assembler') and
@@ -281,6 +290,8 @@ class WinTool(object):
     popen = subprocess.Popen(args, shell=True, env=env,
                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = popen.communicate()
+    if PY3:
+      out = out.decode('utf-8')
     for line in out.splitlines():
       if (not line.startswith('Microsoft (R) Windows (R) Resource Compiler') and
           not line.startswith('Copyright (C) Microsoft Corporation') and


### PR DESCRIPTION
Fixes: #1943

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Like #1890 and #1894 but for all remaining instances of popen.communicate() in this repo.  This conditionally decodes the bytes that come from popen.communicate() into str for proper handling in Python 3.

`grep -r communicate .` and ensure all stdout and stderr instances are decoded on Python 3.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

