### PR TITLE
doc: give more attention to Catalina issues doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ Depending on your operating system, you will need to install:
 
 ### On macOS
 
+**ATTENTION**: If your Mac has been _upgraded_ to macOS Catalina (10.15), please read [macOS_Catalina.md](macOS_Catalina.md).
+
    * Python v2.7, v3.5, v3.6, v3.7, or v3.8
    * [Xcode](https://developer.apple.com/xcode/download/)
      * You also need to install the `XCode Command Line Tools` by running `xcode-select --install`. Alternatively, if you already have the full Xcode installed, you can find them under the menu `Xcode -> Open Developer Tool -> More Developer Tools...`. This step will install `clang`, `clang++`, and `make`.
-   * If your Mac has been _upgraded_ to macOS Catalina (10.15), please read [macOS_Catalina.md](macOS_Catalina.md).
 
 ### On Windows
 


### PR DESCRIPTION
It's easy to miss the Catalina issues doc when reading the readme. Since
it can be a common issue among developers, it makes sense to give more
attention to it in the readme.

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
