### PR TITLE
gyp: update gyp to v0.9.1

### DIFF
--- a/gyp/.github/workflows/release-please.yml
+++ b/gyp/.github/workflows/release-please.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
 
 name: release-please
 jobs:

--- a/gyp/CHANGELOG.md
+++ b/gyp/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+### [0.9.1](https://www.github.com/nodejs/gyp-next/compare/v0.9.0...v0.9.1) (2021-05-14)
+
+
+### Bug Fixes
+
+* py lint ([3b6a8ee](https://www.github.com/nodejs/gyp-next/commit/3b6a8ee7a66193a8a6867eba9e1d2b70bdf04402))
+
+## [0.9.0](https://www.github.com/nodejs/gyp-next/compare/v0.8.1...v0.9.0) (2021-05-13)
+
+
+### Features
+
+* use LDFLAGS_host for host toolset ([#98](https://www.github.com/nodejs/gyp-next/issues/98)) ([bea5c7b](https://www.github.com/nodejs/gyp-next/commit/bea5c7bd67d6ad32acbdce79767a5481c70675a2))
+
+
+### Bug Fixes
+
+* msvs.py: remove overindentation ([#102](https://www.github.com/nodejs/gyp-next/issues/102)) ([3f83e99](https://www.github.com/nodejs/gyp-next/commit/3f83e99056d004d9579ceb786e06b624ddc36529))
+* update gyp.el to change case to cl-case ([#93](https://www.github.com/nodejs/gyp-next/issues/93)) ([13d5b66](https://www.github.com/nodejs/gyp-next/commit/13d5b66aab35985af9c2fb1174fdc6e1c1407ecc))
+
 ### [0.8.1](https://www.github.com/nodejs/gyp-next/compare/v0.8.0...v0.8.1) (2021-02-18)
 
 

--- a/gyp/CODE_OF_CONDUCT.md
+++ b/gyp/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 # Code of Conduct
 
-* [Node.js Code of Conduct](https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md)
-* [Node.js Moderation Policy](https://github.com/nodejs/admin/blob/master/Moderation-Policy.md)
+* [Node.js Code of Conduct](https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md)
+* [Node.js Moderation Policy](https://github.com/nodejs/admin/blob/HEAD/Moderation-Policy.md)

--- a/gyp/CONTRIBUTING.md
+++ b/gyp/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Code of Conduct
 
-This project is bound to the [Node.js Code of Conduct](https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md).
+This project is bound to the [Node.js Code of Conduct](https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md).
 
 <a id="developers-certificate-of-origin"></a>
 ## Developer's Certificate of Origin 1.1

--- a/gyp/pylib/gyp/generator/make.py
+++ b/gyp/pylib/gyp/generator/make.py
@@ -319,7 +319,7 @@ CFLAGS.host ?= $(CPPFLAGS_host) $(CFLAGS_host)
 CXX.host ?= %(CXX.host)s
 CXXFLAGS.host ?= $(CPPFLAGS_host) $(CXXFLAGS_host)
 LINK.host ?= %(LINK.host)s
-LDFLAGS.host ?=
+LDFLAGS.host ?= $(LDFLAGS_host)
 AR.host ?= %(AR.host)s
 
 # Define a dir function that can handle spaces.

--- a/gyp/pylib/gyp/generator/ninja.py
+++ b/gyp/pylib/gyp/generator/ninja.py
@@ -1417,7 +1417,11 @@ class NinjaWriter:
         is_executable = spec["type"] == "executable"
         # The ldflags config key is not used on mac or win. On those platforms
         # linker flags are set via xcode_settings and msvs_settings, respectively.
-        env_ldflags = os.environ.get("LDFLAGS", "").split()
+        if self.toolset == "target":
+            env_ldflags = os.environ.get("LDFLAGS", "").split()
+        elif self.toolset == "host":
+            env_ldflags = os.environ.get("LDFLAGS_host", "").split()
+
         if self.flavor == "mac":
             ldflags = self.xcode_settings.GetLdflags(
                 config_name,

--- a/gyp/setup.py
+++ b/gyp/setup.py
@@ -15,7 +15,7 @@ with open(path.join(here, "README.md")) as in_file:
 
 setup(
     name="gyp-next",
-    version="0.8.1",
+    version="0.9.1",
     description="A fork of the GYP build system for use in the Node.js projects",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/gyp/tools/emacs/gyp-tests.el
+++ b/gyp/tools/emacs/gyp-tests.el
@@ -30,7 +30,7 @@
   "For the purposes of face comparison, we're not interested in the
    differences between certain faces. For example, the difference between
    font-lock-comment-delimiter and font-lock-comment-face."
-  (case face
+  (cl-case face
     ((font-lock-comment-delimiter-face) font-lock-comment-face)
     (t face)))
 

--- a/gyp/tools/emacs/gyp.el
+++ b/gyp/tools/emacs/gyp.el
@@ -213,7 +213,7 @@
                 string-start)
       (setq string-start (gyp-parse-to limit))
       (if string-start
-          (setq group (case (gyp-section-at-point)
+          (setq group (cl-case (gyp-section-at-point)
                         ('dependencies 1)
                         ('variables 2)
                         ('conditions 2)


### PR DESCRIPTION
### Features

* use LDFLAGS_host for host toolset ([#98](https://www.github.com/nodejs/gyp-next/issues/98)) ([bea5c7b](https://www.github.com/nodejs/gyp-next/commit/bea5c7bd67d6ad32acbdce79767a5481c70675a2))


### Bug Fixes

* msvs.py: remove overindentation ([#102](https://www.github.com/nodejs/gyp-next/issues/102)) ([3f83e99](https://www.github.com/nodejs/gyp-next/commit/3f83e99056d004d9579ceb786e06b624ddc36529))
* update gyp.el to change case to cl-case ([#93](https://www.github.com/nodejs/gyp-next/issues/93)) ([13d5b66](https://www.github.com/nodejs/gyp-next/commit/13d5b66aab35985af9c2fb1174fdc6e1c1407ecc))