### PR TITLE
gyp: fix XCode CLT version detection on Catalina

### DIFF
--- a/gyp/pylib/gyp/xcode_emulation.py
+++ b/gyp/pylib/gyp/xcode_emulation.py
@@ -1541,6 +1541,13 @@ def CLTVersion():
         except GypError:
             continue
 
+    regex = re.compile('Command Line Tools for Xcode\s+(?P<version>\S+)')
+    try:
+        output = GetStdout(['/usr/sbin/softwareupdate', '--history'])
+        return re.search(regex, output).groupdict()['version']
+    except:
+        return None
+
 
 def GetStdoutQuiet(cmdlist):
     """Returns the content of standard output returned by invoking |cmdlist|.

--- a/gyp/pylib/gyp/xcode_emulation.py
+++ b/gyp/pylib/gyp/xcode_emulation.py
@@ -1545,7 +1545,7 @@ def CLTVersion():
     try:
         output = GetStdout(['/usr/sbin/softwareupdate', '--history'])
         return re.search(regex, output).groupdict()['version']
-    except:
+    except (GypError, OSError):
         return None
 
 


### PR DESCRIPTION
Since Catalina XCode Command Line Tools don't show up among installed packages,
which breaks version detection in gyp/pylib/gyp/xcode_emulation.py.

The workaround is to remove the CLT installation directory, and run
`xcode-select --install` which reinstalls an older version of CLT. This older
version will eventually be upgraded by Software Update, which breaks gyp again.

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
This patch adds a fallback mechanism to detect newer CLT versions based on
software update history.

