### PR TITLE
chore: get update-gyp.py to work with Python >= v3.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: pip install --user ruff
-    - run: ruff --format=github --select="E,F,PLC,PLE,UP,W,YTT" --ignore="S101,UP031" --target-version=py37 .
+    - run: ruff --format=github --select="E,F,PLC,PLE,UP,W,YTT" --ignore="PLC1901,S101,UP031" --target-version=py37 .
   Tests:
     strategy:
       fail-fast: false

--- a/update-gyp.py
+++ b/update-gyp.py
@@ -49,7 +49,7 @@ with tempfile.TemporaryDirectory() as tmp_dir:
                     if not is_within_directory(path, member_path):
                         raise Exception("Attempted Path Traversal in Tar File")
 
-                tar.extractall(path, members, numeric_owner)
+                tar.extractall(path, members, numeric_owner=numeric_owner)
 
             safe_extract(tar_ref, unzip_target)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->
`numeric_owner` is a keyword-only argument in Python v3.9. When I try running the script without the change, Python gives me the following error:
```
Unzipping...
Traceback (most recent call last):
  File "C:\Users\raymondzhao\work\node-gyp\update-gyp.py", line 54, in <module>
    safe_extract(tar_ref, unzip_target)
  File "C:\Users\raymondzhao\work\node-gyp\update-gyp.py", line 52, in safe_extract
    tar.extractall(path, members, numeric_owner)
TypeError: extractall() takes from 1 to 3 positional arguments but 4 were given
```