### PR TITLE
Fix: findVisualStudio with pwsh constrained lang. mode

### DIFF
--- a/lib/find-visualstudio.js
+++ b/lib/find-visualstudio.js
@@ -129,6 +129,8 @@ VisualStudioFinder.prototype = {
       'WindowsPowerShell', 'v1.0', 'powershell.exe')
     var csFile = path.join(__dirname, 'Find-VisualStudio.cs')
     var psArgs = [
+      '-Version',
+      '2',
       '-ExecutionPolicy',
       'Unrestricted',
       '-NoProfile',


### PR DESCRIPTION
'Add-Type' cannot be used in powershell with constrained language mode. Language mode does not exist in PowerShell 2.0 engine. To force powershell to use 2.0 engine allows the usage of msvc 2017 or newer in environment with constrained language mode.
See : 
https://devblogs.microsoft.com/powershell/powershell-constrained-language-mode/
https://docs.microsoft.com/en-us/powershell/scripting/windows-powershell/starting-the-windows-powershell-2.0-engine?view=powershell-7.1

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
I added the option '-Version 2' in the powershell command which retrieves the installation data of Visual Studio 2017 (or newer). This option allows you to ignore the constrained language mode since the user does not necessarily have control over this parameter in his environment. This language mode does not allow the use of 'Add-Type', but this powershell applet is currently required to run C # code.

