### PR TITLE
Travis CI: macOS does not include Python anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,101 +9,102 @@ addons:
     - pyenv
 jobs:
   include:
-    - name: "Python 2.7 on Linux"
-      env: NODE_GYP_FORCE_PYTHON=python2
-      python: 2.7
     - name: "Python 2.7 on macOS"
       os: osx
       osx_image: xcode11.2
       language: shell  # 'language: python' is not yet supported on macOS
-      env: NODE_GYP_FORCE_PYTHON=python2
-      before_install:
-        - pyenv install 2.7
-        - pyenv global 2.7
-    - name: "Node.js 6 & Python 2.7 on Windows"
-      os: windows
-      language: node_js
-      node_js: 6  # node
-      env: >-
-        PATH=/c/Python27:/c/Python27/Scripts:$PATH
-        NODE_GYP_FORCE_PYTHON=/c/Python27/python.exe
-      before_install: choco install python2
-    - name: "Node.js 12 & Python 2.7 on Windows"
-      os: windows
-      language: node_js
-      node_js: 12  # node
-      env: >-
-        PATH=/c/Python27:/c/Python27/Scripts:$PATH
-        NODE_GYP_FORCE_PYTHON=/c/Python27/python.exe
-      before_install: choco install python2
-
-    - name: "Node.js 6 & Python 3.8 on Linux"
-      python: 3.8
-      env: NODE_GYP_FORCE_PYTHON=python3
-      before_install: nvm install 6
-    - name: "Node.js 8 & Python 3.8 on Linux"
-      python: 3.8
-      env: NODE_GYP_FORCE_PYTHON=python3
-      before_install: nvm install 8
-    - name: "Node.js 10 & Python 3.8 on Linux"
-      python: 3.8
-      env: NODE_GYP_FORCE_PYTHON=python3
-      before_install: nvm install 10
-
-    - name: "Node.js 12 & Python 3.5 on Linux"
-      python: 3.5
-      env: NODE_GYP_FORCE_PYTHON=python3
-      before_install: nvm install 12
-    - name: "Node.js 12 & Python 3.6 on Linux"
-      python: 3.6
-      env: NODE_GYP_FORCE_PYTHON=python3
-      before_install: nvm install 12
-    - name: "Node.js 12 & Python 3.7 on Linux"
-      python: 3.7
-      env: NODE_GYP_FORCE_PYTHON=python3
-      before_install: nvm install 12
-    - name: "Node.js 12 & Python 3.8 on Linux"
-      python: 3.8
-      env: NODE_GYP_FORCE_PYTHON=python3
-      before_install: nvm install 12
-
-    - name: "Python 3.7 on macOS"
+      env: NODE_GYP_FORCE_PYTHON=python2 PATH=$HOME/.pyenv/shims:$PATH PYENV_VERSION=2.7.17
+      before_install: pyenv init - && pyenv install $PYENV_VERSION
+    - name: "Python 3.8 on macOS"
       os: osx
       osx_image: xcode11.2
       language: shell  # 'language: python' is not yet supported on macOS
