### PR TITLE
lib: update to mkdirp@1 w/ Promises interface

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -73,18 +73,17 @@ function configure (gyp, argv, callback) {
 
   function createBuildDir () {
     log.verbose('build dir', 'attempting to create "build" dir: %s', buildDir)
-    mkdirp(buildDir, function (err, isNew) {
-      if (err) {
-        return callback(err)
-      }
-      log.verbose('build dir', '"build" dir needed to be created?', isNew)
-      if (win) {
-        findVisualStudio(release.semver, gyp.opts.msvs_version,
-          createConfigFile)
-      } else {
-        createConfigFile()
-      }
-    })
+    mkdirp(buildDir)
+      .catch(callback)
+      .then((isNew) => {
+        log.verbose('build dir', '"build" dir needed to be created?', isNew)
+        if (win) {
+          findVisualStudio(release.semver, gyp.opts.msvs_version,
+            createConfigFile)
+        } else {
+          createConfigFile()
+        }
+      })
   }
 
   function createConfigFile (err, vsInfo) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -8,7 +8,7 @@ const crypto = require('crypto')
 const log = require('npmlog')
 const semver = require('semver')
 const request = require('request')
-const mkdir = require('mkdirp')
+const mkdirp = require('mkdirp')
 const processRelease = require('./process-release')
 const win = process.platform === 'win32'
 const getProxyFromURI = require('./proxy')
@@ -114,16 +114,17 @@ function install (fs, gyp, argv, callback) {
     log.verbose('ensuring nodedir is created', devDir)
 
     // first create the dir for the node dev files
-    mkdir(devDir, function (err, created) {
-      if (err) {
+    mkdirp(devDir)
+      .catch((err) => {
         if (err.code === 'EACCES') {
           eaccesFallback(err)
         } else {
           cb(err)
         }
-        return
-      }
+      })
+      .then(afterDevDirMkdirp)
 
+    function afterDevDirMkdirp (created) {
       if (created) {
         log.verbose('created nodedir', created)
       }
@@ -310,10 +311,11 @@ function install (fs, gyp, argv, callback) {
           log.verbose(name, 'dir', dir)
           log.verbose(name, 'url', libUrl)
 
-          mkdir(dir, function (err) {
-            if (err) {
-              return done(err)
-            }
+          mkdirp(dir)
+            .catch(done)
+            .then(afterMkdirpLibDir)
+
+          function afterMkdirpLibDir () {
             log.verbose('streaming', name, 'to:', targetLibPath)
 
             try {
@@ -347,10 +349,10 @@ function install (fs, gyp, argv, callback) {
               req.pipe(ws)
             })
             req.on('end', function () { --async || done() })
-          })
+          }
         })
       } // downloadNodeLib()
-    }) // mkdir()
+    } // mkdirp()
   } // go()
 
   /**

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "env-paths": "^2.2.0",
     "glob": "^7.1.4",
     "graceful-fs": "^4.2.2",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^1.0.3",
     "nopt": "^4.0.1",
     "npmlog": "^4.1.2",
     "request": "^2.88.0",


### PR DESCRIPTION
Ref #2074

I did want to update to 0.5.3 but Isaac has deprecated all 0.x versions. To avoid the deprecation warning we need to go to @1 which has a Promises interface. We don't have any async/await in 5.x so I don't want to introduce it. We do have one use of Promises already so this isn't a major change. I'd just like some checking of my code!
