### PR TITLE
doc: Update Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Depending on your operating system, you will need to install:
 
 ### On Unix
 
-   * Python v3.6, v3.7, v3.8, or v3.9
+   * Python v3.7, v3.8, v3.9, or v3.10
    * `make`
    * A proper C/C++ compiler toolchain, like [GCC](https://gcc.gnu.org)
 
@@ -39,13 +39,15 @@ Depending on your operating system, you will need to install:
 
 **ATTENTION**: If your Mac has been _upgraded_ to macOS Catalina (10.15), please read [macOS_Catalina.md](macOS_Catalina.md).
 
-   * Python v3.6, v3.7, v3.8, or v3.9
-   * [Xcode](https://developer.apple.com/xcode/download/)
-     * You also need to install the `XCode Command Line Tools` by running `xcode-select --install`. Alternatively, if you already have the full Xcode installed, you can find them under the menu `Xcode -> Open Developer Tool -> More Developer Tools...`. This step will install `clang`, `clang++`, and `make`.
+   * Python v3.7, v3.8, v3.9, or v3.10
+   * `XCode Command Line Tools` which will install `clang`, `clang++`, and `make`.
+     * Install the `XCode Command Line Tools` standalone by running `xcode-select --install`. -- OR --
+     * Alternatively, if you already have the [full Xcode installed](https://developer.apple.com/xcode/download/), you can install the Command Line Tools under the menu `Xcode -> Open Developer Tool -> More Developer Tools...`.
+
 
 ### On Windows
 
-Install the current version of Python from the [Microsoft Store package](https://docs.python.org/3/using/windows.html#the-microsoft-store-package).
+Install the current version of Python from the [Microsoft Store package](https://www.microsoft.com/en-us/p/python-310/9pjpw5ldxlz5).
 
 Install tools and configuration manually:
    * Install Visual C++ Build Environment: [Visual Studio Build Tools](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools)
@@ -59,8 +61,8 @@ Install tools and configuration manually:
 
 ### Configuring Python Dependency
 
-`node-gyp` requires that you have installed a compatible version of Python, one of: v3.6, v3.7,
-v3.8, or v3.9. If you have multiple Python versions installed, you can identify which Python
+`node-gyp` requires that you have installed a compatible version of Python, one of: v3.7, v3.8,
+v3.9, or v3.10. If you have multiple Python versions installed, you can identify which Python
 version `node-gyp` should use in one of the following ways:
 
 1. by setting the `--python` command-line option, e.g.:


### PR DESCRIPTION
* Add Python 3.10
* Drop Python 3.6 which [EOLs on 23 Dec. 2021](https://devguide.python.org/#status-of-python-branches)
* macOS: clarify `Xcode Command Line Tools` standalone vs. from full Xcode
* Windows: Use the same URL as https://github.com/nodejs/node/blob/master/BUILDING.md#windows

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

