### PR TITLE
lib: log as yes/no whether build dir was created

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -76,7 +76,9 @@ function configure (gyp, argv, callback) {
       if (err) {
         return callback(err)
       }
-      log.verbose('build dir', '"build" dir needed to be created?', isNew)
+      log.verbose(
+        'build dir', '"build" dir needed to be created?', isNew ? 'Yes' : 'No'
+      )
       if (win) {
         findVisualStudio(release.semver, gyp.opts.msvs_version,
           createConfigFile)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

When logging `"build" dir needed to be created?`, put "Yes" or "No" instead of `[path that was created]` or `undefined` .

<details>

There is a bit of verbose logging in the package that informs the user whether the build dir needed to be created (as opposed to having already been there from a previous `node-gyp configure` run).

This bit of logging apparently expected to be given a boolean, but was receiving either a path or `undefined` based on the result of [`fs.mkdir()`](https://nodejs.org/docs/latest-v14.x/api/fs.html#fs_fs_mkdir_path_options_callback). So it was logging either the path of the build dir that was just created or `undefined`, somewhat nonsensically if you don't know what's going on behind the scenes.

Now it prints either "Yes" or "No".

Before:

`gyp verb build dir "build" dir needed to be created? /Users/[user]/[package-name]/build`,
`gyp verb build dir "build" dir needed to be created? undefined`

After:

`gyp verb build dir "build" dir needed to be created? Yes`,
`gyp verb build dir "build" dir needed to be created? No`

</details>

**Note:** The CI failure was a timeout on a single Ubuntu run. All other runs passed. This happens to me seemingly at random/as flakiness. I don't think it is caused by this tiny PR. CI passed for this commit at my fork: https://github.com/DeeDeeG/node-gyp/actions/runs/739328726 I believe it would pass here if re-run.