### PR TITLE
feat: Update function getSDK() to support Windows 11 SDK

### DIFF
--- a/lib/find-visualstudio.js
+++ b/lib/find-visualstudio.js
@@ -314,29 +314,30 @@ VisualStudioFinder.prototype = {
   getSDK: function getSDK (info) {
     const win8SDK = 'Microsoft.VisualStudio.Component.Windows81SDK'
     const win10SDKPrefix = 'Microsoft.VisualStudio.Component.Windows10SDK.'
+    const win11SDKPrefix = 'Microsoft.VisualStudio.Component.Windows11SDK.'
 
-    var Win10SDKVer = 0
+    var Win10or11SDKVer = 0
     info.packages.forEach((pkg) => {
-      if (!pkg.startsWith(win10SDKPrefix)) {
+      if (!pkg.startsWith(win10SDKPrefix) && !pkg.startsWith(win11SDKPrefix)) {
         return
       }
       const parts = pkg.split('.')
       if (parts.length > 5 && parts[5] !== 'Desktop') {
-        this.log.silly('- ignoring non-Desktop Win10SDK:', pkg)
+        this.log.silly('- ignoring non-Desktop Win10/11SDK:', pkg)
         return
       }
       const foundSdkVer = parseInt(parts[4], 10)
       if (isNaN(foundSdkVer)) {
         // Microsoft.VisualStudio.Component.Windows10SDK.IpOverUsb
-        this.log.silly('- failed to parse Win10SDK number:', pkg)
+        this.log.silly('- failed to parse Win10/11SDK number:', pkg)
         return
       }
-      this.log.silly('- found Win10SDK:', foundSdkVer)
-      Win10SDKVer = Math.max(Win10SDKVer, foundSdkVer)
+      this.log.silly('- found Win10/11SDK:', foundSdkVer)
+      Win10or11SDKVer = Math.max(Win10or11SDKVer, foundSdkVer)
     })
 
-    if (Win10SDKVer !== 0) {
-      return `10.0.${Win10SDKVer}.0`
+    if (Win10or11SDKVer !== 0) {
+      return `10.0.${Win10or11SDKVer}.0`
     } else if (info.packages.indexOf(win8SDK) !== -1) {
       this.log.silly('- found Win8SDK')
       return '8.1'


### PR DESCRIPTION
##### Description of change
fix: Fixes #2527
Latest Windows 11 SDK was not supported by implementation due to a change in the naming convention made by Microsoft. The implementation has been amended to account for this change.