### PR TITLE
dep: remove mkdirp dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,9 @@ before_script:
   - npm list
 script:
   - node -e 'require("npmlog").level="verbose"; require("./lib/find-python")(null,()=>{})'
-  - npm test
+  - node --version
+  # Standard no longer supports Node.js v6
+  - if [[ $(node --version) != 'v6.17.0' ]]; then npm test; fi
   - GYP_MSVS_VERSION=2015 GYP_MSVS_OVERRIDE_PATH="C:\\Dummy" python -m pytest
 notifications:
   on_success: change

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -1,10 +1,10 @@
 'use strict'
 
+const nodeFs = require('fs')
 const fs = require('graceful-fs')
 const path = require('path')
 const log = require('npmlog')
 const os = require('os')
-const mkdirp = require('mkdirp')
 const processRelease = require('./process-release')
 const win = process.platform === 'win32'
 const findNodeDirectory = require('./find-node-directory')
@@ -73,7 +73,8 @@ function configure (gyp, argv, callback) {
 
   function createBuildDir () {
     log.verbose('build dir', 'attempting to create "build" dir: %s', buildDir)
-    mkdirp(buildDir, function (err, isNew) {
+
+    nodeFs.mkdir(buildDir, { recursive: true }, function (err, isNew) {
       if (err) {
         return callback(err)
       }

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const nodeFs = require('fs')
 const fs = require('graceful-fs')
 const os = require('os')
 const tar = require('tar')
@@ -8,7 +9,6 @@ const crypto = require('crypto')
 const log = require('npmlog')
 const semver = require('semver')
 const request = require('request')
-const mkdir = require('mkdirp')
 const processRelease = require('./process-release')
 const win = process.platform === 'win32'
 const getProxyFromURI = require('./proxy')
@@ -114,7 +114,7 @@ function install (fs, gyp, argv, callback) {
     log.verbose('ensuring nodedir is created', devDir)
 
     // first create the dir for the node dev files
-    mkdir(devDir, function (err, created) {
+    nodeFs.mkdir(devDir, { recursive: true }, function (err, created) {
       if (err) {
         if (err.code === 'EACCES') {
           eaccesFallback(err)
@@ -310,7 +310,7 @@ function install (fs, gyp, argv, callback) {
           log.verbose(name, 'dir', dir)
           log.verbose(name, 'url', libUrl)
 
-          mkdir(dir, function (err) {
+          nodeFs.mkdir(dir, { recursive: true }, function (err) {
             if (err) {
               return done(err)
             }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "env-paths": "^2.2.0",
     "glob": "^7.1.4",
     "graceful-fs": "^4.2.2",
-    "mkdirp": "^0.5.1",
     "nopt": "^4.0.1",
     "npmlog": "^4.1.2",
     "request": "^2.88.0",


### PR DESCRIPTION
#1071 ### Checklist

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
`mkdirp` hasn't been updated in 4 years, and node's fs library
has had a recursive option for `fs` since v10.12 (oldest active LTS
version)

I was notified of an issue with `minmist` (a dependency of `mkdirp`) by `npm audit`. https://npmjs.com/advisories/1179. This library shouldn't be necessary as the old LTS supports recursive directory creation
