### PR TITLE
Add Python symlink to path (for non-Windows OSes only)

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -185,6 +185,13 @@ function build (gyp, argv, callback) {
       }
     }
 
+    if (!win) {
+      // Add build-time dependency symlinks (such as Python) to PATH
+      const buildBinsDir = path.resolve('build', 'node_gyp_bins')
+      process.env.PATH = `${buildBinsDir}:${process.env.PATH}`
+      log.verbose('bin symlinks', `adding symlinks (such as Python), at "${buildBinsDir}", to PATH`)
+    }
+
     var proc = gyp.spawn(command, argv)
     proc.on('exit', onExit)
   }

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -100,13 +100,13 @@ function configure (gyp, argv, callback) {
 
     fs.unlink(symlinkDestination, function (err) {
       if (err && err.code !== 'ENOENT') {
-        log.warn('python symlink', 'error when attempting to remove existing symlink')
-        log.warn('python symlink', err.stack, 'errno: ' + err.errno)
+        log.verbose('python symlink', 'error when attempting to remove existing symlink')
+        log.verbose('python symlink', err.stack, 'errno: ' + err.errno)
       }
       fs.symlink(python, symlinkDestination, function (err) {
         if (err) {
-          log.warn('python symlink', 'error when attempting to create Python symlink')
-          log.warn('python symlink', err.stack, 'errno: ' + err.errno)
+          log.verbose('python symlink', 'error when attempting to create Python symlink')
+          log.verbose('python symlink', err.stack, 'errno: ' + err.errno)
         }
       })
     })

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -100,11 +100,13 @@ function configure (gyp, argv, callback) {
 
     fs.unlink(symlinkDestination, function (err) {
       if (err && err.code !== 'ENOENT') {
-        log.warn('python symlink', 'error when attempting to remove existing symlink\n', err)
+        log.warn('python symlink', 'error when attempting to remove existing symlink')
+        log.warn('python symlink', err.stack)
       }
       fs.symlink(python, symlinkDestination, function (err) {
         if (err) {
-          log.warn('python symlink', 'error when attempting to create Python symlink\n', err)
+          log.warn('python symlink', 'error when attempting to create Python symlink')
+          log.warn('python symlink', err.stack)
         }
       })
     })

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -98,8 +98,15 @@ function configure (gyp, argv, callback) {
 
     log.verbose('python symlink', `creating symlink to "${python}" at "${symlinkDestination}"`)
 
-    fs.unlink(symlinkDestination, function () {
-      fs.symlink(python, symlinkDestination, function () {})
+    fs.unlink(symlinkDestination, function (err) {
+      if (err && err.code !== 'ENOENT') {
+        log.warn('python symlink', 'error when attempting to remove existing symlink\n', err)
+      }
+      fs.symlink(python, symlinkDestination, function (err) {
+        if (err) {
+          log.warn('python symlink', 'error when attempting to create Python symlink\n', err)
+        }
+      })
     })
   }
 

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -101,12 +101,12 @@ function configure (gyp, argv, callback) {
     fs.unlink(symlinkDestination, function (err) {
       if (err && err.code !== 'ENOENT') {
         log.warn('python symlink', 'error when attempting to remove existing symlink')
-        log.warn('python symlink', err.stack)
+        log.warn('python symlink', err.stack, 'errno: ' + err.errno)
       }
       fs.symlink(python, symlinkDestination, function (err) {
         if (err) {
           log.warn('python symlink', 'error when attempting to create Python symlink')
-          log.warn('python symlink', err.stack)
+          log.warn('python symlink', err.stack, 'errno: ' + err.errno)
         }
       })
     })

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -17,6 +17,7 @@ if (win) {
 function configure (gyp, argv, callback) {
   var python
   var buildDir = path.resolve('build')
+  var buildBinsDir = path.join(buildDir, 'node_gyp_bins')
   var configNames = ['config.gypi', 'common.gypi']
   var configs = []
   var nodeDir
@@ -73,7 +74,9 @@ function configure (gyp, argv, callback) {
 
   function createBuildDir () {
     log.verbose('build dir', 'attempting to create "build" dir: %s', buildDir)
-    fs.mkdir(buildDir, { recursive: true }, function (err, isNew) {
+
+    const deepestBuildDirSubdirectory = win ? buildDir : buildBinsDir
+    fs.mkdir(deepestBuildDirSubdirectory, { recursive: true }, function (err, isNew) {
       if (err) {
         return callback(err)
       }
@@ -84,8 +87,19 @@ function configure (gyp, argv, callback) {
         findVisualStudio(release.semver, gyp.opts.msvs_version,
           createConfigFile)
       } else {
+        createPythonSymlink()
         createConfigFile()
       }
+    })
+  }
+
+  function createPythonSymlink () {
+    const symlinkDestination = path.join(buildBinsDir, 'python3')
+
+    log.verbose('python symlink', `creating symlink to "${python}" at "${symlinkDestination}"`)
+
+    fs.unlink(symlinkDestination, function () {
+      fs.symlink(python, symlinkDestination, function () {})
     })
   }
 

--- a/test/test-configure-python.js
+++ b/test/test-configure-python.js
@@ -14,7 +14,9 @@ const configure = requireInject('../lib/configure', {
     mkdir: function (dir, options, cb) { cb() },
     promises: {
       writeFile: function (file, data) { return Promise.resolve(null) }
-    }
+    },
+    unlink: function (path, cb) { cb() },
+    symlink: function (target, path, cb) { cb() }
   }
 })
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

An attempt to fix https://github.com/nodejs/node-gyp/issues/2351 for the rest of users not yet addressed by https://github.com/nodejs/node-gyp/pull/2355.

- Symlink the valid Python binary found by `lib/find-python.js` at `build/node_gyp_bins/python3`
- Add `build/node_gyp_bins` to the `PATH` just before building
  - Ensures any of the build-time Python scripts (such as `build/gyp-mac-tool` or `build/gyp-flock-tool`) will be run with the Python binary validated by`lib/find-python.js`

##### More notes/thoughts/explanation

**The corner case/bug is not applicable to Windows. So this PR changes nothing on Windows.**

<details>

This PR changes nothing on Windows. The bug being fixed is Not Applicable to Windows; There are no Python scripts to run at build time on Windows, per my testing, nor as far as I can deduce from research.

_(If someone can prove that there are ever Python scripts at build-time on Windows, or the maintainers prefer to do something on Windows just in case, I can work on a solution involving writing a batch script to `build/node_gyp_bins/python3.bat` that runs the validated Python binary from `lib/find-python.js`. That should work just as well. Non-administrator users cannot create symlinks by default on Windows, so in my opinion we can't rely on symlinks on Windows. But again, I don't think there's any Python to run during the build phase on Windows. So this all should be moot!)_

</details>

**Who is this for?**

Specifically, folks with older or somehow invalid `python3` (< 3.6) first on their `PATH`, who have nevertheless managed to supply a newer, valid Python binary to `node-gyp`, probably by command-line `--python=/some/python3` or as an env var `PYTHON=/some/python3`.

<details>

_(Note that Debian [Jessie](https://packages.debian.org/jessie/python3) and [Stretch](https://packages.debian.org/jessie/python3), as well as Ubuntu [Xenial](https://packages.ubuntu.com/xenial/python3) all ship `python3` older than 3.6. Perhaps these users will get newer Python3 and opt not to put it early on the PATH?)_

</details>

**What does this PR achieve?** A user with older Python on their PATH who manages to supply a valid Python version to `node-gyp` and make it through the configure stage (including `lib/find-python.js`) should not abruptly hit errors at the build stage. This PR aims to solve that corner case. (See: https://github.com/nodejs/node-gyp/issues/2351 for details.)

**Where did the idea come from?** This was inspired by the approach that `nodejs/node` takes when setting up the build for NodeJS itself. See `configure.py` at that repository:

- https://github.com/nodejs/node/blob/v15.14.0/configure.py#L1826-L1857 and
- https://github.com/nodejs/node/blob/v15.14.0/configure.py#L1960-L1965