### PR TITLE
fix: wording to redirect to macOS_Catalina.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Depending on your operating system, you will need to install:
 
 ### On macOS
 
-**ATTENTION**: If your Mac has been _upgraded_ to macOS Catalina (10.15), please read [macOS_Catalina.md](macOS_Catalina.md).
+**ATTENTION**: If your Mac has been _upgraded_ to macOS Catalina (10.15) or higher, please read [macOS_Catalina.md](macOS_Catalina.md).
 
    * Python v3.6, v3.7, v3.8, or v3.9
    * [Xcode](https://developer.apple.com/xcode/download/)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
Clarifies that macOS_Catalina.md is meant for any user that's upgraded beyond 10.15 and not just users that upgraded to 10.15 Catalina

