### PR TITLE
deps: npmlog@6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "graceful-fs": "^4.2.6",
     "make-fetch-happen": "^9.1.0",
     "nopt": "^5.0.0",
-    "npmlog": "^4.1.2",
+    "npmlog": "^6.0.0",
     "rimraf": "^3.0.2",
     "semver": "^7.3.5",
     "tar": "^6.1.2",


### PR DESCRIPTION


##### Checklist

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
This updates `npmlog` to the latest version. It will also clear all current `npm audit` warnings for any project that has this package installed.

The semver-major change in npmlog@5 was dropping support for node 6 and 8.
The semver-major change in npmlog@6 was dropping support for node10, and non-LTS versions of node12 and node14 (i.e. `<12.13.0` and `<14.15.0`)

I don't believe either of those are issues for the current version of node-gyp.
