### PR TITLE
show error log directly after powsershell failed

### DIFF
--- a/lib/find-visualstudio.js
+++ b/lib/find-visualstudio.js
@@ -152,12 +152,12 @@ VisualStudioFinder.prototype = {
 
     const failPowershell = () => {
       this.addLog(
-        'could not use PowerShell to find Visual Studio 2017 or newer, try re-running with \'--loglevel silly\' for more details')
+        'could not use PowerShell to find Visual Studio 2017 or newer')
       cb(null)
     }
 
     if (err) {
-      this.log.silly('PS err = %j', err && (err.stack || err))
+      this.log.error('PS err = %j', err && (err.stack || err))
       return failPowershell()
     }
 
@@ -165,13 +165,13 @@ VisualStudioFinder.prototype = {
     try {
       vsInfo = JSON.parse(stdout)
     } catch (e) {
-      this.log.silly('PS stdout = %j', stdout)
-      this.log.silly(e)
+      this.log.error('PS stdout = %j', stdout)
+      this.log.error(e)
       return failPowershell()
     }
 
     if (!Array.isArray(vsInfo)) {
-      this.log.silly('PS stdout = %j', stdout)
+      this.log.error('PS stdout = %j', stdout)
       return failPowershell()
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->
When use powershell to call csharp script failed, no error log would show as default. The pull request make the error log show directly.
