### PR TITLE
doc: Add note about Python symlinks (PR 2362) to CHANGELOG.md for v9.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 ### Core
 
 * update due to rename of primary branch ([ca1f068](https://www.github.com/nodejs/node-gyp/commit/ca1f0681a5567ca8cd51acebccd37a633f19bc6a))
+* Add Python symlink to path (for non-Windows OSes only) ([#2362](https://github.com/nodejs/node-gyp/pull/2362)) ([b9ddcd5](https://github.com/nodejs/node-gyp/commit/b9ddcd5bbd93b05b03674836b6ebdae2c2e74c8c))
 
 
 ### Tests


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

Add an entry for PR https://github.com/nodejs/node-gyp/pull/2362 to the CHANGELOG.md for version 9.1.0.

(Details below...)

---

PR https://github.com/nodejs/node-gyp/pull/2362 was merged without a prefixed name, such as "lib:" or "fix:". That means `release-please` didn't include it in the changelog for v9.1.0.

This change did end up affecting users, though. (See issue https://github.com/nodejs/node-gyp/issues/2713 and PR https://github.com/nodejs/node-gyp/pull/2721). Therefore, I believe PR https://github.com/nodejs/node-gyp/pull/2362 should be noted in the CHANGELOG.md, so users can better understand the behavior they are seeing.

(And of course, I think a fix for the unintended side-effects of https://github.com/nodejs/node-gyp/pull/2362 should be merged soon if reasonably possible. See: https://github.com/nodejs/node-gyp/pull/2721 for a fix.)