### PR TITLE
lib: Match proxy support with `request` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,8 @@ Some additional resources for Node.js native addons and writing `gyp` configurat
 | `--devdir=$path`                  | SDK download directory (default is OS cache directory)
 | `--ensure`                        | Don't reinstall headers if already present
 | `--dist-url=$url`                 | Download header tarball from custom URL
-| `--proxy=$url`                    | Set HTTP proxy for downloading header tarball
+| `--proxy=$url`                    | Set HTTP(S) proxy for downloading header tarball
+| `--noproxy=$urls`                 | Set urls to ignore proxies when downloading header tarball
 | `--cafile=$cafile`                | Override default CA chain (to download tarball)
 | `--nodedir=$path`                 | Set the path to the node source code
 | `--python=$path`                  | Set path to the Python binary

--- a/lib/install.js
+++ b/lib/install.js
@@ -420,6 +420,10 @@ function download (gyp, env, url) {
    */
 
   // basic support for a proxy server
+  env.https_proxy = env.HTTPS_PROXY = gyp.opts.proxy ||
+              env.https_proxy ||
+              env.HTTPS_PROXY ||
+              env.npm_config_proxy
   env.http_proxy = env.HTTP_PROXY = gyp.opts.proxy ||
               env.http_proxy ||
               env.HTTP_PROXY ||
@@ -430,9 +434,9 @@ function download (gyp, env, url) {
 
   // basic support for proxy overrides
   env.no_proxy = env.NO_PROXY = gyp.opts.noproxy ||
-                  env.no_proxy ||
-                  env.NO_PROXY ||
-                  env.npm_config_noproxy
+              env.no_proxy ||
+              env.NO_PROXY ||
+              env.npm_config_noproxy
   if (env.no_proxy) {
     log.verbose('download', 'using proxy url: "%s"', env.no_proxy)
   }

--- a/lib/install.js
+++ b/lib/install.js
@@ -438,7 +438,7 @@ function download (gyp, env, url) {
               env.NO_PROXY ||
               env.npm_config_noproxy
   if (env.no_proxy) {
-    log.verbose('download', 'using proxy url: "%s"', env.no_proxy)
+    log.verbose('download', 'ignoring proxy for: "%s"', env.no_proxy)
   }
 
   var req = request(requestOpts)

--- a/lib/install.js
+++ b/lib/install.js
@@ -409,18 +409,31 @@ function download (gyp, env, url) {
     requestOpts.ca = readCAFile(cafile)
   }
 
+  /**
+   * Proxy support is delegated to the `request` module. `request` already
+   * supports proxies using the ones provided in the environment. For
+   * compatibility those provided using the CLI or `npm config` will be
+   * attached to the environment, keeping previous precedence, for
+   * `request` to use.
+   *
+   * See: https://github.com/request/request/blob/master/lib/getProxyFromURI.js
+   */
+
   // basic support for a proxy server
-  var proxyUrl = gyp.opts.proxy ||
+  env.http_proxy = env.HTTP_PROXY = gyp.opts.proxy ||
               env.http_proxy ||
               env.HTTP_PROXY ||
               env.npm_config_proxy
-  if (proxyUrl) {
-    if (/^https?:\/\//i.test(proxyUrl)) {
-      log.verbose('download', 'using proxy url: "%s"', proxyUrl)
-      requestOpts.proxy = proxyUrl
-    } else {
-      log.warn('download', 'ignoring invalid "proxy" config setting: "%s"', proxyUrl)
-    }
+  if (env.http_proxy) {
+    log.verbose('download', 'using proxy url: "%s"', env.http_proxy)
+  }
+
+  // basic support for proxy overrides
+  env.no_proxy = env.NO_PROXY = env.no_proxy ||
+                  env.NO_PROXY ||
+                  env.npm_config_noproxy
+  if (env.no_proxy) {
+    log.verbose('download', 'using proxy url: "%s"', env.no_proxy)
   }
 
   var req = request(requestOpts)

--- a/lib/install.js
+++ b/lib/install.js
@@ -11,6 +11,7 @@ const request = require('request')
 const mkdir = require('mkdirp')
 const processRelease = require('./process-release')
 const win = process.platform === 'win32'
+const getProxyFromURI = require('./proxy')
 
 function install (fs, gyp, argv, callback) {
   var release = processRelease(argv, gyp, process.version, process.release)
@@ -409,36 +410,15 @@ function download (gyp, env, url) {
     requestOpts.ca = readCAFile(cafile)
   }
 
-  /**
-   * Proxy support is delegated to the `request` module. `request` already
-   * supports proxies using the ones provided in the environment. For
-   * compatibility those provided using the CLI or `npm config` will be
-   * attached to the environment, keeping previous precedence, for
-   * `request` to use.
-   *
-   * See: https://github.com/request/request/blob/master/lib/getProxyFromURI.js
-   */
-
   // basic support for a proxy server
-  env.https_proxy = env.HTTPS_PROXY = gyp.opts.proxy ||
-              env.https_proxy ||
-              env.HTTPS_PROXY ||
-              env.npm_config_proxy
-  env.http_proxy = env.HTTP_PROXY = gyp.opts.proxy ||
-              env.http_proxy ||
-              env.HTTP_PROXY ||
-              env.npm_config_proxy
-  if (env.http_proxy) {
-    log.verbose('download', 'using proxy url: "%s"', env.http_proxy)
-  }
-
-  // basic support for proxy overrides
-  env.no_proxy = env.NO_PROXY = gyp.opts.noproxy ||
-              env.no_proxy ||
-              env.NO_PROXY ||
-              env.npm_config_noproxy
-  if (env.no_proxy) {
-    log.verbose('download', 'ignoring proxy for: "%s"', env.no_proxy)
+  var proxyUrl = getProxyFromURI(gyp, env, url)
+  if (proxyUrl) {
+    if (/^https?:\/\//i.test(proxyUrl)) {
+      log.verbose('download', 'using proxy url: "%s"', proxyUrl)
+      requestOpts.proxy = proxyUrl
+    } else {
+      log.warn('download', 'ignoring invalid "proxy" config setting: "%s"', proxyUrl)
+    }
   }
 
   var req = request(requestOpts)

--- a/lib/install.js
+++ b/lib/install.js
@@ -429,7 +429,8 @@ function download (gyp, env, url) {
   }
 
   // basic support for proxy overrides
-  env.no_proxy = env.NO_PROXY = env.no_proxy ||
+  env.no_proxy = env.NO_PROXY = gyp.opts.noproxy ||
+                  env.no_proxy ||
                   env.NO_PROXY ||
                   env.npm_config_noproxy
   if (env.no_proxy) {

--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -67,6 +67,7 @@ proto.configDefs = {
   ensure: Boolean, // 'install'
   solution: String, // 'build' (windows only)
   proxy: String, // 'install'
+  noproxy: String, // 'install'
   devdir: String, // everywhere
   nodedir: String, // 'configure'
   loglevel: String, // everywhere

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,0 +1,92 @@
+'use strict'
+// Taken from https://github.com/request/request/blob/212570b/lib/getProxyFromURI.js
+
+const url = require('url')
+
+function formatHostname (hostname) {
+  // canonicalize the hostname, so that 'oogle.com' won't match 'google.com'
+  return hostname.replace(/^\.*/, '.').toLowerCase()
+}
+
+function parseNoProxyZone (zone) {
+  zone = zone.trim().toLowerCase()
+
+  var zoneParts = zone.split(':', 2)
+  var zoneHost = formatHostname(zoneParts[0])
+  var zonePort = zoneParts[1]
+  var hasPort = zone.indexOf(':') > -1
+
+  return { hostname: zoneHost, port: zonePort, hasPort: hasPort }
+}
+
+function uriInNoProxy (uri, noProxy) {
+  var port = uri.port || (uri.protocol === 'https:' ? '443' : '80')
+  var hostname = formatHostname(uri.hostname)
+  var noProxyList = noProxy.split(',')
+
+  // iterate through the noProxyList until it finds a match.
+  return noProxyList.map(parseNoProxyZone).some(function (noProxyZone) {
+    var isMatchedAt = hostname.indexOf(noProxyZone.hostname)
+    var hostnameMatched = (
+      isMatchedAt > -1 &&
+        (isMatchedAt === hostname.length - noProxyZone.hostname.length)
+    )
+
+    if (noProxyZone.hasPort) {
+      return (port === noProxyZone.port) && hostnameMatched
+    }
+
+    return hostnameMatched
+  })
+}
+
+function getProxyFromURI (gyp, env, uri) {
+  // If a string URI/URL was given, parse it into a URL object
+  if (typeof uri === 'string') {
+    // eslint-disable-next-line
+    uri = url.parse(uri)
+  }
+
+  // Decide the proper request proxy to use based on the request URI object and the
+  // environmental variables (NO_PROXY, HTTP_PROXY, etc.)
+  // respect NO_PROXY environment variables (see: https://lynx.invisible-island.net/lynx2.8.7/breakout/lynx_help/keystrokes/environments.html)
+
+  var noProxy = gyp.opts.noproxy || env.NO_PROXY || env.no_proxy || env.npm_config_noproxy || ''
+
+  // if the noProxy is a wildcard then return null
+
+  if (noProxy === '*') {
+    return null
+  }
+
+  // if the noProxy is not empty and the uri is found return null
+
+  if (noProxy !== '' && uriInNoProxy(uri, noProxy)) {
+    return null
+  }
+
+  // Check for HTTP or HTTPS Proxy in environment Else default to null
+
+  if (uri.protocol === 'http:') {
+    return gyp.opts.proxy ||
+      env.HTTP_PROXY ||
+      env.http_proxy ||
+      env.npm_config_proxy || null
+  }
+
+  if (uri.protocol === 'https:') {
+    return gyp.opts.proxy ||
+      env.HTTPS_PROXY ||
+      env.https_proxy ||
+      env.HTTP_PROXY ||
+      env.http_proxy ||
+      env.npm_config_proxy || null
+  }
+
+  // if none of that works, return null
+  // (What uri protocol are you using then?)
+
+  return null
+}
+
+module.exports = getProxyFromURI

--- a/test/test-download.js
+++ b/test/test-download.js
@@ -90,6 +90,101 @@ test('download over https with custom ca', function (t) {
   })
 })
 
+test('download over http with proxy', function (t) {
+  t.plan(2)
+
+  var server = http.createServer(function (req, res) {
+    t.strictEqual(req.headers['user-agent'],
+      'node-gyp v42 (node ' + process.version + ')')
+    res.end('ok')
+    pserver.close(function () {
+      server.close()
+    })
+  })
+
+  var pserver = http.createServer(function (req, res) {
+    t.strictEqual(req.headers['user-agent'],
+      'node-gyp v42 (node ' + process.version + ')')
+    res.end('proxy ok')
+    server.close(function () {
+      pserver.close()
+    })
+  })
+
+  var host = 'localhost'
+  server.listen(0, host, function () {
+    var port = this.address().port
+    pserver.listen(port + 1, host, function () {
+      var gyp = {
+        opts: {
+          proxy: 'http://' + host + ':' + (port + 1)
+        },
+        version: '42'
+      }
+      var url = 'http://' + host + ':' + port
+      var req = install.test.download(gyp, {}, url)
+      req.on('response', function (res) {
+        var body = ''
+        res.setEncoding('utf8')
+        res.on('data', function (data) {
+          body += data
+        })
+        res.on('end', function () {
+          t.strictEqual(body, 'proxy ok')
+        })
+      })
+    })
+  })
+})
+
+test('download over http with noproxy', function (t) {
+  t.plan(2)
+
+  var server = http.createServer(function (req, res) {
+    t.strictEqual(req.headers['user-agent'],
+      'node-gyp v42 (node ' + process.version + ')')
+    res.end('ok')
+    pserver.close(function () {
+      server.close()
+    })
+  })
+
+  var pserver = http.createServer(function (req, res) {
+    t.strictEqual(req.headers['user-agent'],
+      'node-gyp v42 (node ' + process.version + ')')
+    res.end('proxy ok')
+    server.close(function () {
+      pserver.close()
+    })
+  })
+
+  var host = 'localhost'
+  server.listen(0, host, function () {
+    var port = this.address().port
+    pserver.listen(port + 1, host, function () {
+      var gyp = {
+        opts: {
+          proxy: 'http://' + host + ':' + (port + 1),
+          noproxy: 'localhost'
+        },
+        version: '42'
+      }
+      var url = 'http://' + host + ':' + port
+      var req = install.test.download(gyp, {}, url)
+      req.on('response', function (res) {
+        var body = ''
+        res.setEncoding('utf8')
+        res.on('data', function (data) {
+          body += data
+        })
+        res.on('end', function () {
+          t.strictEqual(body, 'ok')
+        })
+      })
+    })
+  })
+})
+
 test('download with missing cafile', function (t) {
   t.plan(1)
   var gyp = {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

Per https://github.com/nodejs/node-gyp/pull/1176#issuecomment-559293620, closes https://github.com/nodejs/node-gyp/pull/1751

When using the `no_proxy` environmental variable I noticed that some installations would fail when `NODE_CONFIG_PROXY` was set (or its equivalent). From inspecting this code plus how its dependency, https://github.com/request/request, I noticed it already has full proxy support. Changing env itself might lead to side effects.

- Prevents `--proxy` to blocking `no_proxy` from https://github.com/request/request/blob/212570b6971a732b8dd9f3c73354bcdda158a737/request.js#L276-L278
- Adds `no_proxy` support through CLI `--noproxy` or equivalent NPM alternatives.
- __Possibly breaking__: Passing `proxy` effectively blocks `https_proxy` currently, this also unblocks that variable (which would override _our_ `proxy` variable). However I am mirroring the `http_proxy` and `https_proxy` definitions and then letting the dependency to pick either. (Implemention downstream in: https://github.com/request/request/blob/212570b6971a732b8dd9f3c73354bcdda158a737/lib/getProxyFromURI.js#L40)
