### PR TITLE
fix: failure when build directory contains spaces (#65)

### DIFF
--- a/gyp/pylib/gyp/generator/make.py
+++ b/gyp/pylib/gyp/generator/make.py
@@ -1328,7 +1328,7 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
             includes = config.get("include_dirs")
             if includes:
                 includes = [Sourceify(self.Absolutify(i)) for i in includes]
-            self.WriteList(includes, "INCS_%s" % configname, prefix="-I")
+            self.WriteList(includes, "INCS_%s" % configname, prefix="-I", quoter=EscapeShellArgument)
 
         compilable = list(filter(Compilable, sources))
         objs = [self.Objectify(self.Absolutify(Target(c))) for c in compilable]


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
Before this fix, if the build directory had a space in the path then it would fail because spaces were not escaped properly. Happy to add a test for this if anyone has a suggestion for how I should test this? Had a brief look through the existing tests and it wasn't obvious to me.

