### PR TITLE
feat: support vs2022

### DIFF
--- a/.github/workflows/visual-studio.yml
+++ b/.github/workflows/visual-studio.yml
@@ -1,0 +1,25 @@
+name: Tests on Windows
+on: [push, pull_request]
+jobs:
+  Tests:
+    strategy:
+      fail-fast: false
+      max-parallel: 15
+      matrix:
+        os: [windows-2022]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: |
+          npm install --no-progress
+      - name: Set Windows environment
+        if: matrix.os == 'windows-latest'
+        run: |
+          echo 'GYP_MSVS_VERSION=2015' >> $Env:GITHUB_ENV
+          echo 'GYP_MSVS_OVERRIDE_PATH=C:\\Dummy' >> $Env:GITHUB_ENV
+      - name: Environment Information
+        run: npx envinfo
+      - name: Run Node tests
+        run: npm test

--- a/lib/find-visualstudio.js
+++ b/lib/find-visualstudio.js
@@ -2,6 +2,7 @@
 
 const log = require('npmlog')
 const execFile = require('child_process').execFile
+const fs = require('fs')
 const path = require('path').win32
 const logWithPrefix = require('./util').logWithPrefix
 const regSearchKeys = require('./util').regSearchKeys
@@ -257,6 +258,10 @@ VisualStudioFinder.prototype = {
       ret.versionYear = 2019
       return ret
     }
+    if (ret.versionMajor === 17) {
+      ret.versionYear = 2022
+      return ret
+    }
     this.log.silly('- unsupported version:', ret.versionMajor)
     return {}
   },
@@ -264,14 +269,19 @@ VisualStudioFinder.prototype = {
   // Helper - process MSBuild information
   getMSBuild: function getMSBuild (info, versionYear) {
     const pkg = 'Microsoft.VisualStudio.VC.MSBuild.Base'
+    const msbuildPath = path.join(info.path, 'MSBuild', 'Current', 'Bin', 'MSBuild.exe')
     if (info.packages.indexOf(pkg) !== -1) {
       this.log.silly('- found VC.MSBuild.Base')
       if (versionYear === 2017) {
         return path.join(info.path, 'MSBuild', '15.0', 'Bin', 'MSBuild.exe')
       }
       if (versionYear === 2019) {
-        return path.join(info.path, 'MSBuild', 'Current', 'Bin', 'MSBuild.exe')
+        return msbuildPath
       }
+    }
+    // visual studio 2022 don't has msbuild pkg
+    if (fs.existsSync(msbuildPath)) {
+      return msbuildPath
     }
     return null
   },
@@ -293,6 +303,8 @@ VisualStudioFinder.prototype = {
       return 'v141'
     } else if (versionYear === 2019) {
       return 'v142'
+    } else if (versionYear === 2022) {
+      return 'v143'
     }
     this.log.silly('- invalid versionYear:', versionYear)
     return null


### PR DESCRIPTION
closes #2520.

Since github action now provide vs2022, so I also add vs2022 to CI.

Verified on win10.