### PR TITLE
Adding tarfile member sanitization to extractall()

### DIFF
--- a/update-gyp.py
+++ b/update-gyp.py
@@ -33,7 +33,25 @@ with tempfile.TemporaryDirectory() as tmp_dir:
 
         print("Unzipping...")
         with tarfile.open(tar_file, "r:gz") as tar_ref:
-            tar_ref.extractall(unzip_target)
+            def is_within_directory(directory, target):
+
+                abs_directory = os.path.abspath(directory)
+                abs_target = os.path.abspath(target)
+
+                prefix = os.path.commonprefix([abs_directory, abs_target])
+
+                return prefix == abs_directory
+
+            def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+
+                for member in tar.getmembers():
+                    member_path = os.path.join(path, member.name)
+                    if not is_within_directory(path, member_path):
+                        raise Exception("Attempted Path Traversal in Tar File")
+
+                tar.extractall(path, members, numeric_owner)
+
+            safe_extract(tar_ref, unzip_target)
 
         print("Moving to current checkout (" + CHECKOUT_PATH + ")...")
         if os.path.exists(CHECKOUT_GYP_PATH):


### PR DESCRIPTION
From https://github.com/nodejs/node/pull/44823:

> # Patching CVE-2007-4559
> 
> Hi, we are security researchers from the Advanced Research Center at [Trellix](https://www.trellix.com). We have began a campaign to patch a widespread bug named CVE-2007-4559. CVE-2007-4559 is a 15 year old bug in the Python tarfile package. By using extract() or extractall() on a tarfile object without sanitizing input, a maliciously crafted .tar file could perform a directory path traversal attack. We found at least one unsantized extractall() in your codebase and are providing a patch for you via pull request. The patch essentially checks to see if all tarfile members will be extracted safely and throws an exception otherwise. We encourage you to use this patch or your own solution to secure against CVE-2007-4559. Further technical information about the vulnerability can be found in this [blog](https://www.trellix.com/en-us/about/newsroom/stories/research/tarfile-exploiting-the-world.html).
> 
> If you have further questions you may contact us through this projects lead researcher [Kasimir Schulz](mailto:kasimir.schulz@trellix.com).

@TrellixVulnTeam