### PR TITLE
Update docs node-gyp update when using nvm

### DIFF
--- a/docs/Updating-npm-bundled-node-gyp.md
+++ b/docs/Updating-npm-bundled-node-gyp.md
@@ -41,6 +41,13 @@ $ npm explore npm/node_modules/npm-lifecycle -g -- npm install node-gyp@latest
 
 If the command fails with a permissions error, please try `sudo` and then the command.
 
+If you are using `nvm` and the logs indicate no change of the `node-gyp` version, you might need to specify the `node` version, for example do:
+```bash
+$ cd /home/user/.nvm/versions/node/v18.13.0/node_modules/npm/node_modules/@npmcli/run-script
+$ npm install node-gyp@latest
+```
+
+
 ## Windows
 
 Windows is a bit trickier, since `npm` might be installed to the "Program Files" directory, which needs admin privileges in order to


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
In case of using nvm, the regular update of node-gyp might not apply. Added a new section to the docs to clearify this. Before this you would execute the instructions but the node-gyp version did not change. Instead this new instruction helps to specify the node version and update node-gyp accordingly.
