### PR TITLE
lib: avoid changing process.config

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -96,7 +96,7 @@ function configure (gyp, argv, callback) {
 
     log.verbose('build/' + configFilename, 'creating config file')
 
-    var config = process.config || {}
+    var config = Object.assign({}, process.config)
     var defaults = config.target_defaults
     var variables = config.variables
 


### PR DESCRIPTION
##### Checklist

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change

It is deprecated and will emit a warning in Node.js 16.

Refs: https://github.com/nodejs/node/pull/36902
