### PR TITLE
chore: skip test when python version is unsupported on platform

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,28 +25,34 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Use Python ${{ matrix.python }}
+        id: setup-python
+        continue-on-error: true
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
         env:
           PYTHON_VERSION: ${{ matrix.python }}  # Why do this?
       - name: Install Dependencies
+        if: steps.setup-python.outcome == 'success'
         run: |
           npm install --no-progress
           pip install flake8 pytest
       - name: Set Windows environment
-        if: startsWith(matrix.os, 'windows')
+        if: startsWith(matrix.os, 'windows') && steps.setup-python.outcome == 'success'
         run: |
           echo 'GYP_MSVS_VERSION=2015' >> $Env:GITHUB_ENV
           echo 'GYP_MSVS_OVERRIDE_PATH=C:\\Dummy' >> $Env:GITHUB_ENV
       - name: Lint Python
-        if: startsWith(matrix.os, 'ubuntu')
+        if: startsWith(matrix.os, 'ubuntu') && steps.setup-python.outcome == 'success'
         run: flake8 . --ignore=E203,W503  --max-complexity=101 --max-line-length=88 --show-source --statistics
       - name: Run Python tests
+        if: steps.setup-python.outcome == 'success'
         run: python -m pytest
       # - name: Run doctests with pytest
       #   run: python -m pytest --doctest-modules
       - name: Environment Information
+        if: steps.setup-python.outcome == 'success'
         run: npx envinfo
       - name: Run Node tests
+        if: steps.setup-python.outcome == 'success'
         run: npm test


### PR DESCRIPTION
##### Checklist

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change

`python@3.6` is no longer supported on `ubuntu-latest` (which is now `22.04`). See this recent [workflow run](https://github.com/nodejs/node-gyp/actions/runs/3661197360/jobs/6189168960#step:4:12) to see the failure that occurs when the matrix tries to test that combination.

This change makes CI skip all subsequent steps when the `setup-python` step fails.

One downside to this is that the GitHub UI will still show ✅ for the workflow run instead of indicating that it was skipped.

##### Alternative options

Instead of this, `3.6` could be dropped from the CI matrix, but I don't know enough about python usage to have an opinion on if that is a good idea.