### PR TITLE
doc: silence curl for macOS Catalina acid test

### DIFF
--- a/macOS_Catalina.md
+++ b/macOS_Catalina.md
@@ -22,7 +22,7 @@ If `ProductVersion` is less then `10.15` then this document is not for you. Norm
 ### The acid test
 To see if `Xcode Command Line Tools` is installed in a way that will work with `node-gyp`, run:
 ```
-curl -L https://github.com/nodejs/node-gyp/raw/master/macOS_Catalina_acid_test.sh | bash
+curl -sL https://github.com/nodejs/node-gyp/raw/master/macOS_Catalina_acid_test.sh | bash
 ```
 
 If test succeeded, _you are done_! You should be ready to install `node-gyp`.


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node-gyp/issues/2148

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

Silences the curl part of the curl|bash command that's copy pasted into the user's CLI for less noisy output.