### PR TITLE
Don't use the "-2" flag with the py.exe launcher on Windows

### DIFF
--- a/lib/find-python.js
+++ b/lib/find-python.js
@@ -119,7 +119,7 @@ PythonFinder.prototype = {
         checks.push({
           before: () => {
             this.addLog(
-              'checking if the py launcher can be used to find Python 2')
+              'checking if the py launcher can be used to find Python')
           },
           check: this.checkPyLauncher
         })
@@ -188,15 +188,10 @@ PythonFinder.prototype = {
   // Distributions of Python on Windows by default install with the "py.exe"
   // Python launcher which is more likely to exist than the Python executable
   // being in the $PATH.
-  // Because the Python launcher supports all versions of Python, we have to
-  // explicitly request a Python 2 version. This is done by supplying "-2" as
-  // the first command line argument. Since "py.exe -2" would be an invalid
-  // executable for "execFile", we have to use the launcher to figure out
-  // where the actual "python.exe" executable is located.
   checkPyLauncher: function checkPyLauncher (errorCallback) {
     this.log.verbose(
-      `- executing "${this.pyLauncher}" to get Python 2 executable path`)
-    this.run(this.pyLauncher, ['-2', ...this.argsExecutable], false,
+      `- executing "${this.pyLauncher}" to get Python executable path`)
+    this.run(this.pyLauncher, this.argsExecutable, false,
       function (err, execPath) {
       // Possible outcomes: same as checkCommand
         if (err) {

--- a/test/test-find-python.js
+++ b/test/test-find-python.js
@@ -146,14 +146,13 @@ test('find python - no python2, no python, unix', function (t) {
 })
 
 test('find python - no python, use python launcher', function (t) {
-  t.plan(4)
+  t.plan(3)
 
   var f = new TestPythonFinder(null, done)
   f.win = true
 
   f.execFile = function (program, args, opts, cb) {
     if (program === 'py.exe') {
-      t.notEqual(args.indexOf('-2'), -1)
       t.notEqual(args.indexOf('-c'), -1)
       return cb(null, 'Z:\\snake.exe')
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

Fixes #2130

The [`py.exe` launcher for Windows](https://docs.python.org/3/using/windows.html#launcher) helps to locate Python on the system.

The `-2` or `-3` flags can specify a major version to find. Now that `node-gyp` supports Python 3, it makes sense to not restrict the `py.exe` launcher to only finding Python 2. It would be advantageous to let it find Python 3 as well.

The `py.exe` launcher prefers newer (higher version number) Python when multiple versions are found. (i.e. it prefers Python 3 over Python 2 if both are available).