### PR TITLE
gyp: add missing extensions to compile_commands_json

### DIFF
--- a/gyp/pylib/gyp/generator/compile_commands_json.py
+++ b/gyp/pylib/gyp/generator/compile_commands_json.py
@@ -61,8 +61,9 @@ def AddCommandsForTarget(cwd, target, params, per_config_commands):
         defines = ["-D" + s for s in defines]
 
         # TODO(bnoordhuis) Handle generated source files.
+        extensions = (".c", ".cc", ".cpp", ".cxx")
         sources = target.get("sources", [])
-        sources = [s for s in sources if s.endswith(".c") or s.endswith(".cc")]
+        sources = [s for s in sources if s.endswith(extensions)]
 
         def resolve(filename):
             return os.path.abspath(os.path.join(cwd, filename))

--- a/gyp/pylib/gyp/generator/compile_commands_json.py
+++ b/gyp/pylib/gyp/generator/compile_commands_json.py
@@ -62,7 +62,6 @@ def AddCommandsForTarget(cwd, target, params, per_config_commands):
 
         # TODO(bnoordhuis) Handle generated source files.
         extensions = (".c", ".cc", ".cpp", ".cxx")
-        sources = target.get("sources", [])
         sources = [s for s in target.get("sources", []) if s.endswith(extensions)]
 
         def resolve(filename):

--- a/gyp/pylib/gyp/generator/compile_commands_json.py
+++ b/gyp/pylib/gyp/generator/compile_commands_json.py
@@ -63,7 +63,7 @@ def AddCommandsForTarget(cwd, target, params, per_config_commands):
         # TODO(bnoordhuis) Handle generated source files.
         extensions = (".c", ".cc", ".cpp", ".cxx")
         sources = target.get("sources", [])
-        sources = [s for s in sources if s.endswith(extensions)]
+        sources = [s for s in target.get("sources", []) if s.endswith(extensions)]
 
         def resolve(filename):
             return os.path.abspath(os.path.join(cwd, filename))


### PR DESCRIPTION
##### Checklist

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change

Extends compile_commands_json generator to consider more file extensions
than just c and cc. This commit adds the cpp and cxx extensions to the
list of input source files.
