### PR TITLE
node --version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,9 @@ before_script:
   - npm list
 script:
   - node -e 'require("npmlog").level="verbose"; require("./lib/find-python")(null,()=>{})'
-  - npm test
+  - node --version
+  # Standard no longer supports Node.js v6
+  - if [[ $(node --version) != 'v6.17.0' ]]; then npm test; fi
   - GYP_MSVS_VERSION=2015 GYP_MSVS_OVERRIDE_PATH="C:\\Dummy" python -m pytest
 notifications:
   on_success: change


### PR DESCRIPTION
This commit was on `master`, I think probably accidentally as I don't believe there's a PR for it and there wasn't any metadata. I've pulled it out and force pushed a new `master` impacting the two commits following it, which I think should be fine.

This one looks necessary, but maybe the answer here is to remove the `Node.js 6 & Python 3.8 on Linux` instead of having a manual skip. I imagine this was a testing commit that accidentally made it onto `master` @cclauss?

Not a big deal but let's figure out what the final form is and get it landed ASAP.