### PR TITLE
removing breaking space

### DIFF
--- a/docs/Updating-npm-bundled-node-gyp.md
+++ b/docs/Updating-npm-bundled-node-gyp.md
@@ -31,12 +31,12 @@ Unix is easy. Just run the following command.
 
 If your npm is version ___7 or 8___, do:
 ```bash
-$ npm explore npm/node_modules/@npmcli/run-script -g -- npm_config_global=false npm install node-gyp@latest
+$ npm explore npm/node_modules/@npmcli/run-script -g --npm_config_global=false npm install node-gyp@latest
 ```
 
 Else if your npm is version ___less than 7___, do:
 ```bash
-$ npm explore npm/node_modules/npm-lifecycle -g -- npm install node-gyp@latest
+$ npm explore npm/node_modules/npm-lifecycle -g --npm install node-gyp@latest
 ```
 
 If the command fails with a permissions error, please try `sudo` and then the command.


### PR DESCRIPTION
space between -- and npm_config_global cause the following error:
```
'npm_config_global' is not recognized as an internal or external command,
```

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

