### PR TITLE
gyp: update gyp to v0.7.0

### DIFF
--- a/gyp/CHANGELOG.md
+++ b/gyp/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.7.0](https://www.github.com/nodejs/gyp-next/compare/v0.6.2...v0.7.0) (2020-12-17)
+
+
+### ⚠ BREAKING CHANGES
+
+* **msvs:** On Windows, arguments passed to the "action" commands are no longer transformed to replace slashes with backslashes.
+
+### Features
+
+* **xcode:** --cross-compiling overrides arch-specific settings ([973bae0](https://www.github.com/nodejs/gyp-next/commit/973bae0b7b08be7b680ecae9565fbd04b3e0787d))
+
+
+### Bug Fixes
+
+* **msvs:** do not fix paths in action command arguments ([fc22f83](https://www.github.com/nodejs/gyp-next/commit/fc22f8335e2016da4aae4f4233074bd651d2faea))
+* cmake on python 3 ([fd61f5f](https://www.github.com/nodejs/gyp-next/commit/fd61f5faa5275ec8fc98e3c7868c0dd46f109540))
+* ValueError: invalid mode: 'rU' while trying to load binding.gyp ([d0504e6](https://www.github.com/nodejs/gyp-next/commit/d0504e6700ce48f44957a4d5891b142a60be946f))
+* xcode cmake parsing ([eefe8d1](https://www.github.com/nodejs/gyp-next/commit/eefe8d10e99863bc4ac7e2ed32facd608d400d4b))
+
 ### [0.6.2](https://www.github.com/nodejs/gyp-next/compare/v0.6.1...v0.6.2) (2020-10-16)
 
 

--- a/gyp/pylib/gyp/generator/cmake.py
+++ b/gyp/pylib/gyp/generator/cmake.py
@@ -41,7 +41,7 @@ import gyp.xcode_emulation
 try:
     # maketrans moved to str in python3.
     _maketrans = string.maketrans
-except NameError:
+except (NameError, AttributeError):
     _maketrans = str.maketrans
 
 generator_default_variables = {
@@ -1047,7 +1047,7 @@ def WriteTarget(
 
         # XCode settings
         xcode_settings = config.get("xcode_settings", {})
-        for xcode_setting, xcode_value in xcode_settings.viewitems():
+        for xcode_setting, xcode_value in xcode_settings.items():
             SetTargetProperty(
                 output,
                 cmake_target_name,

--- a/gyp/pylib/gyp/generator/msvs.py
+++ b/gyp/pylib/gyp/generator/msvs.py
@@ -423,13 +423,7 @@ def _BuildCommandLineForRuleRaw(
         # file out of the raw command string, and some commands (like python) are
         # actually batch files themselves.
         command.insert(0, "call")
-        # Fix the paths
-        # TODO(quote): This is a really ugly heuristic, and will miss path fixing
-        #              for arguments like "--arg=path" or "/opt:path".
-        # If the argument starts with a slash or dash, it's probably a command line
-        # switch
-        arguments = [i if (i[:1] in "/-") else _FixPath(i) for i in cmd[1:]]
-        arguments = [i.replace("$(InputDir)", "%INPUTDIR%") for i in arguments]
+        arguments = [i.replace("$(InputDir)", "%INPUTDIR%") for i in cmd[1:]]
         arguments = [MSVSSettings.FixVCMacroSlashes(i) for i in arguments]
         if quote_cmd:
             # Support a mode for using cmd directly.

--- a/gyp/pylib/gyp/input.py
+++ b/gyp/pylib/gyp/input.py
@@ -231,7 +231,7 @@ def LoadOneBuildFile(build_file_path, data, aux_data, includes, is_target, check
         # Open the build file for read ('r') with universal-newlines mode ('U')
         # to make sure platform specific newlines ('\r\n' or '\r') are converted to '\n'
         # which otherwise will fail eval()
-        if sys.platform == "zos":
+        if PY3 or sys.platform == "zos":
             # On z/OS, universal-newlines mode treats the file as an ascii file.
             # But since node-gyp produces ebcdic files, do not use that mode.
             build_file_contents = open(build_file_path, "r").read()

--- a/gyp/setup.py
+++ b/gyp/setup.py
@@ -15,7 +15,7 @@ with open(path.join(here, "README.md")) as in_file:
 
 setup(
     name="gyp-next",
-    version="0.6.2",
+    version="0.7.0",
     description="A fork of the GYP build system for use in the Node.js projects",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
### ⚠ BREAKING CHANGES

* **msvs:** On Windows, arguments passed to the "action" commands are no longer transformed to replace slashes with backslashes.

### Features

* **xcode:** --cross-compiling overrides arch-specific settings ([973bae0](https://www.github.com/nodejs/gyp-next/commit/973bae0b7b08be7b680ecae9565fbd04b3e0787d))


### Bug Fixes

* **msvs:** do not fix paths in action command arguments ([fc22f83](https://www.github.com/nodejs/gyp-next/commit/fc22f8335e2016da4aae4f4233074bd651d2faea))
* cmake on python 3 ([fd61f5f](https://www.github.com/nodejs/gyp-next/commit/fd61f5faa5275ec8fc98e3c7868c0dd46f109540))
* ValueError: invalid mode: 'rU' while trying to load binding.gyp ([d0504e6](https://www.github.com/nodejs/gyp-next/commit/d0504e6700ce48f44957a4d5891b142a60be946f))
* xcode cmake parsing ([eefe8d1](https://www.github.com/nodejs/gyp-next/commit/eefe8d10e99863bc4ac7e2ed32facd608d400d4b))

