### PR TITLE
fix: workaround for missing COM class on Windows 11 arm64

### DIFF
--- a/lib/find-visualstudio.js
+++ b/lib/find-visualstudio.js
@@ -125,7 +125,11 @@ VisualStudioFinder.prototype = {
   // Invoke the PowerShell script to get information about Visual Studio 2017
   // or newer installations
   findVisualStudio2017OrNewer: function findVisualStudio2017OrNewer (cb) {
-    var ps = path.join(process.env.SystemRoot, 'System32',
+    // Workaround for missing class on Windows 11 arm64 by invoking x86 PowerShell:
+    // https://developercommunity.visualstudio.com/t/Class-177F0C4A-1CD3-4DE7-A32C-71DBBB9FA3/1491726
+    const sysFolder = (process.arch === 'arm64') ? 'SysWOW64' : 'System32'
+
+    var ps = path.join(process.env.SystemRoot, sysFolder,
       'WindowsPowerShell', 'v1.0', 'powershell.exe')
     var csFile = path.join(__dirname, 'Find-VisualStudio.cs')
     var psArgs = [


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests --> (can't add tests as there's no Windows arm64 hosted CI runners)
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

After upgrading to Windows 11, `node-gyp` builds started to fail on my ARM64 device with the following error:

```
...
could not use PowerShell to find Visual Studio 2017 or newer, try re-running with '--loglevel silly' for more details
...
```

So I ran the following command:

```
PS C:\repos\node-gyp> powershell -ExecutionPolicy Unrestricted -Command "Add-Type -Path .\lib\Find-VisualStudio.cs; [VisualStudioConfiguration.Main]::PrintJson()"
Exception calling "PrintJson" with "0" argument(s): "Retrieving the COM class factory for component with CLSID {177F0C4A-1CD3-4DE7-A32C-71DBBB9FA36D} failed due to the following error: 80040154 Klasse is niet geregistreerd (Exception from HRESULT: 0x80040154 (REGDB_E_CLASSNOTREG))."
At line:1 char:44
+ ... b\Find-VisualStudio.cs; [VisualStudioConfiguration.Main]::PrintJson()
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : COMException
```

After some investigation it turned out that the following is the causing this issue:
- Windows 11 introduces x64 emulation on arm64. Aactually, [it was added in build 21277 already](https://blogs.windows.com/windows-insider/2020/12/10/introducing-x64-emulation-in-preview-for-windows-10-on-arm-pcs-to-the-windows-insider-program/) - the current stable build is 19043 (21H1).
- Windows 11 [takes x64 emulation to a new level with ARM64EC](https://blogs.windows.com/windowsdeveloper/2021/06/28/announcing-arm64ec-building-native-and-interoperable-apps-for-windows-11-on-arm/), so tools like PowerShell run as ARM64EC
- As a result, the script above breaks because class `177F0C4A-1CD3-4DE7-A32C-71DBBB9FA36D` is only registered in x86 by the Visual Studio installer.

A workaround is to call the script above from x86 PowerShell (`C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell.exe`). This works correctly and outputs the JSON. While this works standalone, this doesn't work when `node-gyp` is invoked by arm64 NodeJS from a x86 shell. The arm64 NodeJS will still trigger the x64 PowerShell and [WOW Redirection](https://docs.microsoft.com/en-us/windows/win32/winprog64/file-system-redirector) doesn't work in this scenario.

I've [reported this issue to Microsoft](https://developercommunity.visualstudio.com/t/Class-177F0C4A-1CD3-4DE7-A32C-71DBBB9FA3/1491726) and they're currently investigating it. In the meantime, I'd like to introduce a workaround for Windows arm64 to use x86 PowerShell. That's exactly what this PR does. This works on all supported versions of Windows 10 arm64 and Windows 11.
