### PR TITLE
gyp: update gyp to v0.8.1

### DIFF
--- a/gyp/.github/workflows/node-gyp.yml
+++ b/gyp/.github/workflows/node-gyp.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           repository: nodejs/node-gyp
           path: node-gyp
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 14.x
       - uses: actions/setup-python@v2

--- a/gyp/.github/workflows/release-please.yml
+++ b/gyp/.github/workflows/release-please.yml
@@ -8,7 +8,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v2.5.6
+      - uses: GoogleCloudPlatform/release-please-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: python

--- a/gyp/CHANGELOG.md
+++ b/gyp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### [0.8.1](https://www.github.com/nodejs/gyp-next/compare/v0.8.0...v0.8.1) (2021-02-18)
+
+
+### Bug Fixes
+
+* update shebang lines from python to python3 ([#94](https://www.github.com/nodejs/gyp-next/issues/94)) ([a1b0d41](https://www.github.com/nodejs/gyp-next/commit/a1b0d4171a8049a4ab7a614202063dec332f2df4))
+
 ## [0.8.0](https://www.github.com/nodejs/gyp-next/compare/v0.7.0...v0.8.0) (2021-01-15)
 
 

--- a/gyp/gyp_main.py
+++ b/gyp/gyp_main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2009 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/gyp/pylib/gyp/MSVSSettings.py
+++ b/gyp/pylib/gyp/MSVSSettings.py
@@ -22,9 +22,11 @@ import sys
 _msvs_validators = {}
 _msbuild_validators = {}
 
+
 # A dictionary of settings converters. The key is the tool name, the value is
 # a dictionary mapping setting names to conversion functions.
 _msvs_to_msbuild_converters = {}
+
 
 # Tool name mapping from MSVS to MSBuild.
 _msbuild_name_of_tool = {}

--- a/gyp/pylib/gyp/MSVSSettings_test.py
+++ b/gyp/pylib/gyp/MSVSSettings_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/gyp/pylib/gyp/__init__.py
+++ b/gyp/pylib/gyp/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/gyp/pylib/gyp/common_test.py
+++ b/gyp/pylib/gyp/common_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/gyp/pylib/gyp/easy_xml_test.py
+++ b/gyp/pylib/gyp/easy_xml_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2011 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/gyp/pylib/gyp/flock_tool.py
+++ b/gyp/pylib/gyp/flock_tool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2011 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/gyp/pylib/gyp/generator/android.py
+++ b/gyp/pylib/gyp/generator/android.py
@@ -486,9 +486,7 @@ class AndroidMkWriter:
                     self.LocalPathify(os.path.join(copy["destination"], filename))
                 )
 
-                self.WriteLn(
-                    f"{output}: {path} $(GYP_TARGET_DEPENDENCIES) | $(ACP)"
-                )
+                self.WriteLn(f"{output}: {path} $(GYP_TARGET_DEPENDENCIES) | $(ACP)")
                 self.WriteLn("\t@echo Copying: $@")
                 self.WriteLn("\t$(hide) mkdir -p $(dir $@)")
                 self.WriteLn("\t$(hide) $(ACP) -rpf $< $@")

--- a/gyp/pylib/gyp/generator/msvs_test.py
+++ b/gyp/pylib/gyp/generator/msvs_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/gyp/pylib/gyp/generator/ninja_test.py
+++ b/gyp/pylib/gyp/generator/ninja_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/gyp/pylib/gyp/generator/xcode_test.py
+++ b/gyp/pylib/gyp/generator/xcode_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2013 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/gyp/pylib/gyp/input_test.py
+++ b/gyp/pylib/gyp/input_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2013 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/gyp/pylib/gyp/mac_tool.py
+++ b/gyp/pylib/gyp/mac_tool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/gyp/pylib/gyp/win_tool.py
+++ b/gyp/pylib/gyp/win_tool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/gyp/setup.py
+++ b/gyp/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2009 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
@@ -15,7 +15,7 @@ with open(path.join(here, "README.md")) as in_file:
 
 setup(
     name="gyp-next",
-    version="0.8.0",
+    version="0.8.1",
     description="A fork of the GYP build system for use in the Node.js projects",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/gyp/test_gyp.py
+++ b/gyp/test_gyp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/gyp/tools/graphviz.py
+++ b/gyp/tools/graphviz.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2011 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/gyp/tools/pretty_gyp.py
+++ b/gyp/tools/pretty_gyp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/gyp/tools/pretty_sln.py
+++ b/gyp/tools/pretty_sln.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/gyp/tools/pretty_vcproj.py
+++ b/gyp/tools/pretty_vcproj.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

Ran `./update-gyp.py v0.8.1` to pull in `gyp` from `gyp-next` v0.8.1

- See the CHANGELOG: https://github.com/nodejs/gyp-next/releases/tag/v0.8.1
- and see the commit-for-commit comparison: https://github.com/nodejs/gyp-next/compare/v0.8.0...v0.8.1

In terms of actual source code changes, this is strictly updating the shebang lines of various Python source code files from `#!/usr/bin/env python` to `#!/usr/bin/env python3`... and a couple of functionally identical whitespace/indentation changes. (Other changes are version updates to GitHub actions in workflows for that repository, and a new entry in `gyp`'s `CHANGELOG.md` -- not functionally impactful to `node-gyp`.)

Partially addresses https://github.com/nodejs/node-gyp/issues/2351. (Addresses https://github.com/nodejs/node-gyp/issues/2351 for users with Python 3 >=3.6 as the first `python3` on their PATH.)