### PR TITLE
deps: update deps to match npm@7

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "env-paths": "^2.2.0",
     "glob": "^7.1.4",
     "graceful-fs": "^4.2.3",
-    "nopt": "^4.0.3",
+    "nopt": "^5.0.0",
     "npmlog": "^4.1.2",
     "request": "^2.88.2",
-    "rimraf": "^2.6.3",
+    "rimraf": "^3.0.2",
     "semver": "^7.3.2",
-    "tar": "^6.0.1",
+    "tar": "^6.0.2",
     "which": "^2.0.2"
   },
   "engines": {
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "bindings": "^1.5.0",
-    "nan": "^2.14.1",
+    "nan": "^2.14.2",
     "require-inject": "^1.4.4",
     "standard": "^14.3.4",
     "tap": "^12.7.0"


### PR DESCRIPTION
this is actually pretty simple, the two semver-major jumps are just dropping support for node 6, not introducing anything else that might break