### PR TITLE
build: shrink bloated addon binaries on windows

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -1,7 +1,8 @@
 {
   'variables' : {
     'node_engine_include_dir%': 'deps/v8/include',
-    'node_host_binary%': 'node'
+    'node_host_binary%': 'node',
+    'node_with_ltcg%': 'true',
   },
   'target_defaults': {
     'type': 'loadable_module',
@@ -126,6 +127,26 @@
             'library_dirs': [ '<(node_root_dir)/$(ConfigurationName)' ],
             'libraries': [ '<@(node_engine_libs)' ],
           }],
+          ['node_with_ltcg=="true"', {
+            'msvs_settings': {
+              'VCCLCompilerTool': {
+                'WholeProgramOptimization': 'true' # /GL, whole program optimization, needed for LTCG
+              },
+              'VCLibrarianTool': {
+                'AdditionalOptions': [
+                  '/LTCG:INCREMENTAL', # incremental link-time code generation
+                ]
+              },
+              'VCLinkerTool': {
+                'OptimizeReferences': 2, # /OPT:REF
+                'EnableCOMDATFolding': 2, # /OPT:ICF
+                'LinkIncremental': 1, # disable incremental linking
+                'AdditionalOptions': [
+                  '/LTCG:INCREMENTAL', # incremental link-time code generation
+                ]
+              }
+            }
+          }]
         ],
         'libraries': [
           '-lkernel32.lib',


### PR DESCRIPTION
### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change

Closes https://github.com/nodejs/node/issues/29501.
Refs nodejs/node-gyp#1118.

Moves build-time optimizations to `node-gyp` to shrink the binary size accidentally bloated by a change to `common.gypi` in core. Also furthers the goal of decoupling addons from being affected by `common.gypi` changes.

Feel free to tell me if this isn't quite what the issue had in mind and i'll adapt accordingly.

cc @richardlau @deepak1556

