### PR TITLE
Make argsVersion compatible with python3

### DIFF
--- a/lib/find-python.js
+++ b/lib/find-python.js
@@ -48,7 +48,7 @@ function PythonFinder (configPython, callback) {
 PythonFinder.prototype = {
   log: logWithPrefix(log, 'find Python'),
   argsExecutable: ['-c', 'import sys; print(sys.executable);'],
-  argsVersion: ['-c', 'import sys; print("%s.%s.%s" % sys.version_info[:3]);'],
+  argsVersion: ['-c', 'import sys; print("{0}.{1}.{2}".format(sys.version_info[0], sys.version_info[1], sys.version_info[2]));'],
   semverRange: '>=3.6.0',
 
   // These can be overridden for testing:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
Fixes an incompatability with python3 that i ran into when running node-gyp on my fedora 35 system where python3 is the default python version. The fix should cover python2.x and python3.x versions.

