### PR TITLE
Fix toolkit selection for VS 2017/2019

### DIFF
--- a/gyp/pylib/gyp/MSVSVersion.py
+++ b/gyp/pylib/gyp/MSVSVersion.py
@@ -236,6 +236,24 @@ def _CreateVersion(name, path, sdk_based=False):
   if path:
     path = os.path.normpath(path)
   versions = {
+      '2019': VisualStudioVersion('2019',
+                                  'Visual Studio 2019',
+                                  solution_version='12.00',
+                                  project_version='16.0',
+                                  flat_sln=False,
+                                  uses_vcxproj=True,
+                                  path=path,
+                                  sdk_based=sdk_based,
+                                  default_toolset='v142'),
+      '2017': VisualStudioVersion('2017',
+                                  'Visual Studio 2017',
+                                  solution_version='12.00',
+                                  project_version='15.0',
+                                  flat_sln=False,
+                                  uses_vcxproj=True,
+                                  path=path,
+                                  sdk_based=sdk_based,
+                                  default_toolset='v141'),
       '2015': VisualStudioVersion('2015',
                                   'Visual Studio 2015',
                                   solution_version='12.00',
@@ -358,6 +376,8 @@ def _DetectVisualStudioVersions(versions_to_check, force_express):
       2012(e) - Visual Studio 2012 (11)
       2013(e) - Visual Studio 2013 (12)
       2015    - Visual Studio 2015 (14)
+      2017    - Visual Studio 2017 (15)
+      2019    - Visual Studio 2019 (16)
     Where (e) is e for express editions of MSVS and blank otherwise.
   """
   version_to_year = {
@@ -367,6 +387,8 @@ def _DetectVisualStudioVersions(versions_to_check, force_express):
       '11.0': '2012',
       '12.0': '2013',
       '14.0': '2015',
+      '15.0': '2017',
+      '16.0': '2019',
   }
   versions = []
   for version in versions_to_check:
@@ -403,7 +425,10 @@ def _DetectVisualStudioVersions(versions_to_check, force_express):
       if not path:
         continue
       path = _ConvertToCygpath(path)
-      if version != '14.0':  # There is no Express edition for 2015.
+      if version == '15.0':
+          if os.path.exists(path):
+              versions.append(_CreateVersion('2017', path))
+      elif version != '14.0':  # There is no Express edition for 2015.
         versions.append(_CreateVersion(version_to_year[version] + 'e',
             os.path.join(path, '..'), sdk_based=True))
 
@@ -422,7 +447,7 @@ def SelectVisualStudioVersion(version='auto', allow_fallback=True):
   if version == 'auto':
     version = os.environ.get('GYP_MSVS_VERSION', 'auto')
   version_map = {
-    'auto': ('14.0', '12.0', '10.0', '9.0', '8.0', '11.0'),
+    'auto': ('16.0', '15.0', '14.0', '12.0', '10.0', '9.0', '8.0', '11.0'),
     '2005': ('8.0',),
     '2005e': ('8.0',),
     '2008': ('9.0',),
@@ -434,6 +459,8 @@ def SelectVisualStudioVersion(version='auto', allow_fallback=True):
     '2013': ('12.0',),
     '2013e': ('12.0',),
     '2015': ('14.0',),
+    '2017': ('15.0',),
+    '2019': ('16.0',),
   }
   override_path = os.environ.get('GYP_MSVS_OVERRIDE_PATH')
   if override_path:

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -142,7 +142,7 @@ function configure (gyp, argv, callback) {
     variables.standalone_static_library = gyp.opts.thin ? 0 : 1
 
     if (win) {
-      process.env.GYP_MSVS_VERSION = Math.min(vsInfo.versionYear, 2015)
+      process.env.GYP_MSVS_VERSION = Math.min(vsInfo.versionYear, 2019)
       process.env.GYP_MSVS_OVERRIDE_PATH = vsInfo.path
       defaults.msbuild_toolset = vsInfo.toolset
       if (vsInfo.sdk) {


### PR DESCRIPTION
##### Checklist
- [x] `npm install && npm test` passes

##### Description of change
`npm install --build-from-source sqlite3` failed for me in a fresh Visual Studio 2019 Build Tools environment, because node-gyp fell back to platform tools v140 which are not installed in VS 2019 by default, but v142 is. The error message was something like
```
The builds tools for v140 (Platform Toolset = 'v140') cannot be found.
```
This patch basically repeats some lines that @refack has already in GYP3 to default to toolset `v141` for VS2017 and `v142` for VS2019, see
- refack/GYP3@c40235ddad9f588d50ab79f6a8d1fca17717d8d0
- refack/GYP3@703706c4995b4c9ed0d5f319d684ba52647ab255
- refack/GYP3@eb296f67da078ec01f5e3a9ea9cdc6d26d680161

In case you're already about to replace GYP with GYP3, sorry for the noise, just ignore this PR.

Disclaimer:

- Registry based detection in `MSVSVersion._DetectVisualStudioVersions` is still incomplete. Maybe it's even in GYP3, because [registry handling has changed](https://developercommunity.visualstudio.com/comments/539856/view.html) in VS2017/19 and keys are stored in a private location now. I didn't bother much, it works in node-gyp context anyway because node-gyps configure.js does it's own detection based on `VCINSTALLDIR` and sets `GYP_MSVS_OVERRIDE_PATH` and `GYP_MSVS_VERSION` accordingly. Btw., why is detection done in both the JS part and GYP, shouldn't it go to GYP solely for separation of concerns?

- I guessed `project_version='16.0'` for 2019, but it seems the `Version` element is not meaningful anymore at all in MSBuild project files?