### PR TITLE
feat: build with config.gypi from node headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ Python executable, it will be used instead of any of the other configured or
 builtin Python search paths. If it's not a compatible version, no further
 searching will be done.
 
+### Build for Third Party Node.js Runtimes
+
+When building modules for thid party Node.js runtimes like Electron, which have
+different build configurations from the official Node.js distribution, you
+should use `--dist-url` or `--nodedir` flags to specify the headers of the
+runtime to build for.
+
+Also when `--dist-url` or `--nodedir` flags are passed, node-gyp will use the
+`config.gypi` shipped in the headers distribution to generate build
+configurations, which is different from the default mode that would use the
+`process.config` object of the running Node.js instance.
+
+Some old versions of Electron shipped malformed `config.gypi` in their headers
+distributions, and you might need to pass `--force-process-config` to node-gyp
+to work around configuration errors.
+
 ## How to Use
 
 To compile your native addon, first go to its root directory:
@@ -198,6 +214,7 @@ Some additional resources for Node.js native addons and writing `gyp` configurat
 | `--python=$path`                  | Set path to the Python binary
 | `--msvs_version=$version`         | Set Visual Studio version (Windows only)
 | `--solution=$solution`            | Set Visual Studio Solution version (Windows only)
+| `--force-process-config`          | Force using runtime's `process.config` object to generate `config.gypi` file
 
 ## Configuration
 

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -97,17 +97,15 @@ function configure (gyp, argv, callback) {
       process.env.GYP_MSVS_VERSION = Math.min(vsInfo.versionYear, 2015)
       process.env.GYP_MSVS_OVERRIDE_PATH = vsInfo.path
     }
