### PR TITLE
update make-fetch-happen to 11.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "env-paths": "^2.2.0",
     "glob": "^7.1.4",
     "graceful-fs": "^4.2.6",
-    "make-fetch-happen": "^10.0.3",
+    "make-fetch-happen": "^11.0.3",
     "nopt": "^6.0.0",
     "npmlog": "^6.0.0",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
Closes #2795
Blocked by #2770

http-cache-semantics 4.1.0 is vulnerable

https://www.cve.org/CVERecord?id=CVE-2022-25881

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
http-cache-semantics 4.1.0 is vulnerable

https://www.cve.org/CVERecord?id=CVE-2022-25881

https://github.com/npm/make-fetch-happen/pull/210
