### PR TITLE
deps: update deps, match to npm@7, upgrade to tap 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "nan": "^2.14.1",
     "require-inject": "^1.4.4",
     "standard": "^14.3.4",
-    "tap": "^14.10.7"
+    "tap": "^12.7.0"
   },
   "scripts": {
     "lint": "standard */*.js test/**/*.js",

--- a/package.json
+++ b/package.json
@@ -24,25 +24,25 @@
   "dependencies": {
     "env-paths": "^2.2.0",
     "glob": "^7.1.4",
-    "graceful-fs": "^4.2.2",
+    "graceful-fs": "^4.2.3",
     "mkdirp": "^0.5.1",
-    "nopt": "^4.0.1",
+    "nopt": "^4.0.3",
     "npmlog": "^4.1.2",
-    "request": "^2.88.0",
+    "request": "^2.88.2",
     "rimraf": "^2.6.3",
-    "semver": "^5.7.1",
-    "tar": "^4.4.12",
-    "which": "^1.3.1"
+    "semver": "^7.3.2",
+    "tar": "^6.0.1",
+    "which": "^2.0.2"
   },
   "engines": {
     "node": ">= 6.0.0"
   },
   "devDependencies": {
     "bindings": "^1.5.0",
-    "nan": "^2.14.0",
+    "nan": "^2.14.1",
     "require-inject": "^1.4.4",
-    "standard": "^14.3.1",
-    "tap": "~12.7.0"
+    "standard": "^14.3.4",
+    "tap": "^14.10.7"
   },
   "scripts": {
     "lint": "standard */*.js test/**/*.js",


### PR DESCRIPTION
semver, tar and which were the major bumps in here, but none had breaking APIs that we touch, thankfully.

I've matched the ranges to npm@7's current ranges, as seen @ https://github.com/npm/cli/blob/release/v7.0.0-beta/package.json, so for some of them they're not the actual latest but they're only out by a patch release or two.

Updated tap to v14, which drops support for older versions of Node.js, but it runs nicer in parallel and gives automatic coverage reporting (which is dismal, but we knew that).