### PR TITLE
feat: adds environment variable to allow PowerShell executable to be specified

### DIFF
--- a/lib/find-visualstudio.js
+++ b/lib/find-visualstudio.js
@@ -127,6 +127,10 @@ VisualStudioFinder.prototype = {
   findVisualStudio2017OrNewer: function findVisualStudio2017OrNewer (cb) {
     var ps = path.join(process.env.SystemRoot, 'System32',
       'WindowsPowerShell', 'v1.0', 'powershell.exe')
+    if (process.env.NODE_GYP_POWERSHELL_PATH) {
+      ps = path.resolve(process.env.NODE_GYP_POWERSHELL_PATH)
+      this.addLog('PowerShell path has been set by NODE_GYP_POWERSHELL_PATH:', ps)
+    }
     var csFile = path.join(__dirname, 'Find-VisualStudio.cs')
     var psArgs = [
       '-ExecutionPolicy',


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
The `Add-Type` powershell command in `findVisualStudio2017OrNewer()` can fail with early versions of PowerShell (<=5.x) in a restricted corporate environment due to permission denied on a temp folder in `~\AppData\Local\Temp`.  This is not a problem in node-gyp itself, but rather a limitation of legacy versions of PowerShell in a restricted environment.

Newer versions of PowerShell (7.0 for example) do not have this problem and are able to perform the `Add-Type` command without any problems in a restricted environment.

This PR adds a new check for a new environment variable (`NODE_GYP_POWERSHELL_PATH`) which can be used to specify a different PowerShell executable to use, if you want.

Example usage:
```
$env:NODE_GYP_POWERSHELL_PATH = "C:\Program Files\PowerShell\7\pwsh.exe"
npm i
```

---

NOTE: This is different than the problem addressed by https://github.com/nodejs/node-gyp/pull/2449.  I'm looking for a way to use Powershell 7, which is an entirely different executable than powershell.exe.