### PR TITLE
Revert "update make-fetch-happen to 11.0.3 (#2796)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "exponential-backoff": "^3.1.1",
     "glob": "^8.0.3",
     "graceful-fs": "^4.2.6",
-    "make-fetch-happen": "^11.0.3",
+    "make-fetch-happen": "^10.0.3",
     "nopt": "^7.0.0",
     "proc-log": "^3.0.0",
     "semver": "^7.3.5",


### PR DESCRIPTION
This reverts commit 02480f6b6894a6bb81dd3e1365bc4df6d5336f7c, as it introduced breaking changes blocking a release of node-gyp 9 from a clean `main`.

`make-fetch-happen` would have to be updated to a (hypothetical future) v10.x fix, or replaced with something else.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change

This reverts commit 02480f6b6894a6bb81dd3e1365bc4df6d5336f7c, thereby rolling back dependency `make-fetch-happen` from `^11.0.3` to `^10.0.3`.

The upgrade is breaking for node-fetch users as it has transitive
dependencies with syntax incompatible with supported Node.js versions.

Related:
- https://github.com/nodejs/node-gyp/pull/2770
- https://github.com/nodejs/node-gyp/pull/2837
- https://github.com/nodejs/node-gyp/pull/2816
- https://github.com/nodejs/node-gyp/issues/2848
- https://github.com/nodejs/node-gyp/pull/2827
- https://github.com/nodejs/node-gyp/pull/2796