### PR TITLE
gyp: update gyp.el to change case to cl-case

### DIFF
--- a/gyp/tools/emacs/gyp.el
+++ b/gyp/tools/emacs/gyp.el
@@ -213,7 +213,7 @@
                 string-start)
       (setq string-start (gyp-parse-to limit))
       (if string-start
-          (setq group (case (gyp-section-at-point)
+          (setq group (cl-case (gyp-section-at-point)
                         ('dependencies 1)
                         ('variables 2)
                         ('conditions 2)


### PR DESCRIPTION
##### Checklist
- [x] commit message follows [commit guidelines]

##### Description of change
‘case’ is an obsolete alias (as of 27.1); use ‘cl-case’ instead.