### PR TITLE
docs: update applicable GitHub links from master to main

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -13,7 +13,7 @@ provide the basic information we require.
 
 -->
 
-Please look thru your error log for the string `gyp info using node-gyp@` and if the version number is less than the [current release of node-gyp](https://github.com/nodejs/node-gyp/releases) then __please upgrade__ using the instructions at https://github.com/nodejs/node-gyp/blob/master/docs/Updating-npm-bundled-node-gyp.md and try your command again.
+Please look thru your error log for the string `gyp info using node-gyp@` and if the version number is less than the [current release of node-gyp](https://github.com/nodejs/node-gyp/releases) then __please upgrade__ using the instructions at https://github.com/nodejs/node-gyp/blob/main/docs/Updating-npm-bundled-node-gyp.md and try your command again.
 
 Requests for help with [`node-sass` are very common](https://github.com/nodejs/node-gyp/issues?q=label%3A%22Node+Sass+--%3E+Dart+Sass%22). Please be aware that this package is deprecated, you should seek alternatives and avoid opening new issues about it here.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 Thank you for your pull request. Please review the below requirements.
 
-Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
+Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
 -->
 
 ##### Checklist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Code of Conduct
 
 Please read the
-[Code of Conduct](https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md)
+[Code of Conduct](https://github.com/nodejs/admin/blob/main/CODE_OF_CONDUCT.md)
 which explains the minimum behavior expectations for node-gyp contributors.
 
 <a id="developers-certificate-of-origin"></a>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `node-gyp` - Node.js native addon build tool
 
-[![Build Status](https://github.com/nodejs/node-gyp/workflows/Tests/badge.svg?branch=master)](https://github.com/nodejs/node-gyp/actions?query=workflow%3ATests+branch%3Amaster)
+[![Build Status](https://github.com/nodejs/node-gyp/workflows/Tests/badge.svg?branch=main)](https://github.com/nodejs/node-gyp/actions?query=workflow%3ATests+branch%3Amain)
 ![npm](https://img.shields.io/npm/dm/node-gyp)
 
 `node-gyp` is a cross-platform command-line tool written in Node.js for
@@ -168,7 +168,7 @@ The **[docs](./docs/)** directory contains additional documentation on specific 
 Some additional resources for Node.js native addons and writing `gyp` configuration files:
 
  * ["Going Native" a nodeschool.io tutorial](http://nodeschool.io/#goingnative)
- * ["Hello World" node addon example](https://github.com/nodejs/node/tree/master/test/addons/hello-world)
+ * ["Hello World" node addon example](https://github.com/nodejs/node/tree/main/test/addons/hello-world)
  * [gyp user documentation](https://gyp.gsrc.io/docs/UserDocumentation.md)
  * [gyp input format reference](https://gyp.gsrc.io/docs/InputFormatReference.md)
  * [*"binding.gyp" files out in the wild* wiki page](./docs/binding.gyp-files-in-the-wild.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ## Versions of `node-gyp` that are earlier than v9.x.x
 
-Please look thru your error log for the string `gyp info using node-gyp@` and if that version number is less than the [current release of node-gyp](https://github.com/nodejs/node-gyp/releases) then __please upgrade__ using [these instructions](https://github.com/nodejs/node-gyp/blob/master/docs/Updating-npm-bundled-node-gyp.md) and then try your command again.
+Please look thru your error log for the string `gyp info using node-gyp@` and if that version number is less than the [current release of node-gyp](https://github.com/nodejs/node-gyp/releases) then __please upgrade__ using [these instructions](https://github.com/nodejs/node-gyp/blob/main/docs/Updating-npm-bundled-node-gyp.md) and then try your command again.
 
 ## `node-sass` is deprecated
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

Mostly just tidying up the links (which for now redirect), but changing the branch for the workflow status badge in `README.md` fixes it - it was still pointing at `master` and so it wasn't accurately reflecting the current state of `main` (it currently says passing, even though it's failing).