### PR TITLE
doc: remove backticks from Python version list

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ Depending on your operating system, you will need to install:
 
 ### On Unix
 
-   * `Python v2.7, v3.5, v3.6, or v3.7`
+   * Python v2.7, v3.5, v3.6, or v3.7
    * `make`
    * A proper C/C++ compiler toolchain, like [GCC](https://gcc.gnu.org)
 
 ### On macOS
 
-   * `Python v2.7, v3.5, v3.6, or v3.7`
+   * Python v2.7, v3.5, v3.6, or v3.7
    * [Xcode](https://developer.apple.com/xcode/download/)
      * You also need to install the `XCode Command Line Tools` by running `xcode-select --install`. Alternatively, if you already have the full Xcode installed, you can find them under the menu `Xcode -> Open Developer Tool -> More Developer Tools...`. This step will install `clang`, `clang++`, and `make`.
    * If your Mac has been _upgraded_ to macOS Catalina (10.15), please read [macOS_Catalina.md](macOS_Catalina.md).


### PR DESCRIPTION
This has been bothering me for a while now, it was fixed on `v5.x` and is the main difference in the README between the two. The backticks have a complicated history in this list and never got properly cleaned up.