### PR TITLE
workflows: replace depracted set-env with github envs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Set Windows environment
         if: matrix.os == 'windows-latest'
         run: |
-          echo 'GYP_MSVS_VERSION=2015' >> $GITHUB_ENV
-          echo 'GYP_MSVS_OVERRIDE_PATH=C:\\Dummy' >> $GITHUB_ENV
+          Set-Variable -Name "GYP_MSVS_VERSION" -Value "2015"
+          Set-Variable -Name "GYP_MSVS_OVERRIDE_PATH" -Value "C:\\Dummy"
       - name: Lint Python
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
           pip install flake8 pytest
       - name: Set Windows environment
         if: matrix.os == 'windows-latest'
-        run:
+        run: |
           echo 'GYP_MSVS_VERSION=2015' >> $GITHUB_ENV
           echo 'GYP_MSVS_OVERRIDE_PATH=C:\\Dummy' >> $GITHUB_ENV
       - name: Lint Python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Set Windows environment
         if: matrix.os == 'windows-latest'
         run: |
+          import os
           os.environ["GYP_MSVS_VERSION"] = "2015"
           os.environ["GYP_MSVS_OVERRIDE_PATH"] = "C:\\Dummy"
         shell: python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   Tests:
     strategy:
-      fail-fast: false		
+      fail-fast: false
       max-parallel: 15
       matrix:
         node: [10.x, 12.x, 14.x]
@@ -32,8 +32,8 @@ jobs:
       - name: Set Windows environment
         if: matrix.os == 'windows-latest'
         run:
-          echo '::set-env name=GYP_MSVS_VERSION::2015'
-          echo '::set-env name=GYP_MSVS_OVERRIDE_PATH::C:\\Dummy'
+          echo 'GYP_MSVS_VERSION=2015' >> $GITHUB_ENV
+          echo 'GYP_MSVS_OVERRIDE_PATH=C:\\Dummy' >> $GITHUB_ENV
       - name: Lint Python
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Set Windows environment
         if: matrix.os == 'windows-latest'
         run: |
-          Set-Variable -Name "GYP_MSVS_VERSION" -Value "2015"
-          Set-Variable -Name "GYP_MSVS_OVERRIDE_PATH" -Value "C:\\Dummy"
+          echo "GYP_MSVS_VERSION=2015" >> $GITHUB_ENV
+          echo "GYP_MSVS_OVERRIDE_PATH=C:\\Dummy" >> $GITHUB_ENV
       - name: Lint Python
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,8 +32,9 @@ jobs:
       - name: Set Windows environment
         if: matrix.os == 'windows-latest'
         run: |
-          echo "GYP_MSVS_VERSION=2015" >> $GITHUB_ENV
-          echo "GYP_MSVS_OVERRIDE_PATH=C:\\Dummy" >> $GITHUB_ENV
+          os.environ["GYP_MSVS_VERSION"] = "2015"
+          os.environ["GYP_MSVS_OVERRIDE_PATH"] = "C:\\Dummy"
+        shell: python
       - name: Lint Python
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/gyp/pylib/gyp/MSVSVersion.py
+++ b/gyp/pylib/gyp/MSVSVersion.py
@@ -549,6 +549,9 @@ def SelectVisualStudioVersion(version="auto", allow_fallback=True):
         "2017": ("15.0",),
         "2019": ("16.0",),
     }
+    print('ENV OVERRIDES: \n')
+    print(os.environ.get("GYP_MSVS_OVERRIDE_PATH"))
+    print(os.environ.get("GYP_MSVS_VERSION"))
     override_path = os.environ.get("GYP_MSVS_OVERRIDE_PATH")
     if override_path:
         msvs_version = os.environ.get("GYP_MSVS_VERSION")

--- a/gyp/pylib/gyp/MSVSVersion.py
+++ b/gyp/pylib/gyp/MSVSVersion.py
@@ -550,8 +550,8 @@ def SelectVisualStudioVersion(version="auto", allow_fallback=True):
         "2019": ("16.0",),
     }
     print('ENV OVERRIDES: \n')
-    print(os.environ.get("GYP_MSVS_OVERRIDE_PATH"))
-    print(os.environ.get("GYP_MSVS_VERSION"))
+    for key in ("GYP_MSVS_OVERRIDE_PATH", "GYP_MSVS_VERSION"):
+        print("{}: {}".format(key, os.environ.get(key)))
     override_path = os.environ.get("GYP_MSVS_OVERRIDE_PATH")
     if override_path:
         msvs_version = os.environ.get("GYP_MSVS_VERSION")


### PR DESCRIPTION
Fixes #2231 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change

set-env is deprecated and builds will fail, this should fix it

