### PR TITLE
deps: increase "engines" to "node" : ">= 10.12.0"

### DIFF
--- a/macOS_Catalina.md
+++ b/macOS_Catalina.md
@@ -1,5 +1,5 @@
 # Installation notes for macOS Catalina (v10.15)
-# [node-gyp v7](https://github.com/nodejs/node-gyp/releases) should solve the [`gyp: No Xcode or CLT version detected!`](https://github.com/nodejs/node-gyp/issues?q=is%3Aissue+label%3A%22gyp%3A+No+Xcode+or+CLT+version+detected%21%22+is%3Aclosed) issue.
+### [node-gyp v7](https://github.com/nodejs/node-gyp/releases) should solve the [`gyp: No Xcode or CLT version detected!`](https://github.com/nodejs/node-gyp/issues?q=is%3Aissue+label%3A%22gyp%3A+No+Xcode+or+CLT+version+detected%21%22+is%3Aclosed) issue.
 
 _This document specifically refers to upgrades from previous versions of macOS to Catalina (10.15). It should be removed from the source repository when Catalina ceases to be the latest macOS version or when future Catalina versions no longer raise these issues._
 

--- a/macOS_Catalina.md
+++ b/macOS_Catalina.md
@@ -1,4 +1,5 @@
 # Installation notes for macOS Catalina (v10.15)
+# [node-gyp v7](https://github.com/nodejs/node-gyp/releases) should solve the [`gyp: No Xcode or CLT version detected!`](https://github.com/nodejs/node-gyp/issues?q=is%3Aissue+label%3A%22gyp%3A+No+Xcode+or+CLT+version+detected%21%22+is%3Aclosed) issue.
 
 _This document specifically refers to upgrades from previous versions of macOS to Catalina (10.15). It should be removed from the source repository when Catalina ceases to be the latest macOS version or when future Catalina versions no longer raise these issues._
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "which": "^2.0.2"
   },
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">= 10.12.0"
   },
   "devDependencies": {
     "bindings": "^1.5.0",


### PR DESCRIPTION
Makes npm warn users if they are using an unsupported Node version.

Resolves #2152.

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

Updates the [`"engines"` field of `package.json`](https://docs.npmjs.com/files/package.json#engines) to `"Node" : ">= 10.12.0"`. This is done to reflect a change in #2123, which requires Node v10.12.0 or above.