### PR TITLE
doc, bin: stop suggesting opening  node-gyp issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,10 +1,16 @@
 <!--
-Thank you for reporting an issue. The more information you can give us, the
-better the chance we can fix your problem.
+Thank you for reporting an issue!
 
-This issue tracker is for issues with node-gyp,
-if you have an issue installing a specific module, please file an issue on
-that module's issue tracker (`npm issues modulename`).
+Remember, this issue tracker is for reporting issues ONLY with node-gyp.
+
+If you have an issue installing a specific module, please file an issue on
+that module's issue tracker (`npm issues modulename`). Open issue here only if
+you are sure this is an issue with node-gyp, not with the module you are
+trying to build.
+
+Fill out the form below. We probably won't investigate an issue that does not
+provide the basic information we require.
+
 -->
 
 * **Node Version**: <!-- `node -v` and `npm -v` -->
@@ -19,6 +25,22 @@ Paste your log here, between the backticks. It can be:
   - npm --verbose output,
   - or contents of npm-debug.log,
   - or output of node-gyp rebuild --verbose.
+Include the command you were trying to run.
+
+This should look like this:
+
+>npm --verbose
+npm info it worked if it ends with ok
+npm verb cli [
+npm verb cli   'C:\\...\\node\\13.9.0\\x64\\node.exe',
+npm verb cli   'C:\\...\\node\\13.9.0\\x64\\node_modules\\npm\\bin\\npm-cli.js',
+npm verb cli   '--verbose'
+npm verb cli ]
+npm info using npm@6.13.7
+npm info using node@v13.9.0
+
+Usage: npm <command>
+(...)
 ```
 
 </details>

--- a/bin/node-gyp.js
+++ b/bin/node-gyp.js
@@ -132,7 +132,7 @@ function errorMessage () {
 function issueMessage () {
   errorMessage()
   log.error('', ['Node-gyp failed to build your package.',
-    'Try to update npm and/or node-gyp and if it does not help file an issue with the package author.',
+    'Try to update npm and/or node-gyp and if it does not help file an issue with the package author.'
   ].join('\n'))
 }
 

--- a/bin/node-gyp.js
+++ b/bin/node-gyp.js
@@ -132,7 +132,7 @@ function errorMessage () {
 function issueMessage () {
   errorMessage()
   log.error('', ['Node-gyp failed to build your package.',
-    'Try to update node-gyp and if it does not help file an issue with the package author'
+    'Try to update npm and/or node-gyp and if it does not help file an issue with the package author.',
   ].join('\n'))
 }
 

--- a/bin/node-gyp.js
+++ b/bin/node-gyp.js
@@ -131,9 +131,8 @@ function errorMessage () {
 
 function issueMessage () {
   errorMessage()
-  log.error('', ['This is a bug in `node-gyp`.',
-    'Try to update node-gyp and file an Issue if it does not help:',
-    '    <https://github.com/nodejs/node-gyp/issues>'
+  log.error('', ['Node-gyp failed to build your package.',
+    'Try to update node-gyp and if it does not help file an issue with the package author'
   ].join('\n'))
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->
A lot of new issues in node-gyp are related to outdated node-gyp or broken modules. This removes the suggestion to open a new issue in the node-gyp, instead suggesting the user should open the issue in the module issue tracker.

It also makes the issue template more explicit about providing the logs.
