### PR TITLE
Improve our flake8 linting tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-# TODO: Line 47, enable pytest --doctest-modules
+# TODO: Line 43, enable pytest --doctest-modules
 
 name: Tests
 on: [push, pull_request]
@@ -36,16 +36,10 @@ jobs:
           echo 'GYP_MSVS_OVERRIDE_PATH=C:\\Dummy' >> $Env:GITHUB_ENV
       - name: Lint Python
         if: matrix.os == 'ubuntu-latest'
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        run: flake8 . --ignore=E203,W503  --max-complexity=101 --max-line-length=88 --show-source --statistics
       - name: Run Python tests
-        run: |
-          python -m pytest
+        run: python -m pytest
       # - name: Run doctests with pytest
       #   run: python -m pytest --doctest-modules
       - name: Run Node tests
-        run: |
-          npm test
+        run: npm test

--- a/gyp/pylib/gyp/generator/msvs.py
+++ b/gyp/pylib/gyp/generator/msvs.py
@@ -3276,9 +3276,9 @@ def _GetMSBuildPropertyGroup(spec, label, properties):
             # append to the default value. I.e. PATH=$(PATH);other_path
             edges.update(
                 {
-                        v
-                        for v in MSVS_VARIABLE_REFERENCE.findall(value)
-                        if v in properties and v != node
+                    v
+                    for v in MSVS_VARIABLE_REFERENCE.findall(value)
+                    if v in properties and v != node
                 }
             )
         return edges

--- a/test/fixtures/test-charmap.py
+++ b/test/fixtures/test-charmap.py
@@ -2,28 +2,30 @@ import sys
 import locale
 
 try:
-  reload(sys)
+    reload(sys)
 except NameError:  # Python 3
-  pass
-
-def main():
-  encoding = locale.getdefaultlocale()[1]
-  if not encoding:
-    return False
-
-  try:
-    sys.setdefaultencoding(encoding)
-  except AttributeError:  # Python 3
     pass
 
-  textmap = {
-    'cp936': '\u4e2d\u6587',
-    'cp1252': 'Lat\u012Bna',
-    'cp932': '\u306b\u307b\u3093\u3054'
-  }
-  if encoding in textmap:
-    print(textmap[encoding])
-  return True
 
-if __name__ == '__main__':
-  print(main())
+def main():
+    encoding = locale.getdefaultlocale()[1]
+    if not encoding:
+        return False
+
+    try:
+        sys.setdefaultencoding(encoding)
+    except AttributeError:  # Python 3
+        pass
+
+    textmap = {
+        "cp936": "\u4e2d\u6587",
+        "cp1252": "Lat\u012Bna",
+        "cp932": "\u306b\u307b\u3093\u3054",
+    }
+    if encoding in textmap:
+        print(textmap[encoding])
+    return True
+
+
+if __name__ == "__main__":
+    print(main())

--- a/update-gyp.py
+++ b/update-gyp.py
@@ -4,14 +4,13 @@ import argparse
 import os
 import shutil
 import subprocess
-import sys
 import tarfile
 import tempfile
 import urllib.request
 
 BASE_URL = "https://github.com/nodejs/gyp-next/archive/"
 CHECKOUT_PATH = os.path.dirname(os.path.realpath(__file__))
-CHECKOUT_GYP_PATH = os.path.join(CHECKOUT_PATH, 'gyp')
+CHECKOUT_GYP_PATH = os.path.join(CHECKOUT_PATH, "gyp")
 
 parser = argparse.ArgumentParser()
 parser.add_argument("tag", help="gyp tag to update to")
@@ -21,25 +20,27 @@ tar_url = BASE_URL + args.tag + ".tar.gz"
 
 changed_files = subprocess.check_output(["git", "diff", "--name-only"]).strip()
 if changed_files:
-  raise Exception("Can't update gyp while you have uncommitted changes in node-gyp")
+    raise Exception("Can't update gyp while you have uncommitted changes in node-gyp")
 
 with tempfile.TemporaryDirectory() as tmp_dir:
-  tar_file = os.path.join(tmp_dir, 'gyp.tar.gz')
-  unzip_target = os.path.join(tmp_dir, 'gyp')
-  with open(tar_file, 'wb') as f:
-    print("Downloading gyp-next@" + args.tag + " into temporary directory...")
-    print("From: " + tar_url)
-    with urllib.request.urlopen(tar_url) as in_file:
-        f.write(in_file.read())
+    tar_file = os.path.join(tmp_dir, "gyp.tar.gz")
+    unzip_target = os.path.join(tmp_dir, "gyp")
+    with open(tar_file, "wb") as f:
+        print("Downloading gyp-next@" + args.tag + " into temporary directory...")
+        print("From: " + tar_url)
+        with urllib.request.urlopen(tar_url) as in_file:
+            f.write(in_file.read())
 
-    print("Unzipping...")
-    with tarfile.open(tar_file, "r:gz") as tar_ref:
-      tar_ref.extractall(unzip_target)
-    
-    print("Moving to current checkout (" + CHECKOUT_PATH + ")...")
-    if os.path.exists(CHECKOUT_GYP_PATH):
-      shutil.rmtree(CHECKOUT_GYP_PATH)
-    shutil.move(os.path.join(unzip_target, os.listdir(unzip_target)[0]), CHECKOUT_GYP_PATH)
+        print("Unzipping...")
+        with tarfile.open(tar_file, "r:gz") as tar_ref:
+            tar_ref.extractall(unzip_target)
+
+        print("Moving to current checkout (" + CHECKOUT_PATH + ")...")
+        if os.path.exists(CHECKOUT_GYP_PATH):
+            shutil.rmtree(CHECKOUT_GYP_PATH)
+        shutil.move(
+            os.path.join(unzip_target, os.listdir(unzip_target)[0]), CHECKOUT_GYP_PATH
+        )
 
 subprocess.check_output(["git", "add", "gyp"], cwd=CHECKOUT_PATH)
 subprocess.check_output(["git", "commit", "-m", "gyp: update gyp to " + args.tag])


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

This adds many more flake8 linting tests to align with `gyp-next`.  This PR ran ` black ./test/fixtures/test-charmap.py ./update-gyp.py` to format those files to align with https://github.com/psf/black formatting.