### PR TITLE
Fix reading msvs version on Windows

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -85,7 +85,7 @@ function configure (gyp, argv, callback) {
         'build dir', '"build" dir needed to be created?', isNew ? 'Yes' : 'No'
       )
       if (win) {
-        findVisualStudio(release.semver, gyp.opts.msvs_version,
+        findVisualStudio(release.semver, gyp.opts['msvs-version'],
           createConfigFile)
       } else {
         createPythonSymlink()

--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -60,7 +60,7 @@ proto.configDefs = {
   debug: Boolean, // 'build'
   directory: String, // bin
   make: String, // 'build'
-  msvs_version: String, // 'configure'
+  'msvs-version': String, // 'configure'
   ensure: Boolean, // 'install'
   solution: String, // 'build' (windows only)
   proxy: String, // 'install'

--- a/test/test-options.js
+++ b/test/test-options.js
@@ -39,3 +39,14 @@ describe('options', function () {
     assert.strictEqual(g.opts['force-process-config'], 'true')
   })
 })
+
+test('options with msvs_version', (t) => {
+  t.plan(1)
+
+  process.env.npm_config_msvs_version = '2017'
+
+  const g = gyp()
+  g.parseArgv(['rebuild']) // Also sets opts.argv.
+
+  t.equal(g.opts['msvs-version'], '2017')
+})

--- a/test/test-options.js
+++ b/test/test-options.js
@@ -38,15 +38,13 @@ describe('options', function () {
 
     assert.strictEqual(g.opts['force-process-config'], 'true')
   })
-})
 
-test('options with msvs_version', (t) => {
-  t.plan(1)
+  it('options with msvs_version', () => {
+    process.env.npm_config_msvs_version = '2017'
 
-  process.env.npm_config_msvs_version = '2017'
+    const g = gyp()
+    g.parseArgv(['rebuild']) // Also sets opts.argv.
 
-  const g = gyp()
-  g.parseArgv(['rebuild']) // Also sets opts.argv.
-
-  t.equal(g.opts['msvs-version'], '2017')
+    assert.strictEqual(g.opts['msvs-version'], '2017')
+  })
 })


### PR DESCRIPTION
- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
Ever since #2547 went in for version 9 our Windows machines can't properly read msvs_version from the .npmrc. Since names with '_' are now changed to '-' we need to change the opts definition. If there's a different way you'd like to handle this let me know and I can update.

