### PR TITLE
lib: ignore VS instances that cause COMExceptions

### DIFF
--- a/lib/Find-VisualStudio.cs
+++ b/lib/Find-VisualStudio.cs
@@ -209,7 +209,7 @@ namespace VisualStudioConfiguration
                 {
                     instances.Add(InstanceJson(rgelt[0]));
                 }
-                catch
+                catch (COMException)
                 {
                     // Ignore instances that can't be queried.
                 }

--- a/lib/Find-VisualStudio.cs
+++ b/lib/Find-VisualStudio.cs
@@ -205,7 +205,14 @@ namespace VisualStudioConfiguration
                     return;
                 }
 
-                instances.Add(InstanceJson(rgelt[0]));
+                try
+                {
+                    instances.Add(InstanceJson(rgelt[0]));
+                }
+                catch
+                {
+                    // Ignore instances that can't be queried.
+                }
             }
         }
 


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
  Some tests are failing, but they also fail without my change.  I assume the CI system will catch actual failures.
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
  I see that find-visualstudio has pretty good test coverage, but I didn't see an obvious way to simulate this COM failure
- [ ] documentation is changed or added
  Are there user-facing docs for find-visualstudio?  I'd be happy to add a blurb about ignoring certain instances.
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
I have quite a few instances of VS installed and it looks like Find-VisualStudio.cs enumerates all of them, even when find-visualstudio.js already knows which one it wants (from the environment variable in the developer command prompt).  One of them (from 15.7.2, if that's interesting) causes a COMException on the ISetupInstance2.GetPackages call.  Ignoring such packages seems harmless and unblocks the rest of the run.

Note: an alternative approach would be to print a JSON blob with an empty packages list and let the caller reject it with an explicit error message.

