### PR TITLE
docs: Add notes/disclaimers for upgrading the copy of node-gyp that npm uses

### DIFF
--- a/docs/Force-npm-to-use-global-node-gyp.md
+++ b/docs/Force-npm-to-use-global-node-gyp.md
@@ -1,5 +1,7 @@
 # Force npm to use global installed node-gyp
 
+**Note: These instructions only work with npm 6 or older. For a solution that works with npm 8 (or older), see [Updating-npm-bundled-node-gyp.md](https://github.com/nodejs/node-gyp/blob/master/docs/Updating-npm-bundled-node-gyp.md).**
+
 [Many issues](https://github.com/nodejs/node-gyp/labels/ERR%21%20node-gyp%20-v%20%3C%3D%20v5.1.0) are opened by users who are
 not running a [current version of node-gyp](https://github.com/nodejs/node-gyp/releases).
 

--- a/docs/Force-npm-to-use-global-node-gyp.md
+++ b/docs/Force-npm-to-use-global-node-gyp.md
@@ -1,6 +1,6 @@
 # Force npm to use global installed node-gyp
 
-**Note: These instructions only work with npm 6 or older. For a solution that works with npm 8 (or older), see [Updating-npm-bundled-node-gyp.md](https://github.com/nodejs/node-gyp/blob/master/docs/Updating-npm-bundled-node-gyp.md).**
+**Note: These instructions only work with npm 6 or older. For a solution that works with npm 8 (or older), see [Updating-npm-bundled-node-gyp.md](Updating-npm-bundled-node-gyp.md).**
 
 [Many issues](https://github.com/nodejs/node-gyp/labels/ERR%21%20node-gyp%20-v%20%3C%3D%20v5.1.0) are opened by users who are
 not running a [current version of node-gyp](https://github.com/nodejs/node-gyp/releases).

--- a/docs/Updating-npm-bundled-node-gyp.md
+++ b/docs/Updating-npm-bundled-node-gyp.md
@@ -1,5 +1,9 @@
 # Updating the npm-bundled version of node-gyp
 
+**Note: These instructions are (only) tested and known to work with npm 8 and older.**
+
+**Note: These instructions will be undone if you reinstall or upgrade npm or node! For a more permanent (and simpler) solution, see [Force-npm-to-use-global-node-gyp.md](https://github.com/nodejs/node-gyp/blob/master/docs/Force-npm-to-use-global-node-gyp.md). (npm 6 or older only!)**
+
 [Many issues](https://github.com/nodejs/node-gyp/labels/ERR%21%20node-gyp%20-v%20%3C%3D%20v5.1.0) are opened by users who are
 not running a [current version of node-gyp](https://github.com/nodejs/node-gyp/releases).
 
@@ -25,7 +29,7 @@ npm --version
 
 Unix is easy. Just run the following command.
 
-If your npm is version ___7___, do:
+If your npm is version ___7 or 8___, do:
 ```bash
 $ npm explore npm/node_modules/@npmcli/run-script -g -- npm_config_global=false npm install node-gyp@latest
 ```
@@ -52,7 +56,7 @@ Now `cd` to the directory that `node.exe` is contained in e.g.:
 $ cd "C:\Program Files\nodejs"
 ```
 
-If your npm version is ___7___, do:
+If your npm version is ___7 or 8___, do:
 ```bash
 cd node_modules\npm\node_modules\@npmcli\run-script
 ```

--- a/docs/Updating-npm-bundled-node-gyp.md
+++ b/docs/Updating-npm-bundled-node-gyp.md
@@ -2,7 +2,7 @@
 
 **Note: These instructions are (only) tested and known to work with npm 8 and older.**
 
-**Note: These instructions will be undone if you reinstall or upgrade npm or node! For a more permanent (and simpler) solution, see [Force-npm-to-use-global-node-gyp.md](https://github.com/nodejs/node-gyp/blob/master/docs/Force-npm-to-use-global-node-gyp.md). (npm 6 or older only!)**
+**Note: These instructions will be undone if you reinstall or upgrade npm or node! For a more permanent (and simpler) solution, see [Force-npm-to-use-global-node-gyp.md](Force-npm-to-use-global-node-gyp.md). (npm 6 or older only!)**
 
 [Many issues](https://github.com/nodejs/node-gyp/labels/ERR%21%20node-gyp%20-v%20%3C%3D%20v5.1.0) are opened by users who are
 not running a [current version of node-gyp](https://github.com/nodejs/node-gyp/releases).


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

Add notes on npm version compatibility for methods to update the copy of node-gyp that npm uses.

Also mention that this is tested on npm 8, now that npm 8 exists. (Npm 8 is the same as npm 7 for purposes of these instructions.)

Lastly, add a note that one of the methods is simpler/more durable, but only functional for npm 6 and older.