### PR TITLE
chore: remove support for EOL versions of Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,6 @@ jobs:
       env: NODE_GYP_FORCE_PYTHON=python2
       python: 2.7
 
-    - name: "Node.js 6 & Python 3.8 on Linux"
-      python: 3.8
-      env: NODE_GYP_FORCE_PYTHON=python3
-      before_install: nvm install 6
-    - name: "Node.js 8 & Python 3.8 on Linux"
-      python: 3.8
-      env: NODE_GYP_FORCE_PYTHON=python3
-      before_install: nvm install 8
     - name: "Node.js 10 & Python 3.8 on Linux"
       python: 3.8
       env: NODE_GYP_FORCE_PYTHON=python3
@@ -56,14 +48,6 @@ jobs:
       env: NODE_GYP_FORCE_PYTHON=python3 PATH=$HOME/.pyenv/shims:$PATH PYENV_VERSION=3.8.0
       before_install: pyenv install $PYENV_VERSION
 
-    - name: "Node.js 6 & Python 2.7 on Windows"
-      os: windows
-      language: node_js
-      node_js: 6  # node
-      env: >-
-        PATH=/c/Python27:/c/Python27/Scripts:$PATH
-        NODE_GYP_FORCE_PYTHON=/c/Python27/python.exe
-      before_install: choco install python2
     - name: "Node.js 12 & Python 2.7 on Windows"
       os: windows
       language: node_js


### PR DESCRIPTION
##### Description of change

Refs https://github.com/nodejs/node-gyp/issues/1945.

Should we also consider moving to GitHub Actions and adding specs for Node.js v14? Feel free to tell me if there's any config code specific to these EOL versions that i missed and i'll ditch it :)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)