### PR TITLE
feat: support for configuring nodejs_org_mirror in .npmrc

### DIFF
--- a/lib/process-release.js
+++ b/lib/process-release.js
@@ -20,6 +20,7 @@ function processRelease (argv, gyp, defaultVersion, defaultRelease) {
   var version = (semver.valid(argv[0]) && argv[0]) || gyp.opts.target || defaultVersion
   var versionSemver = semver.parse(version)
   var overrideDistUrl = gyp.opts['dist-url'] || gyp.opts.disturl
+  var npmConfigUrlOrEnvUrl = process.env.NODEJS_ORG_MIRROR || process.env.npm_config_nodejs_org_mirror
   var isDefaultVersion
   var isNamedForLegacyIojs
   var name
@@ -62,8 +63,8 @@ function processRelease (argv, gyp, defaultVersion, defaultRelease) {
   }
 
   // check for the nvm.sh standard mirror env variables
-  if (!overrideDistUrl && process.env.NODEJS_ORG_MIRROR) {
-    overrideDistUrl = process.env.NODEJS_ORG_MIRROR
+  if (!overrideDistUrl && npmConfigUrlOrEnvUrl) {
+    overrideDistUrl = npmConfigUrlOrEnvUrl
   }
 
   if (overrideDistUrl) {

--- a/test/test-process-release.js
+++ b/test/test-process-release.js
@@ -432,3 +432,32 @@ test('test process release - NODEJS_ORG_MIRROR', function (t) {
 
   delete process.env.NODEJS_ORG_MIRROR
 })
+
+test('test process release - npm_config_nodejs_org_mirror', function (t) {
+  t.plan(2)
+
+  // is equivalent to setting nodejs_org_mirror=http://foo.bar in the .npmrc file
+  process.env.npm_config_nodejs_org_mirror = 'http://foo.bar'
+
+  var release = processRelease([], { opts: {} }, 'v4.1.23', {
+    name: 'node',
+    headersUrl: 'https://nodejs.org/dist/v4.1.23/node-v4.1.23-headers.tar.gz'
+  })
+
+  t.equal(release.semver.version, '4.1.23')
+  delete release.semver
+
+  t.deepEqual(release, {
+    version: '4.1.23',
+    name: 'node',
+    baseUrl: 'http://foo.bar/v4.1.23/',
+    tarballUrl: 'http://foo.bar/v4.1.23/node-v4.1.23-headers.tar.gz',
+    shasumsUrl: 'http://foo.bar/v4.1.23/SHASUMS256.txt',
+    versionDir: '4.1.23',
+    ia32: { libUrl: 'http://foo.bar/v4.1.23/win-x86/node.lib', libPath: 'win-x86/node.lib' },
+    x64: { libUrl: 'http://foo.bar/v4.1.23/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+    arm64: { libUrl: 'http://foo.bar/v4.1.23/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
+  })
+
+  delete process.env.npm_config_nodejs_org_mirror
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->
support for configuring nodejs_org_mirror in .npmrc
```
# .npmrc

nodejs_org_mirror=https://npm.taobao.org/mirrors/node
```
