### PR TITLE
lib: fail gracefully if we can't find the username

### DIFF
--- a/lib/find-python.js
+++ b/lib/find-python.js
@@ -8,7 +8,7 @@ const win = process.platform === 'win32'
 const logWithPrefix = require('./util').logWithPrefix
 
 const systemDrive = process.env.SystemDrive || 'C:'
-const username = process.env.USERNAME || process.env.USER || require('os').userInfo().username
+const username = process.env.USERNAME || process.env.USER || getOsUserInfo()
 const localAppData = process.env.LOCALAPPDATA || `${systemDrive}\\${username}\\AppData\\Local`
 const programFiles = process.env.ProgramW6432 || process.env.ProgramFiles || `${systemDrive}\\Program Files`
 const programFilesX86 = process.env['ProgramFiles(x86)'] || `${programFiles} (x86)`
@@ -22,6 +22,12 @@ for (const majorMinor of ['39', '38', '37', '36']) {
     `${programFiles}\\Python${majorMinor}-32\\python.exe`,
     `${programFilesX86}\\Python${majorMinor}-32\\python.exe`
   )
+}
+
+function getOsUserInfo () {
+  try {
+    return require('os').userInfo().username
+  } catch {}
 }
 
 function PythonFinder (configPython, callback) {

--- a/lib/find-python.js
+++ b/lib/find-python.js
@@ -10,18 +10,27 @@ const logWithPrefix = require('./util').logWithPrefix
 const systemDrive = process.env.SystemDrive || 'C:'
 const username = process.env.USERNAME || process.env.USER || getOsUserInfo()
 const localAppData = process.env.LOCALAPPDATA || `${systemDrive}\\${username}\\AppData\\Local`
+const foundLocalAppData = process.env.LOCALAPPDATA || username
 const programFiles = process.env.ProgramW6432 || process.env.ProgramFiles || `${systemDrive}\\Program Files`
 const programFilesX86 = process.env['ProgramFiles(x86)'] || `${programFiles} (x86)`
 
 const winDefaultLocationsArray = []
 for (const majorMinor of ['39', '38', '37', '36']) {
-  winDefaultLocationsArray.push(
-    `${localAppData}\\Programs\\Python\\Python${majorMinor}\\python.exe`,
-    `${programFiles}\\Python${majorMinor}\\python.exe`,
-    `${localAppData}\\Programs\\Python\\Python${majorMinor}-32\\python.exe`,
-    `${programFiles}\\Python${majorMinor}-32\\python.exe`,
-    `${programFilesX86}\\Python${majorMinor}-32\\python.exe`
-  )
+  if (foundLocalAppData) {
+    winDefaultLocationsArray.push(
+      `${localAppData}\\Programs\\Python\\Python${majorMinor}\\python.exe`,
+      `${programFiles}\\Python${majorMinor}\\python.exe`,
+      `${localAppData}\\Programs\\Python\\Python${majorMinor}-32\\python.exe`,
+      `${programFiles}\\Python${majorMinor}-32\\python.exe`,
+      `${programFilesX86}\\Python${majorMinor}-32\\python.exe`
+    )
+  } else {
+    winDefaultLocationsArray.push(
+      `${programFiles}\\Python${majorMinor}\\python.exe`,
+      `${programFiles}\\Python${majorMinor}-32\\python.exe`,
+      `${programFilesX86}\\Python${majorMinor}-32\\python.exe`
+    )
+  }
 }
 
 function getOsUserInfo () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description of change
<!-- Provide a description of the change -->

In `lib\find-python.js`...

- Only attempt to get `os.userInfo().username` in a `try {}` block, since it's not 100% guaranteed to succeed
- If we can't find the `Appdata\Local` directory, skip checking paths under `Appdata\Local`.

Fixes https://github.com/nodejs/node-gyp/issues/2373