### PR TITLE
try libnode.dll first in load_exe_hook

### DIFF
--- a/src/win_delay_load_hook.cc
+++ b/src/win_delay_load_hook.cc
@@ -28,7 +28,9 @@ static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
   if (_stricmp(info->szDll, HOST_BINARY) != 0)
     return NULL;
 
-  m = GetModuleHandle(NULL);
+  // try for libnode.dll to compat node.js that using 'vcbuild.bat dll'
+  m = GetModuleHandle("libnode.dll");
+  if (m == NULL) m = GetModuleHandle(NULL);
   return (FARPROC) m;
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

It is a following PR of https://github.com/nodejs/node/issues/47682.

I've tried to rename my executable to `node.exe` but the error is still there.
That's because the node.js's symbol is in `libnode.dll` but not in my executable. So, `GetModuleHandle(NULL)` will not work.

However, I think we can try to load `libnode.dll` first. If failed then fallback to try the executable. That will solve the problem and keep the original path work either.
Maybe it is looks like a edge case, but as Node.js has a [embedding tutorial](https://nodejs.org/dist/latest-v18.x/docs/api/embedding.html) in the doc, I think it's worth to do this.

Or please tell me if there is a more simple way to solve my problem.


------
Test is not included because I need to provide a huge nodedll binary.

Thank you, I love node.js.