### PR TITLE
Fix #2674

### DIFF
--- a/gyp/pylib/gyp/xcodeproj_file.py
+++ b/gyp/pylib/gyp/xcodeproj_file.py
@@ -2990,7 +2990,7 @@ class PBXProject(XCContainerPortal):
             # Xcode seems to sort this list case-insensitively
             self._properties["projectReferences"] = sorted(
                 self._properties["projectReferences"],
-                key=lambda x: x["ProjectRef"].Name().lower
+                key=lambda x: x["ProjectRef"].Name().lower()
             )
         else:
             # The link already exists.  Pull out the relevnt data.


### PR DESCRIPTION
Fix possible typo that causes "TypeError: '<' not supported between instances of 'builtin_function_or_method' and 'builtin_function_or_method'" described in https://github.com/nodejs/node-gyp/issues/2674