### PR TITLE
lib: deep-copy process.config during configure

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -96,7 +96,7 @@ function configure (gyp, argv, callback) {
 
     log.verbose('build/' + configFilename, 'creating config file')
 
-    var config = JSON.parse(JSON.stringify(process.config))
+    var config = process.config ? JSON.parse(JSON.stringify(process.config)) : {}
     var defaults = config.target_defaults
     var variables = config.variables
 

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -96,7 +96,7 @@ function configure (gyp, argv, callback) {
 
     log.verbose('build/' + configFilename, 'creating config file')
 
-    var config = Object.assign({}, process.config)
+    var config = JSON.parse(JSON.stringify(process.config))
     var defaults = config.target_defaults
     var variables = config.variables
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

In `lib/configure.js`, when creating the local `config` object as a copy of `process.config`, use `JSON.parse(JSON.stringify(process.config)` rather than `Object.assign({}, process.config)`.

Makes it so we won't modify properties of child objects of the original `process.config`. (Modifying `process.config` or its children is deprecated as of Node 16.)

<details><summary>Background</summary>

Testing with the latest Node v16 nightly build revealed that the deprecation warning from https://github.com/nodejs/node/pull/36902 was still showing with the latest `node-gyp` v8.0.0 during the  `config` or `rebuild` commands.

```
// ...
gyp info find Python using Python version 3.9.0 found at "/usr/local/bin/python3"
(node:21174) [DEP0150] DeprecationWarning: Setting process.config is deprecated. In the future the property will be read-only.
(Use `node --trace-deprecation ...` to show where the warning was created)
gyp info spawn /usr/local/bin/python3
// ...
```

With the `--trace-deprecation` flag:

```
// ...
gyp info find Python using Python version 3.9.0 found at "/usr/local/bin/python3"
(node:21184) [DEP0150] DeprecationWarning: Setting process.config is deprecated. In the future the property will be read-only.
    at Object.maybeWarn (node:internal/bootstrap/node:79:15)
    at Object.set (node:internal/bootstrap/node:103:10)
    at createConfigFile (/Users/[user]/node-gyp/lib/configure.js:117:21)
    at /Users/[user]/node-gyp/lib/configure.js:84:9
    at FSReqCallback.oncomplete (node:fs:183:23)
gyp info spawn /usr/local/bin/python3
// ...
```

In Node v16, the `process.config` object has a proxy function which warns once if it, or any of its properties, or any of its child objects' properties, are modified. And it turns out that `Object.assign()` does not deep copy any nested objects of the object you assign from. Nested objects are copied by reference rather than by value. So by modifying (for example) our local `config.defaults.cflags` array, we are also modifying `process.config.target_defaults.cflags`.

</details>

See the discussion at the bottom of https://github.com/nodejs/node-gyp/pull/2322 for more details.