### PR TITLE
Fix: find visual studio arm64 support

### DIFF
--- a/lib/find-visualstudio.js
+++ b/lib/find-visualstudio.js
@@ -126,7 +126,19 @@ VisualStudioFinder.prototype = {
   // Invoke the PowerShell script to get information about Visual Studio 2017
   // or newer installations
   findVisualStudio2017OrNewer: function findVisualStudio2017OrNewer (cb) {
-    var ps = path.join(process.env.SystemRoot, 'System32',
+    // 32-bit PowerShell (available in SysWOW64) is needed on ARM64 because of
+    // the COM classes and interfaces used by Find-VisualStudio.cs, which are
+    // not registered for being used from ARM64 processes.
+    //
+    // This fix is required for the clean installation of Windows 11. Old
+    // versions (e.g. Windows 10 upgraded to 11) work without it.
+    //
+    // Since VS v17.4 and later is natively supported on ARM64 it seems to
+    // register the ARM64 COM components correctly, but VS 2019 and 2017 will
+    // still have problems being detected. Once support for VS 2017 and 2019
+    // is dropped, this change can be reverted.
+    var systemDirectory = process.arch === 'arm64' ? 'SysWOW64' : 'System32'
+    var ps = path.join(process.env.SystemRoot, systemDirectory,
       'WindowsPowerShell', 'v1.0', 'powershell.exe')
     var csFile = path.join(__dirname, 'Find-VisualStudio.cs')
     var psArgs = [


### PR DESCRIPTION
##### Checklist
- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
This enables running find visual studio script on Windows on ARM64.

Find-VisualStudio.cs uses certain COM classes and interfaces to fetch information about installed Visual Studio versions. As it turns out, these components are not registered correctly for ARM64 when installed, thus they cannot be used from the ARM64 process. Because of that, when searching for Visual Studio installations on Windows on ARM64, PowerShell from SysWOW64 is used, since then Find-VisualStudio.cs can create instances of COM class.

This issue was noticed when running Node.js native test suites on Windows on ARM. The change proposed here fixes this issue as seen from this run https://ci.nodejs.org/job/node-test-binary-windows-native-suites/17121/

The same problem was previously reported in other repositories, eg. https://github.com/microsoft/vs-setup-samples/issues/15 and https://github.com/rust-lang/rust/issues/83043