### PR TITLE
lib: add lib.target as path for searching libnode on z/OS

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -169,6 +169,8 @@ function configure (gyp, argv, callback) {
         })
       } else {
         candidates = [
+          'out/Release/lib.target/libnode',
+          'out/Debug/lib.target/libnode',
           'out/Release/obj.target/libnode',
           'out/Debug/obj.target/libnode',
           'lib/libnode'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->
Required to enable node.js to build shared library on z/OS.
