### PR TITLE
ci: update python test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 15
       matrix:
         node: [14.x, 16.x, 18.x]
-        python: ["3.6", "3.8", "3.10", "3.11"]
+        python: ["3.8", "3.10", "3.11"]
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 15
       matrix:
         node: [14.x, 16.x, 18.x]
-        python: ["3.8", "3.10", "3.11"]
+        python: ["3.7", "3.9", "3.11"]
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
##### Checklist

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
Python 3.6 is no longer supported: https://devguide.python.org/versions. This PR drops it from the CI test matrix.

This PR replaces #2772 which was an alternative solution to fix the CI failures that resulted from this.