-      env: NODE_GYP_FORCE_PYTHON=python3
-    - name: "Node.js 12 & Python 3.7 on Windows"
-      os: windows
-      language: node_js
-      node_js: 12  # node
-      env: >-
-        PATH=/c/Python37:/c/Python37/Scripts:$PATH
-        NODE_GYP_FORCE_PYTHON=/c/Python37/python.exe
-      before_install: choco install python --version=3.7.4
-    - name: "Node.js 12 & Python 3.8 on Windows"
-      os: windows
-      language: node_js
-      node_js: 12  # node
-      env: >-
-        PATH=/c/Python38:/c/Python38/Scripts:$PATH
-        NODE_GYP_FORCE_PYTHON=/c/Python38/python.exe
-      before_install: choco install python
+      env: NODE_GYP_FORCE_PYTHON=python3 PATH=$HOME/.pyenv/shims:$PATH PYENV_VERSION=3.8.0
+      before_install: pyenv init - && pyenv install $PYENV_VERSION
+
+    # - name: "Python 2.7 on Linux"
+    #   env: NODE_GYP_FORCE_PYTHON=python2
+    #   python: 2.7
+
+    # - name: "Node.js 6 & Python 3.8 on Linux"
+    #   python: 3.8
+    #   env: NODE_GYP_FORCE_PYTHON=python3
+    #   before_install: nvm install 6
+    # - name: "Node.js 8 & Python 3.8 on Linux"
+    #   python: 3.8
+    #   env: NODE_GYP_FORCE_PYTHON=python3
+    #   before_install: nvm install 8
+    # - name: "Node.js 10 & Python 3.8 on Linux"
+    #   python: 3.8
+    #   env: NODE_GYP_FORCE_PYTHON=python3
+    #   before_install: nvm install 10
+
+    # - name: "Node.js 12 & Python 3.5 on Linux"
+    #   python: 3.5
+    #   env: NODE_GYP_FORCE_PYTHON=python3
+    #   before_install: nvm install 12
+    # - name: "Node.js 12 & Python 3.6 on Linux"
+    #   python: 3.6
+    #   env: NODE_GYP_FORCE_PYTHON=python3
+    #   before_install: nvm install 12
+    # - name: "Node.js 12 & Python 3.7 on Linux"
+    #   python: 3.7
+    #   env: NODE_GYP_FORCE_PYTHON=python3
+    #   before_install: nvm install 12
+    # - name: "Node.js 12 & Python 3.8 on Linux"
+    #   python: 3.8
+    #   env: NODE_GYP_FORCE_PYTHON=python3
+    #   before_install: nvm install 12
+
+
+    # - name: "Node.js 6 & Python 2.7 on Windows"
+    #   os: windows
+    #   language: node_js
+    #   node_js: 6  # node
+    #   env: >-
+    #     PATH=/c/Python27:/c/Python27/Scripts:$PATH
+    #     NODE_GYP_FORCE_PYTHON=/c/Python27/python.exe
+    #   before_install: choco install python2
+    # - name: "Node.js 12 & Python 2.7 on Windows"
+    #   os: windows
+    #   language: node_js
+    #   node_js: 12  # node
+    #   env: >-
+    #     PATH=/c/Python27:/c/Python27/Scripts:$PATH
+    #     NODE_GYP_FORCE_PYTHON=/c/Python27/python.exe
+    #   before_install: choco install python2
+
+    # - name: "Node.js 12 & Python 3.7 on Windows"
+    #   os: windows
+    #   language: node_js
+    #   node_js: 12  # node
+    #   env: >-
+    #     PATH=/c/Python37:/c/Python37/Scripts:$PATH
+    #     NODE_GYP_FORCE_PYTHON=/c/Python37/python.exe
+    #   before_install: choco install python --version=3.7.4
+    # - name: "Node.js 12 & Python 3.8 on Windows"
+    #   os: windows
+    #   language: node_js
+    #   node_js: 12  # node
+    #   env: >-
+    #     PATH=/c/Python38:/c/Python38/Scripts:$PATH
+    #     NODE_GYP_FORCE_PYTHON=/c/Python38/python.exe
+    #   before_install: choco install python
 
 install:
-  #- pip install -r requirements.txt
-  - pip install --upgrade flake8 pytest==4.6.6  # pytest 5 no longer supports legacy Python
+  - python -m pip install --upgrade flake8 pytest==4.6.6  # pytest 5 no longer supports legacy Python
 before_script:
-  - flake8 --version
+  - python -m flake8 --version
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+  - python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   # exit-zero treats all errors as warnings.  Two space indentation is OK.  The GitHub editor is 127 chars wide
-  - flake8 . --count --exit-zero --ignore=E111,E114,W503 --max-complexity=10 --max-line-length=127 --statistics
+  - python -m flake8 . --count --exit-zero --ignore=E111,E114,W503 --max-complexity=10 --max-line-length=127 --statistics
   - npm install
   - npm list
 script:
   - node -e 'require("npmlog").level="verbose"; require("./lib/find-python")(null,()=>{})'
   - npm test
-  - GYP_MSVS_VERSION=2015 GYP_MSVS_OVERRIDE_PATH="C:\\Dummy" pytest
+  - GYP_MSVS_VERSION=2015 GYP_MSVS_OVERRIDE_PATH="C:\\Dummy" python -m pytest
 notifications:
   on_success: change
   on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 dist: xenial
 language: python
 cache: pip
