### PR TITLE
feat: Upgrade Python linting from flake8 to ruff

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,12 @@ on:
   pull_request:
     branches: [ main ]
 jobs:
+  Lint_Python:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: pip install --user ruff
+    - run: ruff --format=github --select="E,F,PLC,PLE,UP,W,YTT" --ignore="S101,UP031" --target-version=py37 .
   Tests:
     strategy:
       fail-fast: false
@@ -33,15 +39,12 @@ jobs:
       - name: Install Dependencies
         run: |
           npm install --no-progress
-          pip install flake8 pytest
+          pip install pytest
       - name: Set Windows environment
         if: startsWith(matrix.os, 'windows')
         run: |
           echo 'GYP_MSVS_VERSION=2015' >> $Env:GITHUB_ENV
           echo 'GYP_MSVS_OVERRIDE_PATH=C:\\Dummy' >> $Env:GITHUB_ENV
-      - name: Lint Python
-        if: startsWith(matrix.os, 'ubuntu')
-        run: flake8 . --ignore=E203,W503  --max-complexity=101 --max-line-length=88 --show-source --statistics
       - name: Run Python tests
         run: python -m pytest
       # - name: Run doctests with pytest

--- a/gyp/pylib/gyp/generator/eclipse.py
+++ b/gyp/pylib/gyp/generator/eclipse.py
@@ -24,7 +24,7 @@ import gyp
 import gyp.common
 import gyp.msvs_emulation
 import shlex
-import xml.etree.cElementTree as ET
+import xml.etree.ElementTree as ET
 
 generator_wants_static_library_dependencies_adjusted = False
 

--- a/gyp/pylib/gyp/xcodeproj_file.py
+++ b/gyp/pylib/gyp/xcodeproj_file.py
@@ -2770,7 +2770,7 @@ class PBXProject(XCContainerPortal):
         self.path = path
         self._other_pbxprojects = {}
         # super
-        return XCContainerPortal.__init__(self, properties, id, parent)
+        XCContainerPortal.__init__(self, properties, id, parent)
 
     def Name(self):
         name = self.path


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) including bandit, isort, pylint, pyupgrade, and flake8 plus its plugins and is written in Rust for speed.

The `ruff` Action uses minimal steps to run in ~10 seconds, rapidly providing intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

@nodejs/python 