### PR TITLE
ci: migrate deprecated grammar

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,9 +31,9 @@ jobs:
           pip install flake8 pytest
       - name: Set Windows environment
         if: matrix.os == 'windows-latest'
-        run:
-          echo '::set-env name=GYP_MSVS_VERSION::2015'
-          echo '::set-env name=GYP_MSVS_OVERRIDE_PATH::C:\\Dummy'
+        run: |
+          echo 'GYP_MSVS_VERSION=2015' >> $Env:GITHUB_ENV
+          echo 'GYP_MSVS_OVERRIDE_PATH=C:\\Dummy' >> $Env:GITHUB_ENV
       - name: Lint Python
         if: matrix.os == 'ubuntu-latest'
         run: |


### PR DESCRIPTION
Fixes #2231 

Ref: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/.