-matrix:
+addons:
+  homebrew:
+    update: true
+    packages:
+    - npm
+    - pyenv
+jobs:
   include:
     - name: "Python 2.7 on Linux"
       env: NODE_GYP_FORCE_PYTHON=python2
@@ -11,7 +17,9 @@ matrix:
       osx_image: xcode11.2
       language: shell  # 'language: python' is not yet supported on macOS
       env: NODE_GYP_FORCE_PYTHON=python2
-      before_install: HOMEBREW_NO_AUTO_UPDATE=1 brew install npm
+      before_install:
+        - pyenv install 2.7
+        - pyenv global 2.7
     - name: "Node.js 6 & Python 2.7 on Windows"
       os: windows
       language: node_js
@@ -64,7 +72,6 @@ matrix:
       osx_image: xcode11.2
       language: shell  # 'language: python' is not yet supported on macOS
       env: NODE_GYP_FORCE_PYTHON=python3
-      before_install: HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade npm || true
     - name: "Node.js 12 & Python 3.7 on Windows"
       os: windows
       language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,87 +9,86 @@ addons:
     - pyenv
 jobs:
   include:
+    - name: "Python 2.7 on Linux"
+      env: NODE_GYP_FORCE_PYTHON=python2
+      python: 2.7
+
+    - name: "Node.js 6 & Python 3.8 on Linux"
+      python: 3.8
+      env: NODE_GYP_FORCE_PYTHON=python3
+      before_install: nvm install 6
+    - name: "Node.js 8 & Python 3.8 on Linux"
+      python: 3.8
+      env: NODE_GYP_FORCE_PYTHON=python3
+      before_install: nvm install 8
+    - name: "Node.js 10 & Python 3.8 on Linux"
+      python: 3.8
+      env: NODE_GYP_FORCE_PYTHON=python3
+      before_install: nvm install 10
+
+    - name: "Node.js 12 & Python 3.5 on Linux"
+      python: 3.5
+      env: NODE_GYP_FORCE_PYTHON=python3
+      before_install: nvm install 12
+    - name: "Node.js 12 & Python 3.6 on Linux"
+      python: 3.6
+      env: NODE_GYP_FORCE_PYTHON=python3
+      before_install: nvm install 12
+    - name: "Node.js 12 & Python 3.7 on Linux"
+      python: 3.7
+      env: NODE_GYP_FORCE_PYTHON=python3
+      before_install: nvm install 12
+    - name: "Node.js 12 & Python 3.8 on Linux"
+      python: 3.8
+      env: NODE_GYP_FORCE_PYTHON=python3
+      before_install: nvm install 12
+
     - name: "Python 2.7 on macOS"
       os: osx
       osx_image: xcode11.2
       language: shell  # 'language: python' is not yet supported on macOS
       env: NODE_GYP_FORCE_PYTHON=python2 PATH=$HOME/.pyenv/shims:$PATH PYENV_VERSION=2.7.17
-      before_install: pyenv init - && pyenv install $PYENV_VERSION
+      before_install: pyenv install $PYENV_VERSION
     - name: "Python 3.8 on macOS"
       os: osx
       osx_image: xcode11.2
       language: shell  # 'language: python' is not yet supported on macOS
       env: NODE_GYP_FORCE_PYTHON=python3 PATH=$HOME/.pyenv/shims:$PATH PYENV_VERSION=3.8.0
-      before_install: pyenv init - && pyenv install $PYENV_VERSION
+      before_install: pyenv install $PYENV_VERSION
 
-    # - name: "Python 2.7 on Linux"
-    #   env: NODE_GYP_FORCE_PYTHON=python2
-    #   python: 2.7
+    - name: "Node.js 6 & Python 2.7 on Windows"
+      os: windows
+      language: node_js
+      node_js: 6  # node
+      env: >-
+        PATH=/c/Python27:/c/Python27/Scripts:$PATH
+        NODE_GYP_FORCE_PYTHON=/c/Python27/python.exe
+      before_install: choco install python2
+    - name: "Node.js 12 & Python 2.7 on Windows"
+      os: windows
+      language: node_js
+      node_js: 12  # node
+      env: >-
+        PATH=/c/Python27:/c/Python27/Scripts:$PATH
+        NODE_GYP_FORCE_PYTHON=/c/Python27/python.exe
+      before_install: choco install python2
 
