### PR TITLE
fix: update make-fetch-happen to a minimum of 10.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "env-paths": "^2.2.0",
     "glob": "^7.1.4",
     "graceful-fs": "^4.2.6",
-    "make-fetch-happen": "^10.0.1",
+    "make-fetch-happen": "^10.0.3",
     "nopt": "^5.0.0",
     "npmlog": "^6.0.0",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->
The sporadic timeouts seen here were caused by a change to the default `freeSocketTimeout` value in the `agentkeepalive` module. To work around the issue, we've increased the value back to its original default. This change is only to ensure that the minimum required version of `make-fetch-happen` is one that has this fix applied.
