### PR TITLE
fix: _ in npm_config_ env variables

### DIFF
--- a/lib/create-config-gypi.js
+++ b/lib/create-config-gypi.js
@@ -19,7 +19,8 @@ async function getBaseConfigGypi ({ gyp, nodeDir }) {
   // try reading $nodeDir/include/node/config.gypi first when:
   // 1. --dist-url or --nodedir is specified
   // 2. and --force-process-config is not specified
-  const shouldReadConfigGypi = (gyp.opts.nodedir || gyp.opts['dist-url']) && !gyp.opts['force-process-config']
+  const useCustomHeaders = gyp.opts.nodedir || gyp.opts.disturl || gyp.opts['dist-url']
+  const shouldReadConfigGypi = useCustomHeaders && !gyp.opts['force-process-config']
   if (shouldReadConfigGypi && nodeDir) {
     try {
       const baseConfigGypiPath = path.resolve(nodeDir, 'include/node/config.gypi')

--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -149,6 +149,10 @@ proto.parseArgv = function parseOpts (argv) {
       // gyp@741b7f1 enters an infinite loop when it encounters
       // zero-length options so ensure those don't get through.
       if (name) {
+        // convert names like force_process_config to force-process-config
+        if (name.includes('_')) {
+          name = name.replace(/_/g, '-')
+        }
         this.opts[name] = val
       }
     }

--- a/test/test-options.js
+++ b/test/test-options.js
@@ -29,3 +29,14 @@ test('options in environment', (t) => {
 
   t.deepEqual(Object.keys(g.opts).sort(), keys.sort())
 })
+
+test('options with spaces in environment', (t) => {
+  t.plan(1)
+
+  process.env.npm_config_force_process_config = 'true'
+
+  const g = gyp()
+  g.parseArgv(['rebuild']) // Also sets opts.argv.
+
+  t.equal(g.opts['force-process-config'], 'true')
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

This PR fixes 2 things on `npm_config_` env variables:

1. Make `npm_config_force_process_config=true` env work by automatically converting `_` to `-` when parsing `npmConfigPrefix`.
2. Recognize `--disturl` as option in `create-config-gypi.js`, it is not documented anywhere but users have been relying on `npm_config_disturl` to pass `--dist-url` in env.