### PR TITLE
fix: Find and use ARM64 tools on win32_arm64 platform

### DIFF
--- a/lib/find-visualstudio.js
+++ b/lib/find-visualstudio.js
@@ -288,11 +288,18 @@ VisualStudioFinder.prototype = {
 
   // Helper - process toolset information
   getToolset: function getToolset (info, versionYear) {
-    const pkg = 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64'
+    var pkg
+    if (process.arch === 'arm64') {
+      this.addLog('- Looking for ARM64 Tools')
+      pkg = 'Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+    } else {
+      this.addLog('- Looking for x86.x64 Tools')
+      pkg = 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64'
+    }
     const express = 'Microsoft.VisualStudio.WDExpress'
 
     if (info.packages.indexOf(pkg) !== -1) {
-      this.log.silly('- found VC.Tools.x86.x64')
+      this.log.silly('- found VC.Tools')
     } else if (info.packages.indexOf(express) !== -1) {
       this.log.silly('- found Visual Studio Express (looking for toolset)')
     } else {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
This fixes building on win32_arm64 platform by finding the correct VC tools for the platform. The documentation was already correct in terms of necessary tools to install, but the code would not find/use the ARM64 version of the tools, or worse build x86 code instead. This corrects that by looking for the ARM64 tools when the platform is arm64, otherwise default to the x86.x84 tools. This also allows for future platforms to be added in the if tree later if needed. All of the existing tests apply, and the log messages now show which version of the tools it's looking for in the event of a failure.

This fix works with VS2019 and VS2022. ARM64 support is not available on older versions of VS. This supersedes #2650 since VS2022 has shipped and the pre-release version is no longer needed.

Happy to make any adjustments in order to get this, or a similar patch, merged so that more NodeJS packages are available on the win32_arm64 platform.