### PR TITLE
Clarify that the latest Python might not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Depending on your operating system, you will need to install:
 
 ### On Windows
 
-Install the current version of Python from the [Microsoft Store package](https://www.microsoft.com/en-us/p/python-310/9pjpw5ldxlz5).
+Install the latest [compatible version](https://github.com/nodejs/node-gyp#configuring-python-dependency) of Python from the [Microsoft Store package](https://www.microsoft.com/en-us/p/python-310/9pjpw5ldxlz5).
 
 Install tools and configuration manually:
    * Install Visual C++ Build Environment: [Visual Studio Build Tools](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools)


### PR DESCRIPTION
I wasted a lot of time not realizing Python 3.11 isn't supported because of the lack of clarity in the line I've edited.

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
Remove unclear reference to "current" Python version, that does not necessarily mean "current."


Someone please let me know if I need to re-title my PR. I don't see the relevant prefix, but maybe "docs:" ?