### PR TITLE
feat: Add support for Windows 11 SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ searching will be done.
 
 ### Build for Third Party Node.js Runtimes
 
-When building modules for thid party Node.js runtimes like Electron, which have
+When building modules for third party Node.js runtimes like Electron, which have
 different build configurations from the official Node.js distribution, you
 should use `--dist-url` or `--nodedir` flags to specify the headers of the
 runtime to build for.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-## Versions of `node-gyp` that are earlier than v8.x.x
+## Versions of `node-gyp` that are earlier than v9.x.x
 
 Please look thru your error log for the string `gyp info using node-gyp@` and if that version number is less than the [current release of node-gyp](https://github.com/nodejs/node-gyp/releases) then __please upgrade__ using [these instructions](https://github.com/nodejs/node-gyp/blob/master/docs/Updating-npm-bundled-node-gyp.md) and then try your command again.
 

--- a/lib/find-visualstudio.js
+++ b/lib/find-visualstudio.js
@@ -314,10 +314,12 @@ VisualStudioFinder.prototype = {
   getSDK: function getSDK (info) {
     const win8SDK = 'Microsoft.VisualStudio.Component.Windows81SDK'
     const win10SDKPrefix = 'Microsoft.VisualStudio.Component.Windows10SDK.'
+    const win11SDKPrefix = 'Microsoft.VisualStudio.Component.Windows11SDK.'
 
     var Win10SDKVer = 0
+    var Win11SDKVer = 0
     info.packages.forEach((pkg) => {
-      if (!pkg.startsWith(win10SDKPrefix)) {
+      if (!pkg.startsWith(win10SDKPrefix) && !pkg.startsWith(win11SDKPrefix)) {
         return
       }
       const parts = pkg.split('.')
@@ -328,14 +330,25 @@ VisualStudioFinder.prototype = {
       const foundSdkVer = parseInt(parts[4], 10)
       if (isNaN(foundSdkVer)) {
         // Microsoft.VisualStudio.Component.Windows10SDK.IpOverUsb
-        this.log.silly('- failed to parse Win10SDK number:', pkg)
+        if (pkg.startsWith(win11SDKPrefix)) {
+          this.log.silly('- failed to parse Win11SDK number:', pkg)
+        } else if (pkg.startsWith(win10SDKPrefix)) {
+          this.log.silly('- failed to parse Win10SDK number:', pkg)
+        }
         return
       }
-      this.log.silly('- found Win10SDK:', foundSdkVer)
-      Win10SDKVer = Math.max(Win10SDKVer, foundSdkVer)
+      if (pkg.startsWith(win11SDKPrefix)) {
+        this.log.silly('- found Win11SDK:', foundSdkVer)
+        Win11SDKVer = Math.max(Win11SDKVer, foundSdkVer)
+      } else if (pkg.startsWith(win10SDKPrefix)) {
+        this.log.silly('- found Win10SDK:', foundSdkVer)
+        Win10SDKVer = Math.max(Win10SDKVer, foundSdkVer)
+      }
     })
 
-    if (Win10SDKVer !== 0) {
+    if (Win11SDKVer !== 0) {
+      return `11.0.${Win11SDKVer}.0`
+    } else if (Win10SDKVer !== 0) {
       return `10.0.${Win10SDKVer}.0`
     } else if (info.packages.indexOf(win8SDK) !== -1) {
       this.log.silly('- found Win8SDK')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->
Add support for Windows 11 SDK in `find-visualstudio.js`.

By testing, the script can successfully find Windows 11 SDK:
![image](https://user-images.githubusercontent.com/23608500/167287224-4cf816fc-c7e7-4406-b205-98033d065aaf.png)

This patch can solve some errors caused by Windows SDK not found:
![2022-05-07_212527](https://user-images.githubusercontent.com/23608500/167287310-9d565b98-c705-4a74-9de3-375b99082e85.png)

No documentation needs to be changed or added.
