### PR TITLE
doc: drop the --production flag for installing windows-build-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Install the current version of Python from the [Microsoft Store package](https:/
 
 #### Option 1
 
-Install all the required tools and configurations using Microsoft's [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools) using `npm install --global --production windows-build-tools` from an elevated PowerShell or CMD.exe (run as Administrator).
+Install all the required tools and configurations using Microsoft's [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools) using `npm install --global windows-build-tools` from an elevated PowerShell or CMD.exe (run as Administrator).
 
 #### Option 2
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

Drop `--production` from the install instructions for `windows-build-tools`. The `--production` flag isn't needed here, as "not installing devDependencies" is already implied when `npm install`ing a module by name.

(This was probably copy-pasted a while ago from `windows-build-tools`' `README.md`, which has since been updated to drop the `--production` flag from its install instructions: https://github.com/felixrieseberg/windows-build-tools/commit/4420dc848b74cdc70784ce00a1253d10465b1cb0)