### PR TITLE
gyp: remove support for Python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Depending on your operating system, you will need to install:
 
 ### On Unix
 
-   * Python v2.7, v3.5, v3.6, v3.7, or v3.8
+   * Python v3.5, v3.6, v3.7, v3.8, or v3.9
    * `make`
    * A proper C/C++ compiler toolchain, like [GCC](https://gcc.gnu.org)
 
@@ -38,19 +38,13 @@ Depending on your operating system, you will need to install:
 
 **ATTENTION**: If your Mac has been _upgraded_ to macOS Catalina (10.15), please read [macOS_Catalina.md](macOS_Catalina.md).
 
-   * Python v2.7, v3.5, v3.6, v3.7, or v3.8
+   * Python v3.5, v3.6, v3.7, v3.8, or v3.9
    * [Xcode](https://developer.apple.com/xcode/download/)
      * You also need to install the `XCode Command Line Tools` by running `xcode-select --install`. Alternatively, if you already have the full Xcode installed, you can find them under the menu `Xcode -> Open Developer Tool -> More Developer Tools...`. This step will install `clang`, `clang++`, and `make`.
 
 ### On Windows
 
 Install the current version of Python from the [Microsoft Store package](https://docs.python.org/3/using/windows.html#the-microsoft-store-package).
-
-#### Option 1
-
-Install all the required tools and configurations using Microsoft's [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools) using `npm install --global windows-build-tools` from an elevated PowerShell or CMD.exe (run as Administrator).
-
-#### Option 2
 
 Install tools and configuration manually:
    * Install Visual C++ Build Environment: [Visual Studio Build Tools](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools)
@@ -64,8 +58,8 @@ Install tools and configuration manually:
 
 ### Configuring Python Dependency
 
-`node-gyp` requires that you have installed a compatible version of Python, one of: v2.7, v3.5, v3.6,
-v3.7, or v3.8. If you have multiple Python versions installed, you can identify which Python
+`node-gyp` requires that you have installed a compatible version of Python, one of: v3.5, v3.6,
+v3.7, v3.8, or v3.9. If you have multiple Python versions installed, you can identify which Python
 version `node-gyp` should use in one of the following ways:
 
 1. by setting the `--python` command-line option, e.g.:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Depending on your operating system, you will need to install:
 
 ### On Unix
 
-   * Python v3.5, v3.6, v3.7, v3.8, or v3.9
+   * Python v3.6, v3.7, v3.8, or v3.9
    * `make`
    * A proper C/C++ compiler toolchain, like [GCC](https://gcc.gnu.org)
 
@@ -38,7 +38,7 @@ Depending on your operating system, you will need to install:
 
 **ATTENTION**: If your Mac has been _upgraded_ to macOS Catalina (10.15), please read [macOS_Catalina.md](macOS_Catalina.md).
 
-   * Python v3.5, v3.6, v3.7, v3.8, or v3.9
+   * Python v3.6, v3.7, v3.8, or v3.9
    * [Xcode](https://developer.apple.com/xcode/download/)
      * You also need to install the `XCode Command Line Tools` by running `xcode-select --install`. Alternatively, if you already have the full Xcode installed, you can find them under the menu `Xcode -> Open Developer Tool -> More Developer Tools...`. This step will install `clang`, `clang++`, and `make`.
 
@@ -58,8 +58,8 @@ Install tools and configuration manually:
 
 ### Configuring Python Dependency
 
-`node-gyp` requires that you have installed a compatible version of Python, one of: v3.5, v3.6,
-v3.7, v3.8, or v3.9. If you have multiple Python versions installed, you can identify which Python
+`node-gyp` requires that you have installed a compatible version of Python, one of: v3.6, v3.7,
+v3.8, or v3.9. If you have multiple Python versions installed, you can identify which Python
 version `node-gyp` should use in one of the following ways:
 
 1. by setting the `--python` command-line option, e.g.:

--- a/gyp/pylib/gyp/MSVSSettings.py
+++ b/gyp/pylib/gyp/MSVSSettings.py
@@ -22,11 +22,9 @@ import sys
 _msvs_validators = {}
 _msbuild_validators = {}
 
-
 # A dictionary of settings converters. The key is the tool name, the value is
 # a dictionary mapping setting names to conversion functions.
 _msvs_to_msbuild_converters = {}
-
 
 # Tool name mapping from MSVS to MSBuild.
 _msbuild_name_of_tool = {}

--- a/gyp/pylib/gyp/generator/android.py
+++ b/gyp/pylib/gyp/generator/android.py
@@ -486,7 +486,9 @@ class AndroidMkWriter:
                     self.LocalPathify(os.path.join(copy["destination"], filename))
                 )
 
-                self.WriteLn(f"{output}: {path} $(GYP_TARGET_DEPENDENCIES) | $(ACP)")
+                self.WriteLn(
+                    f"{output}: {path} $(GYP_TARGET_DEPENDENCIES) | $(ACP)"
+                )
                 self.WriteLn("\t@echo Copying: $@")
                 self.WriteLn("\t$(hide) mkdir -p $(dir $@)")
                 self.WriteLn("\t$(hide) $(ACP) -rpf $< $@")

--- a/test/fixtures/test-charmap.py
+++ b/test/fixtures/test-charmap.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import sys
 import locale
 
@@ -18,9 +17,9 @@ def main():
     pass
 
   textmap = {
-    'cp936': u'\u4e2d\u6587',
-    'cp1252': u'Lat\u012Bna',
-    'cp932': u'\u306b\u307b\u3093\u3054'
+    'cp936': '\u4e2d\u6587',
+    'cp1252': 'Lat\u012Bna',
+    'cp932': '\u306b\u307b\u3093\u3054'
   }
   if encoding in textmap:
     print(textmap[encoding])


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Ironic that #2300 is about the migration from 2 --> 3 ;-)

Roughly corresponds with nodejs/node#36691 and ~nodejs/gyp-next#88~

~Blocked by #2318~

Python 2 died one year ago so let's only support the currently supported versions of CPython:
https://devguide.python.org/#status-of-python-branches

Removes `windows-build-tools` because its current release unfortunately still installs legacy Python.
felixrieseberg/windows-build-tools#206

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

