### PR TITLE
GitHub Action: Run Python tests on Ubuntu & macOS

### DIFF
--- a/.github/workflows/Python_tests.yml
+++ b/.github/workflows/Python_tests.yml
@@ -24,7 +24,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pytest  # -r requirements.txt
       - name: Lint with flake8
-        if: matrix.os == "ubuntu-latest"
+        if: matrix.os == 'ubuntu-latest'
         run: |
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.github/workflows/Python_tests.yml
+++ b/.github/workflows/Python_tests.yml
@@ -24,7 +24,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pytest  # -r requirements.txt
       - name: Lint with flake8
-        if: ${{ matrix.os }} == "ubuntu-latest"
+        if: matrix.os == "ubuntu-latest"
         run: |
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.github/workflows/Python_tests.yml
+++ b/.github/workflows/Python_tests.yml
@@ -3,7 +3,7 @@
 # TODO: Line 36, enable pytest --doctest-modules
 
 name: Python_tests
-on: [push]
+on: [push, pull_request]
 jobs:
   Python_tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/Python_tests.yml
+++ b/.github/workflows/Python_tests.yml
@@ -1,0 +1,36 @@
+# TODO: Enable os: windows-latest
+# TODO: Enable python-version: 3.5
+# TODO: Enable pytest --doctest-modules
+
+name: Python_tests
+on: [push]
+jobs:
+  Python_tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      max-parallel: 15
+      matrix:
+        os: [macos-latest, ubuntu-latest]  # , windows-latest]
+        python-version: [2.7, 3.6, 3.7, 3.8]  # 3.5,
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest  # -r requirements.txt
+      - name: Lint with flake8
+        if: ${{ matrix.os }} == "ubuntu-latest"
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with pytest
+        run: pytest
+      # - name: Run doctests with pytest
+      #   run: pytest --doctest-modules

--- a/.github/workflows/Python_tests.yml
+++ b/.github/workflows/Python_tests.yml
@@ -1,6 +1,6 @@
-# TODO: Enable os: windows-latest
-# TODO: Enable python-version: 3.5
-# TODO: Enable pytest --doctest-modules
+# TODO: Line 14, enable os: windows-latest
+# TODO: Line 15, enable python-version: 3.5
+# TODO: Line 36, enable pytest --doctest-modules
 
 name: Python_tests
 on: [push]


### PR DESCRIPTION
Running Python standalone tests on multiple OSes would free up Travis CI for tests of various combinations of Node.js and Python as well as tests on other [CPU architectures](https://docs.travis-ci.com/user/multi-cpu-architectures).
__arch: amd64, arm64, ppc64le, s390x__

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

