### PR TITLE
fix: Use Windows 11 SDKs

### DIFF
--- a/lib/find-visualstudio.js
+++ b/lib/find-visualstudio.js
@@ -313,19 +313,22 @@ VisualStudioFinder.prototype = {
   // Helper - process Windows SDK information
   getSDK: function getSDK (info) {
     const win8SDK = 'Microsoft.VisualStudio.Component.Windows81SDK'
-    const win10SDKPrefix = 'Microsoft.VisualStudio.Component.Windows10SDK.'
+    // Newer Windows SDKs are called "Windows 11 SDKs"
+    // but are usable in the same way as older "Windows 10 SDKs"
+    // and retain the major version 10
+    const win10SDKRegex = /^Microsoft\.VisualStudio\.Component\.Windows1[01]SDK\.(\w+)(\.\w+)?/
 
     var Win10SDKVer = 0
     info.packages.forEach((pkg) => {
-      if (!pkg.startsWith(win10SDKPrefix)) {
+      const result = win10SDKRegex.exec(pkg)
+      if (result === null) {
         return
       }
-      const parts = pkg.split('.')
-      if (parts.length > 5 && parts[5] !== 'Desktop') {
+      if (result[2] !== undefined && result[2] !== '.Desktop') {
         this.log.silly('- ignoring non-Desktop Win10SDK:', pkg)
         return
       }
-      const foundSdkVer = parseInt(parts[4], 10)
+      const foundSdkVer = parseInt(result[1], 10)
       if (isNaN(foundSdkVer)) {
         // Microsoft.VisualStudio.Component.Windows10SDK.IpOverUsb
         this.log.silly('- failed to parse Win10SDK number:', pkg)


### PR DESCRIPTION
In a despicable attempt to frustrate Node.js users, Microsoft has
decided that newer versions of the Windows SDK will be called
`Windows11SDK` instead of `Windows10SDK`.
This commit fixes lib/find-visualstudio.js to accomodate the change.

Maybe fixes #2643.
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

