### PR TITLE
doc: add link to Command Line Tools for Xcode manual download

### DIFF
--- a/macOS_Catalina.md
+++ b/macOS_Catalina.md
@@ -63,7 +63,7 @@ There are three ways to install the Xcode libraries `node-gyp` needs on macOS. P
 9. Repeat step 5 above.  Is the path different this time?  Repeat the _acid test_.
 
 ### Installing `node-gyp` using the Xcode Command Line Tools via manual download
-1. Download the appropriate version of the "Command Line Tools for Xcode" for your version of Catalina from developer.apple.com/download. As of MacOS 10.15.2, that's Command_Line_Tools_for_Xcode_11.3.dmg
+1. Download the appropriate version of the "Command Line Tools for Xcode" for your version of Catalina from developer.apple.com/download. As of MacOS 10.15.2, that's [Command_Line_Tools_for_Xcode_11.3.dmg](https://download.developer.apple.com/Developer_Tools/Command_Line_Tools_for_Xcode_11.3/Command_Line_Tools_for_Xcode_11.3.dmg)
 2. Install the package.
 3. Run the _acid test_.
 


### PR DESCRIPTION
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
It was hard to find specific package needed to run node-gyp on MacOS that's why I added specific link. 
