### PR TITLE
fix: update example to reflect proper argument usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ version `node-gyp` should use in one of the following ways:
 1. by setting the `--python` command-line option, e.g.:
 
 ``` bash
-node-gyp <command> --python /path/to/executable/python
+node-gyp <command> --python=/path/to/executable/python
 ```
 
 2. If `node-gyp` is called by way of `npm`, *and* you have multiple versions of


### PR DESCRIPTION
The example had a space instead of an equals sign (=) where the table below specifies that the argument should utilize an equals sign (=) for it's key-value flags.

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