-    createConfigGypi({ gyp, buildDir, nodeDir, vsInfo }, (err, configPath) => {
+    createConfigGypi({ gyp, buildDir, nodeDir, vsInfo }).then(configPath => {
       configs.push(configPath)
-      findConfigs(err)
+      findConfigs()
+    }).catch(err => {
+      callback(err)
     })
   }
 
-  function findConfigs (err) {
-    if (err) {
-      return callback(err)
-    }
-
+  function findConfigs () {
     var name = configNames.shift()
     if (!name) {
       return runGyp()

--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -75,7 +75,8 @@ proto.configDefs = {
   'dist-url': String, // 'install'
   tarball: String, // 'install'
   jobs: String, // 'build'
-  thin: String // 'configure'
+  thin: String, // 'configure'
+  'force-process-config': Boolean // 'configure'
 }
 
 /**

--- a/test/fixtures/nodedir/include/node/config.gypi
+++ b/test/fixtures/nodedir/include/node/config.gypi
@@ -1,0 +1,6 @@
+# Test configuration
+{
+  'variables': {
+    'build_with_electron': true
+  }
+}

--- a/test/test-configure-python.js
+++ b/test/test-configure-python.js
@@ -11,7 +11,10 @@ const configure = requireInject('../lib/configure', {
     closeSync: function () { },
     writeFile: function (file, data, cb) { cb() },
     stat: function (file, cb) { cb(null, {}) },
-    mkdir: function (dir, options, cb) { cb() }
+    mkdir: function (dir, options, cb) { cb() },
+    promises: {
+      writeFile: function (file, data) { return Promise.resolve(null) }
+    }
   }
 })
 

--- a/test/test-create-config-gypi.js
+++ b/test/test-create-config-gypi.js
@@ -1,37 +1,70 @@
 'use strict'
 
+const path = require('path')
 const { test } = require('tap')
 const gyp = require('../lib/node-gyp')
 const createConfigGypi = require('../lib/create-config-gypi')
-const { getCurrentConfigGypi } = createConfigGypi.test
+const { parseConfigGypi, getCurrentConfigGypi } = createConfigGypi.test
 
-test('config.gypi with no options', function (t) {
+test('config.gypi with no options', async function (t) {
   t.plan(2)
 
   const prog = gyp()
   prog.parseArgv([])
 
-  const config = getCurrentConfigGypi({ gyp: prog, vsInfo: {} })
+  const config = await getCurrentConfigGypi({ gyp: prog, vsInfo: {} })
   t.equal(config.target_defaults.default_configuration, 'Release')
   t.equal(config.variables.target_arch, process.arch)
 })
 
-test('config.gypi with --debug', function (t) {
+test('config.gypi with --debug', async function (t) {
   t.plan(1)
 
   const prog = gyp()
   prog.parseArgv(['_', '_', '--debug'])
 
-  const config = getCurrentConfigGypi({ gyp: prog, vsInfo: {} })
+  const config = await getCurrentConfigGypi({ gyp: prog, vsInfo: {} })
   t.equal(config.target_defaults.default_configuration, 'Debug')
 })
 
-test('config.gypi with custom options', function (t) {
+test('config.gypi with custom options', async function (t) {
   t.plan(1)
 
   const prog = gyp()
   prog.parseArgv(['_', '_', '--shared-libxml2'])
 
-  const config = getCurrentConfigGypi({ gyp: prog, vsInfo: {} })
+  const config = await getCurrentConfigGypi({ gyp: prog, vsInfo: {} })
   t.equal(config.variables.shared_libxml2, true)
+})
+
+test('config.gypi with nodedir', async function (t) {
+  t.plan(1)
+
+  const nodeDir = path.join(__dirname, 'fixtures', 'nodedir')
+
+  const prog = gyp()
+  prog.parseArgv(['_', '_', `--nodedir=${nodeDir}`])
+
+  const config = await getCurrentConfigGypi({ gyp: prog, nodeDir, vsInfo: {} })
+  t.equal(config.variables.build_with_electron, true)
+})
+
+test('config.gypi with --force-process-config', async function (t) {
+  t.plan(1)
+
+  const nodeDir = path.join(__dirname, 'fixtures', 'nodedir')
+
+  const prog = gyp()
+  prog.parseArgv(['_', '_', '--force-process-config', `--nodedir=${nodeDir}`])
+
+  const config = await getCurrentConfigGypi({ gyp: prog, nodeDir, vsInfo: {} })
+  t.equal(config.variables.build_with_electron, undefined)
+})
+
+test('config.gypi parsing', function (t) {
+  t.plan(1)
+
+  const str = "# Some comments\n{'variables': {'multiline': 'A'\n'B'}}"
+  const config = parseConfigGypi(str)
+  t.deepEqual(config, { variables: { multiline: 'AB' } })
 })


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

Close https://github.com/nodejs/node-gyp/issues/2490.

This PR makes the generated `config.gypi` file inherit from `$nodedir/include/node/config.gypi` instead of runtime's `process.config` object when `--nodedir` or `--dist-url` is passed. There is also a `--force-process-config` flag added to force switching back to the old behavior. For the reason behind this change, please check https://github.com/nodejs/node-gyp/issues/2490.

##### Affects of change

This change should have not affect to Node.js users, since they usually don't use either `--nodedir` or `--dist-url`. And even when they explicitly do so, since the `process.config` is generated from the `$nodedir/include/node/config.gypi`, the build configurations will be exactly the same.

For users building modules for Electron, this is a breaking change because old versions of Electron are shipping a malformed `config.gypi` in its headers distribution, and users have to pass `--force-process-config` to node-gyp to correctly build modules.

For NW.js users I believe nothing is changed as they are using a custom fork of node-gyp to build modules.

##### `--nodedir` and `--dist-url`

Note that `$nodedir/include/node/config.gypi` is only used when `--nodedir` or `--dist-url` are passed.

There are 3 kinds of node-gyp use cases:

1. Building modules for official Node.js binaries with official headers.
2. Building modules for third party Node.js binaries with official headers.
3. Building modules for custom Node.js binaries or Node.js-embedded apps with custom headers.

For 1, using either `$nodedir/include/node/config.gypi` or `process.config` is fine since they are the same thing.

For 2, using `$nodedir/include/node/config.gypi` can cause problems, because some third party Node.js distributions are using different build configurations from the official headers.

For example, some Node.js distributions provided in Linux and BSD distributions are using shared libuv and openssl library, and building with `$nodedir/include/node/config.gypi` would cause problems for them because the `$nodedir/include/node/config.gypi` file in official headers distribution assumes bundled libuv and openssl.

This is actually a malformed use case because there is no guarantee that official headers can build with custom `process.config` settings, and it has been causing problems like https://github.com/sass/node-sass/issues/2775. Third party Node.js distributions should build modules with their own headers instead of the official headers, there is no way for Node.js and node-gyp to provide an official build configuration that can work for all kinds of third party Node.js variants. But for now I think we should just make things compatible.

For 3, users have to build modules with `$nodedir/include/node/config.gypi` instead of `process.config`, because only the former includes the correct build configurations of the target to build for. Electron has been patching Node.js to ignore the wrong build configurations used in node-gyp, and NW.js is just forking node-gyp.

So making node-gyp use `$nodedir/include/node/config.gypi` when `--nodedir` or `--dist-url` is passed is a natural choice, because passing the flags means building with custom headers, and it implies that the build configurations of the custom target should be used.

And when `--nodedir` or `--dist-url` is not passed, node-gyp should just keep the old behavior so it won't break the use case 2.

##### Why this is needed

Without this change node-gyp always builds modules with the build configurations of the running Node instance, and custom Node distributions like Electron and NW.js have been forking either Node.js or node-gyp to be able to build modules.

By making node-gyp use the `config.gypi` in node headers, embedders will be able to get rid of their patches, and the ecosystem will have less variants.

/cc @rvagg @nodejs/embedders 