-    # - name: "Node.js 6 & Python 3.8 on Linux"
-    #   python: 3.8
-    #   env: NODE_GYP_FORCE_PYTHON=python3
-    #   before_install: nvm install 6
-    # - name: "Node.js 8 & Python 3.8 on Linux"
-    #   python: 3.8
-    #   env: NODE_GYP_FORCE_PYTHON=python3
-    #   before_install: nvm install 8
-    # - name: "Node.js 10 & Python 3.8 on Linux"
-    #   python: 3.8
-    #   env: NODE_GYP_FORCE_PYTHON=python3
-    #   before_install: nvm install 10
-
-    # - name: "Node.js 12 & Python 3.5 on Linux"
-    #   python: 3.5
-    #   env: NODE_GYP_FORCE_PYTHON=python3
-    #   before_install: nvm install 12
-    # - name: "Node.js 12 & Python 3.6 on Linux"
-    #   python: 3.6
-    #   env: NODE_GYP_FORCE_PYTHON=python3
-    #   before_install: nvm install 12
-    # - name: "Node.js 12 & Python 3.7 on Linux"
-    #   python: 3.7
-    #   env: NODE_GYP_FORCE_PYTHON=python3
-    #   before_install: nvm install 12
-    # - name: "Node.js 12 & Python 3.8 on Linux"
-    #   python: 3.8
-    #   env: NODE_GYP_FORCE_PYTHON=python3
-    #   before_install: nvm install 12
-
-
-    # - name: "Node.js 6 & Python 2.7 on Windows"
-    #   os: windows
-    #   language: node_js
-    #   node_js: 6  # node
-    #   env: >-
-    #     PATH=/c/Python27:/c/Python27/Scripts:$PATH
-    #     NODE_GYP_FORCE_PYTHON=/c/Python27/python.exe
-    #   before_install: choco install python2
-    # - name: "Node.js 12 & Python 2.7 on Windows"
-    #   os: windows
-    #   language: node_js
-    #   node_js: 12  # node
-    #   env: >-
-    #     PATH=/c/Python27:/c/Python27/Scripts:$PATH
-    #     NODE_GYP_FORCE_PYTHON=/c/Python27/python.exe
-    #   before_install: choco install python2
-
-    # - name: "Node.js 12 & Python 3.7 on Windows"
-    #   os: windows
-    #   language: node_js
-    #   node_js: 12  # node
-    #   env: >-
-    #     PATH=/c/Python37:/c/Python37/Scripts:$PATH
-    #     NODE_GYP_FORCE_PYTHON=/c/Python37/python.exe
-    #   before_install: choco install python --version=3.7.4
-    # - name: "Node.js 12 & Python 3.8 on Windows"
-    #   os: windows
-    #   language: node_js
-    #   node_js: 12  # node
-    #   env: >-
-    #     PATH=/c/Python38:/c/Python38/Scripts:$PATH
-    #     NODE_GYP_FORCE_PYTHON=/c/Python38/python.exe
-    #   before_install: choco install python
+    - name: "Node.js 12 & Python 3.7 on Windows"
+      os: windows
+      language: node_js
+      node_js: 12  # node
+      env: >-
+        PATH=/c/Python37:/c/Python37/Scripts:$PATH
+        NODE_GYP_FORCE_PYTHON=/c/Python37/python.exe
+      before_install: choco install python --version=3.7.4
+    - name: "Node.js 12 & Python 3.8 on Windows"
+      os: windows
+      language: node_js
+      node_js: 12  # node
+      env: >-
+        PATH=/c/Python38:/c/Python38/Scripts:$PATH
+        NODE_GYP_FORCE_PYTHON=/c/Python38/python.exe
+      before_install: choco install python
 
 install:
   - python -m pip install --upgrade flake8 pytest==4.6.6  # pytest 5 no longer supports legacy Python


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

macOS stopped bundling python, this attempts to bring back travis tests on macOS

