### PR TITLE
Migration from tap to mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,13 +39,13 @@
   },
   "devDependencies": {
     "bindings": "^1.5.0",
+    "mocha": "^10.2.0",
     "nan": "^2.14.2",
     "require-inject": "^1.4.4",
-    "standard": "^14.3.4",
-    "tap": "^12.7.0"
+    "standard": "^14.3.4"
   },
   "scripts": {
     "lint": "standard */*.js test/**/*.js",
-    "test": "npm run lint && tap --timeout=1200 test/test-*"
+    "test": "npm run lint && mocha test/test-download.js test/test-*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
   },
   "scripts": {
     "lint": "standard */*.js test/**/*.js",
-    "test": "npm run lint && mocha test/test-download.js test/test-*"
+    "test": "npm run lint && mocha --reporter=test/reporter.js test/test-download.js test/test-*"
   }
 }

--- a/test/reporter.js
+++ b/test/reporter.js
@@ -1,0 +1,75 @@
+const Mocha = require('mocha')
+
+class Reporter {
+  constructor (runner) {
+    this.failedTests = []
+
+    runner.on(Mocha.Runner.constants.EVENT_RUN_BEGIN, () => {
+      console.log('Starting tests')
+    })
+
+    runner.on(Mocha.Runner.constants.EVENT_RUN_END, () => {
+      console.log('Tests finished')
+      console.log()
+      console.log('****************')
+      console.log('* TESTS REPORT *')
+      console.log('****************')
+      console.log()
+      console.log(`Executed ${runner.stats.suites} suites with ${runner.stats.tests} tests in ${runner.stats.duration} ms`)
+      console.log(`  Passed: ${runner.stats.passes}`)
+      console.log(`  Skipped: ${runner.stats.pending}`)
+      console.log(`  Failed: ${runner.stats.failures}`)
+      if (this.failedTests.length > 0) {
+        console.log()
+        console.log('  Failed test details')
+        this.failedTests.forEach((failedTest, index) => {
+          console.log()
+          console.log(`    ${index + 1}.'${failedTest.test.fullTitle()}'`)
+          console.log(`      Name: ${failedTest.error.name}`)
+          console.log(`      Message: ${failedTest.error.message}`)
+          console.log(`      Code: ${failedTest.error.code}`)
+          console.log(`      Stack: ${failedTest.error.stack}`)
+        })
+      }
+      console.log()
+    })
+
+    runner.on(Mocha.Runner.constants.EVENT_SUITE_BEGIN, (suite) => {
+      if (suite.root) {
+        return
+      }
+      console.log(`Starting suite '${suite.title}'`)
+    })
+
+    runner.on(Mocha.Runner.constants.EVENT_SUITE_END, (suite) => {
+      if (suite.root) {
+        return
+      }
+      console.log(`Suite '${suite.title}' finished`)
+      console.log()
+    })
+
+    runner.on(Mocha.Runner.constants.EVENT_TEST_BEGIN, (test) => {
+      console.log(`Starting test '${test.title}'`)
+    })
+
+    runner.on(Mocha.Runner.constants.EVENT_TEST_PASS, (test) => {
+      console.log(`Test '${test.title}' passed in ${test.duration} ms`)
+    })
+
+    runner.on(Mocha.Runner.constants.EVENT_TEST_PENDING, (test) => {
+      console.log(`Test '${test.title}' skipped in ${test.duration} ms`)
+    })
+
+    runner.on(Mocha.Runner.constants.EVENT_TEST_FAIL, (test, error) => {
+      this.failedTests.push({ test, error })
+      console.log(`Test '${test.title}' failed in ${test.duration} ms with ${error}`)
+    })
+
+    runner.on(Mocha.Runner.constants.EVENT_TEST_END, (test) => {
+      console.log()
+    })
+  }
+}
+
+module.exports = Reporter

--- a/test/test-configure-python.js
+++ b/test/test-configure-python.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const test = require('tap').test
+const { describe, it } = require('mocha')
+const assert = require('assert')
 const path = require('path')
 const devDir = require('./common').devDir()
 const gyp = require('../lib/node-gyp')
@@ -22,63 +23,59 @@ const configure = requireInject('../lib/configure', {
 
 const EXPECTED_PYPATH = path.join(__dirname, '..', 'gyp', 'pylib')
 const SEPARATOR = process.platform === 'win32' ? ';' : ':'
-const SPAWN_RESULT = { on: function () { } }
+const SPAWN_RESULT = cb => ({ on: function () { cb() } })
 
 require('npmlog').level = 'warn'
 
-test('configure PYTHONPATH with no existing env', function (t) {
-  t.plan(1)
+describe('configure-python', function () {
+  it('configure PYTHONPATH with no existing env', function (done) {
+    delete process.env.PYTHONPATH
 
-  delete process.env.PYTHONPATH
+    var prog = gyp()
+    prog.parseArgv([])
+    prog.spawn = function () {
+      assert.strictEqual(process.env.PYTHONPATH, EXPECTED_PYPATH)
+      return SPAWN_RESULT(done)
+    }
+    prog.devDir = devDir
+    configure(prog, [], assert.fail)
+  })
 
-  var prog = gyp()
-  prog.parseArgv([])
-  prog.spawn = function () {
-    t.equal(process.env.PYTHONPATH, EXPECTED_PYPATH)
-    return SPAWN_RESULT
-  }
-  prog.devDir = devDir
-  configure(prog, [], t.fail)
-})
+  it('configure PYTHONPATH with existing env of one dir', function (done) {
+    var existingPath = path.join('a', 'b')
+    process.env.PYTHONPATH = existingPath
 
-test('configure PYTHONPATH with existing env of one dir', function (t) {
-  t.plan(2)
+    var prog = gyp()
+    prog.parseArgv([])
+    prog.spawn = function () {
+      assert.strictEqual(process.env.PYTHONPATH, [EXPECTED_PYPATH, existingPath].join(SEPARATOR))
 
-  var existingPath = path.join('a', 'b')
-  process.env.PYTHONPATH = existingPath
+      var dirs = process.env.PYTHONPATH.split(SEPARATOR)
+      assert.deepStrictEqual(dirs, [EXPECTED_PYPATH, existingPath])
 
-  var prog = gyp()
-  prog.parseArgv([])
-  prog.spawn = function () {
-    t.equal(process.env.PYTHONPATH, [EXPECTED_PYPATH, existingPath].join(SEPARATOR))
+      return SPAWN_RESULT(done)
+    }
+    prog.devDir = devDir
+    configure(prog, [], assert.fail)
+  })
 
-    var dirs = process.env.PYTHONPATH.split(SEPARATOR)
-    t.deepEqual(dirs, [EXPECTED_PYPATH, existingPath])
+  it('configure PYTHONPATH with existing env of multiple dirs', function (done) {
+    var pythonDir1 = path.join('a', 'b')
+    var pythonDir2 = path.join('b', 'c')
+    var existingPath = [pythonDir1, pythonDir2].join(SEPARATOR)
+    process.env.PYTHONPATH = existingPath
 
-    return SPAWN_RESULT
-  }
-  prog.devDir = devDir
-  configure(prog, [], t.fail)
-})
+    var prog = gyp()
+    prog.parseArgv([])
+    prog.spawn = function () {
+      assert.strictEqual(process.env.PYTHONPATH, [EXPECTED_PYPATH, existingPath].join(SEPARATOR))
 
-test('configure PYTHONPATH with existing env of multiple dirs', function (t) {
-  t.plan(2)
+      var dirs = process.env.PYTHONPATH.split(SEPARATOR)
+      assert.deepStrictEqual(dirs, [EXPECTED_PYPATH, pythonDir1, pythonDir2])
 
-  var pythonDir1 = path.join('a', 'b')
-  var pythonDir2 = path.join('b', 'c')
-  var existingPath = [pythonDir1, pythonDir2].join(SEPARATOR)
-  process.env.PYTHONPATH = existingPath
-
-  var prog = gyp()
-  prog.parseArgv([])
-  prog.spawn = function () {
-    t.equal(process.env.PYTHONPATH, [EXPECTED_PYPATH, existingPath].join(SEPARATOR))
-
-    var dirs = process.env.PYTHONPATH.split(SEPARATOR)
-    t.deepEqual(dirs, [EXPECTED_PYPATH, pythonDir1, pythonDir2])
-
-    return SPAWN_RESULT
-  }
-  prog.devDir = devDir
-  configure(prog, [], t.fail)
+      return SPAWN_RESULT(done)
+    }
+    prog.devDir = devDir
+    configure(prog, [], assert.fail)
+  })
 })

--- a/test/test-download.js
+++ b/test/test-download.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { test } = require('tap')
+const { describe, it, after } = require('mocha')
+const assert = require('assert')
 const fs = require('fs')
 const path = require('path')
 const util = require('util')
@@ -16,202 +17,194 @@ const certs = require('./fixtures/certs')
 
 log.level = 'warn'
 
-test('download over http', async (t) => {
-  t.plan(2)
+describe('download', function () {
+  it('download over http', async function () {
+    const server = http.createServer((req, res) => {
+      assert.strictEqual(req.headers['user-agent'], `node-gyp v42 (node ${process.version})`)
+      res.end('ok')
+    })
 
-  const server = http.createServer((req, res) => {
-    t.strictEqual(req.headers['user-agent'], `node-gyp v42 (node ${process.version})`)
-    res.end('ok')
+    after(() => new Promise((resolve) => server.close(resolve)))
+
+    const host = 'localhost'
+    await new Promise((resolve) => server.listen(0, host, resolve))
+    const { port } = server.address()
+    const gyp = {
+      opts: {},
+      version: '42'
+    }
+    const url = `http://${host}:${port}`
+    const res = await install.test.download(gyp, url)
+    assert.strictEqual(await res.text(), 'ok')
   })
 
-  t.tearDown(() => new Promise((resolve) => server.close(resolve)))
+  it('download over https with custom ca', async function () {
+    const cafile = path.join(__dirname, 'fixtures/ca.crt')
+    const cacontents = certs['ca.crt']
+    const cert = certs['server.crt']
+    const key = certs['server.key']
+    await fs.promises.writeFile(cafile, cacontents, 'utf8')
+    const ca = await install.test.readCAFile(cafile)
 
-  const host = 'localhost'
-  await new Promise((resolve) => server.listen(0, host, resolve))
-  const { port } = server.address()
-  const gyp = {
-    opts: {},
-    version: '42'
-  }
-  const url = `http://${host}:${port}`
-  const res = await install.test.download(gyp, url)
-  t.strictEqual(await res.text(), 'ok')
-})
+    assert.strictEqual(ca.length, 1)
 
-test('download over https with custom ca', async (t) => {
-  t.plan(3)
+    const options = { ca: ca, cert: cert, key: key }
+    const server = https.createServer(options, (req, res) => {
+      assert.strictEqual(req.headers['user-agent'], `node-gyp v42 (node ${process.version})`)
+      res.end('ok')
+    })
 
-  const cafile = path.join(__dirname, 'fixtures/ca.crt')
-  const cacontents = certs['ca.crt']
-  const cert = certs['server.crt']
-  const key = certs['server.key']
-  await fs.promises.writeFile(cafile, cacontents, 'utf8')
-  const ca = await install.test.readCAFile(cafile)
+    after(async () => {
+      await new Promise((resolve) => server.close(resolve))
+      await fs.promises.unlink(cafile)
+    })
 
-  t.strictEqual(ca.length, 1)
+    server.on('clientError', (err) => { throw err })
 
-  const options = { ca: ca, cert: cert, key: key }
-  const server = https.createServer(options, (req, res) => {
-    t.strictEqual(req.headers['user-agent'], `node-gyp v42 (node ${process.version})`)
-    res.end('ok')
+    const host = 'localhost'
+    await new Promise((resolve) => server.listen(0, host, resolve))
+    const { port } = server.address()
+    const gyp = {
+      opts: { cafile },
+      version: '42'
+    }
+    const url = `https://${host}:${port}`
+    const res = await install.test.download(gyp, url)
+    assert.strictEqual(await res.text(), 'ok')
   })
 
-  t.tearDown(async () => {
-    await new Promise((resolve) => server.close(resolve))
-    await fs.promises.unlink(cafile)
+  it('download over http with proxy', async function () {
+    const server = http.createServer((_, res) => {
+      res.end('ok')
+    })
+
+    const pserver = http.createServer((req, res) => {
+      assert.strictEqual(req.headers['user-agent'], `node-gyp v42 (node ${process.version})`)
+      res.end('proxy ok')
+    })
+
+    after(() => Promise.all([
+      new Promise((resolve) => server.close(resolve)),
+      new Promise((resolve) => pserver.close(resolve))
+    ]))
+
+    const host = 'localhost'
+    await new Promise((resolve) => server.listen(0, host, resolve))
+    const { port } = server.address()
+    await new Promise((resolve) => pserver.listen(port + 1, host, resolve))
+    const gyp = {
+      opts: {
+        proxy: `http://${host}:${port + 1}`,
+        noproxy: 'bad'
+      },
+      version: '42'
+    }
+    const url = `http://${host}:${port}`
+    const res = await install.test.download(gyp, url)
+    assert.strictEqual(await res.text(), 'proxy ok')
   })
 
-  server.on('clientError', (err) => { throw err })
+  it('download over http with noproxy', async function () {
+    const server = http.createServer((req, res) => {
+      assert.strictEqual(req.headers['user-agent'], `node-gyp v42 (node ${process.version})`)
+      res.end('ok')
+    })
 
-  const host = 'localhost'
-  await new Promise((resolve) => server.listen(0, host, resolve))
-  const { port } = server.address()
-  const gyp = {
-    opts: { cafile },
-    version: '42'
-  }
-  const url = `https://${host}:${port}`
-  const res = await install.test.download(gyp, url)
-  t.strictEqual(await res.text(), 'ok')
-})
+    const pserver = http.createServer((_, res) => {
+      res.end('proxy ok')
+    })
 
-test('download over http with proxy', async (t) => {
-  t.plan(2)
+    after(() => Promise.all([
+      new Promise((resolve) => server.close(resolve)),
+      new Promise((resolve) => pserver.close(resolve))
+    ]))
 
-  const server = http.createServer((_, res) => {
-    res.end('ok')
+    const host = 'localhost'
+    await new Promise((resolve) => server.listen(0, host, resolve))
+    const { port } = server.address()
+    await new Promise((resolve) => pserver.listen(port + 1, host, resolve))
+    const gyp = {
+      opts: {
+        proxy: `http://${host}:${port + 1}`,
+        noproxy: host
+      },
+      version: '42'
+    }
+    const url = `http://${host}:${port}`
+    const res = await install.test.download(gyp, url)
+    assert.strictEqual(await res.text(), 'ok')
   })
 
-  const pserver = http.createServer((req, res) => {
-    t.strictEqual(req.headers['user-agent'], `node-gyp v42 (node ${process.version})`)
-    res.end('proxy ok')
+  it('download with missing cafile', async function () {
+    const gyp = {
+      opts: { cafile: 'no.such.file' }
+    }
+    try {
+      await install.test.download(gyp, {}, 'http://bad/')
+    } catch (e) {
+      assert.ok(/no.such.file/.test(e.message))
+    }
   })
 
-  t.tearDown(() => Promise.all([
-    new Promise((resolve) => server.close(resolve)),
-    new Promise((resolve) => pserver.close(resolve))
-  ]))
-
-  const host = 'localhost'
-  await new Promise((resolve) => server.listen(0, host, resolve))
-  const { port } = server.address()
-  await new Promise((resolve) => pserver.listen(port + 1, host, resolve))
-  const gyp = {
-    opts: {
-      proxy: `http://${host}:${port + 1}`,
-      noproxy: 'bad'
-    },
-    version: '42'
-  }
-  const url = `http://${host}:${port}`
-  const res = await install.test.download(gyp, url)
-  t.strictEqual(await res.text(), 'proxy ok')
-})
-
-test('download over http with noproxy', async (t) => {
-  t.plan(2)
-
-  const server = http.createServer((req, res) => {
-    t.strictEqual(req.headers['user-agent'], `node-gyp v42 (node ${process.version})`)
-    res.end('ok')
+  it('check certificate splitting', async function () {
+    const cafile = path.join(__dirname, 'fixtures/ca-bundle.crt')
+    const cacontents = certs['ca-bundle.crt']
+    await fs.promises.writeFile(cafile, cacontents, 'utf8')
+    after(async () => {
+      await fs.promises.unlink(cafile)
+    })
+    const cas = await install.test.readCAFile(path.join(__dirname, 'fixtures/ca-bundle.crt'))
+    assert.strictEqual(cas.length, 2)
+    assert.notStrictEqual(cas[0], cas[1])
   })
 
-  const pserver = http.createServer((_, res) => {
-    res.end('proxy ok')
+  // only run this test if we are running a version of Node with predictable version path behavior
+
+  it('download headers (actual)', async function () {
+    if (process.env.FAST_TEST ||
+        process.release.name !== 'node' ||
+        semver.prerelease(process.version) !== null ||
+        semver.satisfies(process.version, '<10')) {
+      return this.skip('Skipping actual download of headers due to test environment configuration')
+    }
+
+    this.timeout(300000)
+
+    const expectedDir = path.join(devDir, process.version.replace(/^v/, ''))
+    await util.promisify(rimraf)(expectedDir)
+
+    const prog = gyp()
+    prog.parseArgv([])
+    prog.devDir = devDir
+    log.level = 'warn'
+    await util.promisify(install)(prog, [])
+
+    const data = await fs.promises.readFile(path.join(expectedDir, 'installVersion'), 'utf8')
+    assert.strictEqual(data, '10\n', 'correct installVersion')
+
+    const list = await fs.promises.readdir(path.join(expectedDir, 'include/node'))
+    assert.ok(list.includes('common.gypi'))
+    assert.ok(list.includes('config.gypi'))
+    assert.ok(list.includes('node.h'))
+    assert.ok(list.includes('node_version.h'))
+    assert.ok(list.includes('openssl'))
+    assert.ok(list.includes('uv'))
+    assert.ok(list.includes('uv.h'))
+    assert.ok(list.includes('v8-platform.h'))
+    assert.ok(list.includes('v8.h'))
+    assert.ok(list.includes('zlib.h'))
+
+    const lines = (await fs.promises.readFile(path.join(expectedDir, 'include/node/node_version.h'), 'utf8')).split('\n')
+
+    // extract the 3 version parts from the defines to build a valid version string and
+    // and check them against our current env version
+    const version = ['major', 'minor', 'patch'].reduce((version, type) => {
+      const re = new RegExp(`^#define\\sNODE_${type.toUpperCase()}_VERSION`)
+      const line = lines.find((l) => re.test(l))
+      const i = line ? parseInt(line.replace(/^[^0-9]+([0-9]+).*$/, '$1'), 10) : 'ERROR'
+      return `${version}${type !== 'major' ? '.' : 'v'}${i}`
+    }, '')
+
+    assert.strictEqual(version, process.version)
   })
-
-  t.tearDown(() => Promise.all([
-    new Promise((resolve) => server.close(resolve)),
-    new Promise((resolve) => pserver.close(resolve))
-  ]))
-
-  const host = 'localhost'
-  await new Promise((resolve) => server.listen(0, host, resolve))
-  const { port } = server.address()
-  await new Promise((resolve) => pserver.listen(port + 1, host, resolve))
-  const gyp = {
-    opts: {
-      proxy: `http://${host}:${port + 1}`,
-      noproxy: host
-    },
-    version: '42'
-  }
-  const url = `http://${host}:${port}`
-  const res = await install.test.download(gyp, url)
-  t.strictEqual(await res.text(), 'ok')
-})
-
-test('download with missing cafile', async (t) => {
-  t.plan(1)
-  const gyp = {
-    opts: { cafile: 'no.such.file' }
-  }
-  try {
-    await install.test.download(gyp, {}, 'http://bad/')
-  } catch (e) {
-    t.ok(/no.such.file/.test(e.message))
-  }
-})
-
-test('check certificate splitting', async (t) => {
-  const cafile = path.join(__dirname, 'fixtures/ca-bundle.crt')
-  const cacontents = certs['ca-bundle.crt']
-  await fs.promises.writeFile(cafile, cacontents, 'utf8')
-  t.tearDown(async () => {
-    await fs.promises.unlink(cafile)
-  })
-  const cas = await install.test.readCAFile(path.join(__dirname, 'fixtures/ca-bundle.crt'))
-  t.plan(2)
-  t.strictEqual(cas.length, 2)
-  t.notStrictEqual(cas[0], cas[1])
-})
-
-// only run this test if we are running a version of Node with predictable version path behavior
-
-test('download headers (actual)', async (t) => {
-  if (process.env.FAST_TEST ||
-      process.release.name !== 'node' ||
-      semver.prerelease(process.version) !== null ||
-      semver.satisfies(process.version, '<10')) {
-    return t.skip('Skipping actual download of headers due to test environment configuration')
-  }
-
-  t.plan(12)
-
-  const expectedDir = path.join(devDir, process.version.replace(/^v/, ''))
-  await util.promisify(rimraf)(expectedDir)
-
-  const prog = gyp()
-  prog.parseArgv([])
-  prog.devDir = devDir
-  log.level = 'warn'
-  await util.promisify(install)(prog, [])
-
-  const data = await fs.promises.readFile(path.join(expectedDir, 'installVersion'), 'utf8')
-  t.strictEqual(data, '10\n', 'correct installVersion')
-
-  const list = await fs.promises.readdir(path.join(expectedDir, 'include/node'))
-  t.ok(list.includes('common.gypi'))
-  t.ok(list.includes('config.gypi'))
-  t.ok(list.includes('node.h'))
-  t.ok(list.includes('node_version.h'))
-  t.ok(list.includes('openssl'))
-  t.ok(list.includes('uv'))
-  t.ok(list.includes('uv.h'))
-  t.ok(list.includes('v8-platform.h'))
-  t.ok(list.includes('v8.h'))
-  t.ok(list.includes('zlib.h'))
-
-  const lines = (await fs.promises.readFile(path.join(expectedDir, 'include/node/node_version.h'), 'utf8')).split('\n')
-
-  // extract the 3 version parts from the defines to build a valid version string and
-  // and check them against our current env version
-  const version = ['major', 'minor', 'patch'].reduce((version, type) => {
-    const re = new RegExp(`^#define\\sNODE_${type.toUpperCase()}_VERSION`)
-    const line = lines.find((l) => re.test(l))
-    const i = line ? parseInt(line.replace(/^[^0-9]+([0-9]+).*$/, '$1'), 10) : 'ERROR'
-    return `${version}${type !== 'major' ? '.' : 'v'}${i}`
-  }, '')
-
-  t.strictEqual(version, process.version)
 })

--- a/test/test-find-accessible-sync.js
+++ b/test/test-find-accessible-sync.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const test = require('tap').test
+const { describe, it } = require('mocha')
+const assert = require('assert')
 const path = require('path')
 const requireInject = require('require-inject')
 const configure = requireInject('../lib/configure', {
@@ -27,58 +28,46 @@ const readableFiles = [
   path.resolve(dir, readableFileInDir)
 ]
 
-test('find accessible - empty array', function (t) {
-  t.plan(1)
+describe('find-accessible-sync', function () {
+  it('find accessible - empty array', function () {
+    var candidates = []
+    var found = configure.test.findAccessibleSync('test', dir, candidates)
+    assert.strictEqual(found, undefined)
+  })
 
-  var candidates = []
-  var found = configure.test.findAccessibleSync('test', dir, candidates)
-  t.strictEqual(found, undefined)
-})
+  it('find accessible - single item array, readable', function () {
+    var candidates = [readableFile]
+    var found = configure.test.findAccessibleSync('test', dir, candidates)
+    assert.strictEqual(found, path.resolve(dir, readableFile))
+  })
 
-test('find accessible - single item array, readable', function (t) {
-  t.plan(1)
+  it('find accessible - single item array, readable in subdir', function () {
+    var candidates = [readableFileInDir]
+    var found = configure.test.findAccessibleSync('test', dir, candidates)
+    assert.strictEqual(found, path.resolve(dir, readableFileInDir))
+  })
 
-  var candidates = [readableFile]
-  var found = configure.test.findAccessibleSync('test', dir, candidates)
-  t.strictEqual(found, path.resolve(dir, readableFile))
-})
+  it('find accessible - single item array, unreadable', function () {
+    var candidates = ['unreadable_file']
+    var found = configure.test.findAccessibleSync('test', dir, candidates)
+    assert.strictEqual(found, undefined)
+  })
 
-test('find accessible - single item array, readable in subdir', function (t) {
-  t.plan(1)
+  it('find accessible - multi item array, no matches', function () {
+    var candidates = ['non_existent_file', 'unreadable_file']
+    var found = configure.test.findAccessibleSync('test', dir, candidates)
+    assert.strictEqual(found, undefined)
+  })
 
-  var candidates = [readableFileInDir]
-  var found = configure.test.findAccessibleSync('test', dir, candidates)
-  t.strictEqual(found, path.resolve(dir, readableFileInDir))
-})
+  it('find accessible - multi item array, single match', function () {
+    var candidates = ['non_existent_file', readableFile]
+    var found = configure.test.findAccessibleSync('test', dir, candidates)
+    assert.strictEqual(found, path.resolve(dir, readableFile))
+  })
 
-test('find accessible - single item array, unreadable', function (t) {
-  t.plan(1)
-
-  var candidates = ['unreadable_file']
-  var found = configure.test.findAccessibleSync('test', dir, candidates)
-  t.strictEqual(found, undefined)
-})
-
-test('find accessible - multi item array, no matches', function (t) {
-  t.plan(1)
-
-  var candidates = ['non_existent_file', 'unreadable_file']
-  var found = configure.test.findAccessibleSync('test', dir, candidates)
-  t.strictEqual(found, undefined)
-})
-
-test('find accessible - multi item array, single match', function (t) {
-  t.plan(1)
-
-  var candidates = ['non_existent_file', readableFile]
-  var found = configure.test.findAccessibleSync('test', dir, candidates)
-  t.strictEqual(found, path.resolve(dir, readableFile))
-})
-
-test('find accessible - multi item array, return first match', function (t) {
-  t.plan(1)
-
-  var candidates = ['non_existent_file', anotherReadableFile, readableFile]
-  var found = configure.test.findAccessibleSync('test', dir, candidates)
-  t.strictEqual(found, path.resolve(dir, anotherReadableFile))
+  it('find accessible - multi item array, return first match', function () {
+    var candidates = ['non_existent_file', anotherReadableFile, readableFile]
+    var found = configure.test.findAccessibleSync('test', dir, candidates)
+    assert.strictEqual(found, path.resolve(dir, anotherReadableFile))
+  })
 })

--- a/test/test-find-node-directory.js
+++ b/test/test-find-node-directory.js
@@ -1,119 +1,115 @@
 'use strict'
 
-const test = require('tap').test
+const { describe, it } = require('mocha')
+const assert = require('assert')
 const path = require('path')
 const findNodeDirectory = require('../lib/find-node-directory')
 
 const platforms = ['darwin', 'freebsd', 'linux', 'sunos', 'win32', 'aix', 'os400']
 
-// we should find the directory based on the directory
-// the script is running in and it should match the layout
-// in a build tree where npm is installed in
-// .... /deps/npm
-test('test find-node-directory - node install', function (t) {
-  t.plan(platforms.length)
-  for (var next = 0; next < platforms.length; next++) {
-    var processObj = { execPath: '/x/y/bin/node', platform: platforms[next] }
-    t.equal(
-      findNodeDirectory('/x/deps/npm/node_modules/node-gyp/lib', processObj),
-      path.join('/x'))
-  }
-})
-
-// we should find the directory based on the directory
-// the script is running in and it should match the layout
-// in an installed tree where npm is installed in
-// .... /lib/node_modules/npm or .../node_modules/npm
-// depending on the patform
-test('test find-node-directory - node build', function (t) {
-  t.plan(platforms.length)
-  for (var next = 0; next < platforms.length; next++) {
-    var processObj = { execPath: '/x/y/bin/node', platform: platforms[next] }
-    if (platforms[next] === 'win32') {
-      t.equal(
-        findNodeDirectory('/y/node_modules/npm/node_modules/node-gyp/lib',
-          processObj), path.join('/y'))
-    } else {
-      t.equal(
-        findNodeDirectory('/y/lib/node_modules/npm/node_modules/node-gyp/lib',
-          processObj), path.join('/y'))
+describe('find-node-directory', function () {
+  // we should find the directory based on the directory
+  // the script is running in and it should match the layout
+  // in a build tree where npm is installed in
+  // .... /deps/npm
+  it('test find-node-directory - node install', function () {
+    for (var next = 0; next < platforms.length; next++) {
+      var processObj = { execPath: '/x/y/bin/node', platform: platforms[next] }
+      assert.strictEqual(
+        findNodeDirectory('/x/deps/npm/node_modules/node-gyp/lib', processObj),
+        path.join('/x'))
     }
-  }
-})
+  })
 
-// we should find the directory based on the execPath
-// for node and match because it was in the bin directory
-test('test find-node-directory - node in bin directory', function (t) {
-  t.plan(platforms.length)
-  for (var next = 0; next < platforms.length; next++) {
-    var processObj = { execPath: '/x/y/bin/node', platform: platforms[next] }
-    t.equal(
-      findNodeDirectory('/nothere/npm/node_modules/node-gyp/lib', processObj),
-      path.join('/x/y'))
-  }
-})
-
-// we should find the directory based on the execPath
-// for node and match because it was in the Release directory
-test('test find-node-directory - node in build release dir', function (t) {
-  t.plan(platforms.length)
-  for (var next = 0; next < platforms.length; next++) {
-    var processObj
-    if (platforms[next] === 'win32') {
-      processObj = { execPath: '/x/y/Release/node', platform: platforms[next] }
-    } else {
-      processObj = {
-        execPath: '/x/y/out/Release/node',
-        platform: platforms[next]
+  // we should find the directory based on the directory
+  // the script is running in and it should match the layout
+  // in an installed tree where npm is installed in
+  // .... /lib/node_modules/npm or .../node_modules/npm
+  // depending on the patform
+  it('test find-node-directory - node build', function () {
+    for (var next = 0; next < platforms.length; next++) {
+      var processObj = { execPath: '/x/y/bin/node', platform: platforms[next] }
+      if (platforms[next] === 'win32') {
+        assert.strictEqual(
+          findNodeDirectory('/y/node_modules/npm/node_modules/node-gyp/lib',
+            processObj), path.join('/y'))
+      } else {
+        assert.strictEqual(
+          findNodeDirectory('/y/lib/node_modules/npm/node_modules/node-gyp/lib',
+            processObj), path.join('/y'))
       }
     }
+  })
 
-    t.equal(
-      findNodeDirectory('/nothere/npm/node_modules/node-gyp/lib', processObj),
-      path.join('/x/y'))
-  }
-})
-
-// we should find the directory based on the execPath
-// for node and match because it was in the Debug directory
-test('test find-node-directory - node in Debug release dir', function (t) {
-  t.plan(platforms.length)
-  for (var next = 0; next < platforms.length; next++) {
-    var processObj
-    if (platforms[next] === 'win32') {
-      processObj = { execPath: '/a/b/Debug/node', platform: platforms[next] }
-    } else {
-      processObj = { execPath: '/a/b/out/Debug/node', platform: platforms[next] }
+  // we should find the directory based on the execPath
+  // for node and match because it was in the bin directory
+  it('test find-node-directory - node in bin directory', function () {
+    for (var next = 0; next < platforms.length; next++) {
+      var processObj = { execPath: '/x/y/bin/node', platform: platforms[next] }
+      assert.strictEqual(
+        findNodeDirectory('/nothere/npm/node_modules/node-gyp/lib', processObj),
+        path.join('/x/y'))
     }
+  })
 
-    t.equal(
-      findNodeDirectory('/nothere/npm/node_modules/node-gyp/lib', processObj),
-      path.join('/a/b'))
-  }
-})
+  // we should find the directory based on the execPath
+  // for node and match because it was in the Release directory
+  it('test find-node-directory - node in build release dir', function () {
+    for (var next = 0; next < platforms.length; next++) {
+      var processObj
+      if (platforms[next] === 'win32') {
+        processObj = { execPath: '/x/y/Release/node', platform: platforms[next] }
+      } else {
+        processObj = {
+          execPath: '/x/y/out/Release/node',
+          platform: platforms[next]
+        }
+      }
 
-// we should not find it as it will not match based on the execPath nor
-// the directory from which the script is running
-test('test find-node-directory - not found', function (t) {
-  t.plan(platforms.length)
-  for (var next = 0; next < platforms.length; next++) {
-    var processObj = { execPath: '/x/y/z/y', platform: next }
-    t.equal(findNodeDirectory('/a/b/c/d', processObj), '')
-  }
-})
+      assert.strictEqual(
+        findNodeDirectory('/nothere/npm/node_modules/node-gyp/lib', processObj),
+        path.join('/x/y'))
+    }
+  })
 
-// we should find the directory based on the directory
-// the script is running in and it should match the layout
-// in a build tree where npm is installed in
-// .... /deps/npm
-// same test as above but make sure additional directory entries
-// don't cause an issue
-test('test find-node-directory - node install', function (t) {
-  t.plan(platforms.length)
-  for (var next = 0; next < platforms.length; next++) {
-    var processObj = { execPath: '/x/y/bin/node', platform: platforms[next] }
-    t.equal(
-      findNodeDirectory('/x/y/z/a/b/c/deps/npm/node_modules/node-gyp/lib',
-        processObj), path.join('/x/y/z/a/b/c'))
-  }
+  // we should find the directory based on the execPath
+  // for node and match because it was in the Debug directory
+  it('test find-node-directory - node in Debug release dir', function () {
+    for (var next = 0; next < platforms.length; next++) {
+      var processObj
+      if (platforms[next] === 'win32') {
+        processObj = { execPath: '/a/b/Debug/node', platform: platforms[next] }
+      } else {
+        processObj = { execPath: '/a/b/out/Debug/node', platform: platforms[next] }
+      }
+
+      assert.strictEqual(
+        findNodeDirectory('/nothere/npm/node_modules/node-gyp/lib', processObj),
+        path.join('/a/b'))
+    }
+  })
+
+  // we should not find it as it will not match based on the execPath nor
+  // the directory from which the script is running
+  it('test find-node-directory - not found', function () {
+    for (var next = 0; next < platforms.length; next++) {
+      var processObj = { execPath: '/x/y/z/y', platform: next }
+      assert.strictEqual(findNodeDirectory('/a/b/c/d', processObj), '')
+    }
+  })
+
+  // we should find the directory based on the directory
+  // the script is running in and it should match the layout
+  // in a build tree where npm is installed in
+  // .... /deps/npm
+  // same test as above but make sure additional directory entries
+  // don't cause an issue
+  it('test find-node-directory - node install', function () {
+    for (var next = 0; next < platforms.length; next++) {
+      var processObj = { execPath: '/x/y/bin/node', platform: platforms[next] }
+      assert.strictEqual(
+        findNodeDirectory('/x/y/z/a/b/c/deps/npm/node_modules/node-gyp/lib',
+          processObj), path.join('/x/y/z/a/b/c'))
+    }
+  })
 })

--- a/test/test-find-python.js
+++ b/test/test-find-python.js
@@ -2,225 +2,212 @@
 
 delete process.env.PYTHON
 
-const test = require('tap').test
+const { describe, it } = require('mocha')
+const assert = require('assert')
 const findPython = require('../lib/find-python')
 const execFile = require('child_process').execFile
 const PythonFinder = findPython.test.PythonFinder
 
 require('npmlog').level = 'warn'
 
-test('find python', function (t) {
-  t.plan(4)
-
-  findPython.test.findPython(null, function (err, found) {
-    t.strictEqual(err, null)
-    var proc = execFile(found, ['-V'], function (err, stdout, stderr) {
-      t.strictEqual(err, null)
-      t.ok(/Python 3/.test(stdout))
-      t.strictEqual(stderr, '')
+describe('find-python', function () {
+  it('find python', function () {
+    findPython.test.findPython(null, function (err, found) {
+      assert.strictEqual(err, null)
+      var proc = execFile(found, ['-V'], function (err, stdout, stderr) {
+        assert.strictEqual(err, null)
+        assert.ok(/Python 3/.test(stdout))
+        assert.strictEqual(stderr, '')
+      })
+      proc.stdout.setEncoding('utf-8')
+      proc.stderr.setEncoding('utf-8')
     })
-    proc.stdout.setEncoding('utf-8')
-    proc.stderr.setEncoding('utf-8')
   })
-})
 
-function poison (object, property) {
-  function fail () {
-    console.error(Error(`Property ${property} should not have been accessed.`))
-    process.abort()
+  function poison (object, property) {
+    function fail () {
+      console.error(Error(`Property ${property} should not have been accessed.`))
+      process.abort()
+    }
+    var descriptor = {
+      configurable: false,
+      enumerable: false,
+      get: fail,
+      set: fail
+    }
+    Object.defineProperty(object, property, descriptor)
   }
-  var descriptor = {
-    configurable: false,
-    enumerable: false,
-    get: fail,
-    set: fail
+
+  function TestPythonFinder () {
+    PythonFinder.apply(this, arguments)
   }
-  Object.defineProperty(object, property, descriptor)
-}
+  TestPythonFinder.prototype = Object.create(PythonFinder.prototype)
+  // Silence npmlog - remove for debugging
+  TestPythonFinder.prototype.log = {
+    silly: () => {},
+    verbose: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {}
+  }
+  delete TestPythonFinder.prototype.env.NODE_GYP_FORCE_PYTHON
 
-function TestPythonFinder () {
-  PythonFinder.apply(this, arguments)
-}
-TestPythonFinder.prototype = Object.create(PythonFinder.prototype)
-// Silence npmlog - remove for debugging
-TestPythonFinder.prototype.log = {
-  silly: () => {},
-  verbose: () => {},
-  info: () => {},
-  warn: () => {},
-  error: () => {}
-}
-delete TestPythonFinder.prototype.env.NODE_GYP_FORCE_PYTHON
-
-test('find python - python', function (t) {
-  t.plan(6)
-
-  var f = new TestPythonFinder('python', done)
-  f.execFile = function (program, args, opts, cb) {
+  it('find python - python', function () {
+    var f = new TestPythonFinder('python', done)
     f.execFile = function (program, args, opts, cb) {
-      poison(f, 'execFile')
-      t.strictEqual(program, '/path/python')
-      t.ok(/sys\.version_info/.test(args[1]))
-      cb(null, '3.9.1')
-    }
-    t.strictEqual(program,
-      process.platform === 'win32' ? '"python"' : 'python')
-    t.ok(/sys\.executable/.test(args[1]))
-    cb(null, '/path/python')
-  }
-  f.findPython()
-
-  function done (err, python) {
-    t.strictEqual(err, null)
-    t.strictEqual(python, '/path/python')
-  }
-})
-
-test('find python - python too old', function (t) {
-  t.plan(2)
-
-  var f = new TestPythonFinder(null, done)
-  f.execFile = function (program, args, opts, cb) {
-    if (/sys\.executable/.test(args[args.length - 1])) {
-      cb(null, '/path/python')
-    } else if (/sys\.version_info/.test(args[args.length - 1])) {
-      cb(null, '2.3.4')
-    } else {
-      t.fail()
-    }
-  }
-  f.findPython()
-
-  function done (err) {
-    t.ok(/Could not find any Python/.test(err))
-    t.ok(/not supported/i.test(f.errorLog))
-  }
-})
-
-test('find python - no python', function (t) {
-  t.plan(2)
-
-  var f = new TestPythonFinder(null, done)
-  f.execFile = function (program, args, opts, cb) {
-    if (/sys\.executable/.test(args[args.length - 1])) {
-      cb(new Error('not found'))
-    } else if (/sys\.version_info/.test(args[args.length - 1])) {
-      cb(new Error('not a Python executable'))
-    } else {
-      t.fail()
-    }
-  }
-  f.findPython()
-
-  function done (err) {
-    t.ok(/Could not find any Python/.test(err))
-    t.ok(/not in PATH/.test(f.errorLog))
-  }
-})
-
-test('find python - no python2, no python, unix', function (t) {
-  t.plan(2)
-
-  var f = new TestPythonFinder(null, done)
-  f.checkPyLauncher = t.fail
-  f.win = false
-
-  f.execFile = function (program, args, opts, cb) {
-    if (/sys\.executable/.test(args[args.length - 1])) {
-      cb(new Error('not found'))
-    } else {
-      t.fail()
-    }
-  }
-  f.findPython()
-
-  function done (err) {
-    t.ok(/Could not find any Python/.test(err))
-    t.ok(/not in PATH/.test(f.errorLog))
-  }
-})
-
-test('find python - no python, use python launcher', function (t) {
-  t.plan(4)
-
-  var f = new TestPythonFinder(null, done)
-  f.win = true
-
-  f.execFile = function (program, args, opts, cb) {
-    if (program === 'py.exe') {
-      t.notEqual(args.indexOf('-3'), -1)
-      t.notEqual(args.indexOf('-c'), -1)
-      return cb(null, 'Z:\\snake.exe')
-    }
-    if (/sys\.executable/.test(args[args.length - 1])) {
-      cb(new Error('not found'))
-    } else if (f.winDefaultLocations.includes(program)) {
-      cb(new Error('not found'))
-    } else if (/sys\.version_info/.test(args[args.length - 1])) {
-      if (program === 'Z:\\snake.exe') {
-        cb(null, '3.9.0')
-      } else {
-        t.fail()
+      f.execFile = function (program, args, opts, cb) {
+        poison(f, 'execFile')
+        assert.strictEqual(program, '/path/python')
+        assert.ok(/sys\.version_info/.test(args[1]))
+        cb(null, '3.9.1')
       }
-    } else {
-      t.fail()
+      assert.strictEqual(program,
+        process.platform === 'win32' ? '"python"' : 'python')
+      assert.ok(/sys\.executable/.test(args[1]))
+      cb(null, '/path/python')
     }
-  }
-  f.findPython()
+    f.findPython()
 
-  function done (err, python) {
-    t.strictEqual(err, null)
-    t.strictEqual(python, 'Z:\\snake.exe')
-  }
-})
-
-test('find python - no python, no python launcher, good guess', function (t) {
-  t.plan(2)
-
-  var f = new TestPythonFinder(null, done)
-  f.win = true
-  const expectedProgram = f.winDefaultLocations[0]
-
-  f.execFile = function (program, args, opts, cb) {
-    if (program === 'py.exe') {
-      return cb(new Error('not found'))
+    function done (err, python) {
+      assert.strictEqual(err, null)
+      assert.strictEqual(python, '/path/python')
     }
-    if (/sys\.executable/.test(args[args.length - 1])) {
-      cb(new Error('not found'))
-    } else if (program === expectedProgram &&
-               /sys\.version_info/.test(args[args.length - 1])) {
-      cb(null, '3.7.3')
-    } else {
-      t.fail()
+  })
+
+  it('find python - python too old', function () {
+    var f = new TestPythonFinder(null, done)
+    f.execFile = function (program, args, opts, cb) {
+      if (/sys\.executable/.test(args[args.length - 1])) {
+        cb(null, '/path/python')
+      } else if (/sys\.version_info/.test(args[args.length - 1])) {
+        cb(null, '2.3.4')
+      } else {
+        assert.fail()
+      }
     }
-  }
-  f.findPython()
+    f.findPython()
 
-  function done (err, python) {
-    t.strictEqual(err, null)
-    t.ok(python === expectedProgram)
-  }
-})
-
-test('find python - no python, no python launcher, bad guess', function (t) {
-  t.plan(2)
-
-  var f = new TestPythonFinder(null, done)
-  f.win = true
-
-  f.execFile = function (program, args, opts, cb) {
-    if (/sys\.executable/.test(args[args.length - 1])) {
-      cb(new Error('not found'))
-    } else if (/sys\.version_info/.test(args[args.length - 1])) {
-      cb(new Error('not a Python executable'))
-    } else {
-      t.fail()
+    function done (err) {
+      assert.ok(/Could not find any Python/.test(err))
+      assert.ok(/not supported/i.test(f.errorLog))
     }
-  }
-  f.findPython()
+  })
 
-  function done (err) {
-    t.ok(/Could not find any Python/.test(err))
-    t.ok(/not in PATH/.test(f.errorLog))
-  }
+  it('find python - no python', function () {
+    var f = new TestPythonFinder(null, done)
+    f.execFile = function (program, args, opts, cb) {
+      if (/sys\.executable/.test(args[args.length - 1])) {
+        cb(new Error('not found'))
+      } else if (/sys\.version_info/.test(args[args.length - 1])) {
+        cb(new Error('not a Python executable'))
+      } else {
+        assert.fail()
+      }
+    }
+    f.findPython()
+
+    function done (err) {
+      assert.ok(/Could not find any Python/.test(err))
+      assert.ok(/not in PATH/.test(f.errorLog))
+    }
+  })
+
+  it('find python - no python2, no python, unix', function () {
+    var f = new TestPythonFinder(null, done)
+    f.checkPyLauncher = assert.fail
+    f.win = false
+
+    f.execFile = function (program, args, opts, cb) {
+      if (/sys\.executable/.test(args[args.length - 1])) {
+        cb(new Error('not found'))
+      } else {
+        assert.fail()
+      }
+    }
+    f.findPython()
+
+    function done (err) {
+      assert.ok(/Could not find any Python/.test(err))
+      assert.ok(/not in PATH/.test(f.errorLog))
+    }
+  })
+
+  it('find python - no python, use python launcher', function () {
+    var f = new TestPythonFinder(null, done)
+    f.win = true
+
+    f.execFile = function (program, args, opts, cb) {
+      if (program === 'py.exe') {
+        assert.notStrictEqual(args.indexOf('-3'), -1)
+        assert.notStrictEqual(args.indexOf('-c'), -1)
+        return cb(null, 'Z:\\snake.exe')
+      }
+      if (/sys\.executable/.test(args[args.length - 1])) {
+        cb(new Error('not found'))
+      } else if (f.winDefaultLocations.includes(program)) {
+        cb(new Error('not found'))
+      } else if (/sys\.version_info/.test(args[args.length - 1])) {
+        if (program === 'Z:\\snake.exe') {
+          cb(null, '3.9.0')
+        } else {
+          assert.fail()
+        }
+      } else {
+        assert.fail()
+      }
+    }
+    f.findPython()
+
+    function done (err, python) {
+      assert.strictEqual(err, null)
+      assert.strictEqual(python, 'Z:\\snake.exe')
+    }
+  })
+
+  it('find python - no python, no python launcher, good guess', function () {
+    var f = new TestPythonFinder(null, done)
+    f.win = true
+    const expectedProgram = f.winDefaultLocations[0]
+
+    f.execFile = function (program, args, opts, cb) {
+      if (program === 'py.exe') {
+        return cb(new Error('not found'))
+      }
+      if (/sys\.executable/.test(args[args.length - 1])) {
+        cb(new Error('not found'))
+      } else if (program === expectedProgram &&
+                 /sys\.version_info/.test(args[args.length - 1])) {
+        cb(null, '3.7.3')
+      } else {
+        assert.fail()
+      }
+    }
+    f.findPython()
+
+    function done (err, python) {
+      assert.strictEqual(err, null)
+      assert.ok(python === expectedProgram)
+    }
+  })
+
+  it('find python - no python, no python launcher, bad guess', function () {
+    var f = new TestPythonFinder(null, done)
+    f.win = true
+
+    f.execFile = function (program, args, opts, cb) {
+      if (/sys\.executable/.test(args[args.length - 1])) {
+        cb(new Error('not found'))
+      } else if (/sys\.version_info/.test(args[args.length - 1])) {
+        cb(new Error('not a Python executable'))
+      } else {
+        assert.fail()
+      }
+    }
+    f.findPython()
+
+    function done (err) {
+      assert.ok(/Could not find any Python/.test(err))
+      assert.ok(/not in PATH/.test(f.errorLog))
+    }
+  })
 })

--- a/test/test-find-visualstudio.js
+++ b/test/test-find-visualstudio.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const test = require('tap').test
+const { describe, it } = require('mocha')
+const assert = require('assert')
 const fs = require('fs')
 const path = require('path')
 const findVisualStudio = require('../lib/find-visualstudio')
@@ -35,701 +36,635 @@ TestVisualStudioFinder.prototype.log = {
   error: () => {}
 }
 
-test('VS2013', function (t) {
-  t.plan(4)
+describe('find-visualstudio', function () {
+  it('VS2013', function () {
+    const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(info, {
+        msBuild: 'C:\\MSBuild12\\MSBuild.exe',
+        path: 'C:\\VS2013',
+        sdk: null,
+        toolset: 'v120',
+        version: '12.0',
+        versionMajor: 12,
+        versionMinor: 0,
+        versionYear: 2013
+      })
+    })
 
-  const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
-    t.strictEqual(err, null)
-    t.deepEqual(info, {
-      msBuild: 'C:\\MSBuild12\\MSBuild.exe',
-      path: 'C:\\VS2013',
-      sdk: null,
-      toolset: 'v120',
-      version: '12.0',
-      versionMajor: 12,
-      versionMinor: 0,
-      versionYear: 2013
+    finder.findVisualStudio2017OrNewer = (cb) => {
+      finder.parseData(new Error(), '', '', cb)
+    }
+    finder.regSearchKeys = (keys, value, addOpts, cb) => {
+      for (var i = 0; i < keys.length; ++i) {
+        const fullName = `${keys[i]}\\${value}`
+        switch (fullName) {
+          case 'HKLM\\Software\\Microsoft\\VisualStudio\\SxS\\VC7\\14.0':
+          case 'HKLM\\Software\\Wow6432Node\\Microsoft\\VisualStudio\\SxS\\VC7\\14.0':
+            continue
+          case 'HKLM\\Software\\Microsoft\\VisualStudio\\SxS\\VC7\\12.0':
+            assert.ok(true, `expected search for registry value ${fullName}`)
+            return cb(null, 'C:\\VS2013\\VC\\')
+          case 'HKLM\\Software\\Microsoft\\MSBuild\\ToolsVersions\\12.0\\MSBuildToolsPath':
+            assert.ok(true, `expected search for registry value ${fullName}`)
+            return cb(null, 'C:\\MSBuild12\\')
+          default:
+            assert.fail(`unexpected search for registry value ${fullName}`)
+        }
+      }
+      return cb(new Error())
+    }
+    finder.findVisualStudio()
+  })
+
+  it('VS2013 should not be found on new node versions', function () {
+    const finder = new TestVisualStudioFinder({
+      major: 10,
+      minor: 0,
+      patch: 0
+    }, null, (err, info) => {
+      assert.ok(/find .* Visual Studio/i.test(err), 'expect error')
+      assert.ok(!info, 'no data')
+    })
+
+    finder.findVisualStudio2017OrNewer = (cb) => {
+      const file = path.join(__dirname, 'fixtures', 'VS_2017_Unusable.txt')
+      const data = fs.readFileSync(file)
+      finder.parseData(null, data, '', cb)
+    }
+    finder.regSearchKeys = (keys, value, addOpts, cb) => {
+      for (var i = 0; i < keys.length; ++i) {
+        const fullName = `${keys[i]}\\${value}`
+        switch (fullName) {
+          case 'HKLM\\Software\\Microsoft\\VisualStudio\\SxS\\VC7\\14.0':
+          case 'HKLM\\Software\\Wow6432Node\\Microsoft\\VisualStudio\\SxS\\VC7\\14.0':
+            continue
+          default:
+            assert.fail(`unexpected search for registry value ${fullName}`)
+        }
+      }
+      return cb(new Error())
+    }
+    finder.findVisualStudio()
+  })
+
+  it('VS2015', function () {
+    const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(info, {
+        msBuild: 'C:\\MSBuild14\\MSBuild.exe',
+        path: 'C:\\VS2015',
+        sdk: null,
+        toolset: 'v140',
+        version: '14.0',
+        versionMajor: 14,
+        versionMinor: 0,
+        versionYear: 2015
+      })
+    })
+
+    finder.findVisualStudio2017OrNewer = (cb) => {
+      finder.parseData(new Error(), '', '', cb)
+    }
+    finder.regSearchKeys = (keys, value, addOpts, cb) => {
+      for (var i = 0; i < keys.length; ++i) {
+        const fullName = `${keys[i]}\\${value}`
+        switch (fullName) {
+          case 'HKLM\\Software\\Microsoft\\VisualStudio\\SxS\\VC7\\14.0':
+            assert.ok(true, `expected search for registry value ${fullName}`)
+            return cb(null, 'C:\\VS2015\\VC\\')
+          case 'HKLM\\Software\\Microsoft\\MSBuild\\ToolsVersions\\14.0\\MSBuildToolsPath':
+            assert.ok(true, `expected search for registry value ${fullName}`)
+            return cb(null, 'C:\\MSBuild14\\')
+          default:
+            assert.fail(`unexpected search for registry value ${fullName}`)
+        }
+      }
+      return cb(new Error())
+    }
+    finder.findVisualStudio()
+  })
+
+  it('error from PowerShell', function () {
+    const finder = new TestVisualStudioFinder(semverV1, null, null)
+
+    finder.parseData(new Error(), '', '', (info) => {
+      assert.ok(/use PowerShell/i.test(finder.errorLog[0]), 'expect error')
+      assert.ok(!info, 'no data')
     })
   })
 
-  finder.findVisualStudio2017OrNewer = (cb) => {
-    finder.parseData(new Error(), '', '', cb)
-  }
-  finder.regSearchKeys = (keys, value, addOpts, cb) => {
-    for (var i = 0; i < keys.length; ++i) {
-      const fullName = `${keys[i]}\\${value}`
-      switch (fullName) {
-        case 'HKLM\\Software\\Microsoft\\VisualStudio\\SxS\\VC7\\14.0':
-        case 'HKLM\\Software\\Wow6432Node\\Microsoft\\VisualStudio\\SxS\\VC7\\14.0':
-          continue
-        case 'HKLM\\Software\\Microsoft\\VisualStudio\\SxS\\VC7\\12.0':
-          t.pass(`expected search for registry value ${fullName}`)
-          return cb(null, 'C:\\VS2013\\VC\\')
-        case 'HKLM\\Software\\Microsoft\\MSBuild\\ToolsVersions\\12.0\\MSBuildToolsPath':
-          t.pass(`expected search for registry value ${fullName}`)
-          return cb(null, 'C:\\MSBuild12\\')
-        default:
-          t.fail(`unexpected search for registry value ${fullName}`)
-      }
-    }
-    return cb(new Error())
-  }
-  finder.findVisualStudio()
-})
+  it('empty output from PowerShell', function () {
+    const finder = new TestVisualStudioFinder(semverV1, null, null)
 
-test('VS2013 should not be found on new node versions', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder({
-    major: 10,
-    minor: 0,
-    patch: 0
-  }, null, (err, info) => {
-    t.ok(/find .* Visual Studio/i.test(err), 'expect error')
-    t.false(info, 'no data')
+    finder.parseData(null, '', '', (info) => {
+      assert.ok(/use PowerShell/i.test(finder.errorLog[0]), 'expect error')
+      assert.ok(!info, 'no data')
+    })
   })
 
-  finder.findVisualStudio2017OrNewer = (cb) => {
+  it('output from PowerShell not JSON', function () {
+    const finder = new TestVisualStudioFinder(semverV1, null, null)
+
+    finder.parseData(null, 'AAAABBBB', '', (info) => {
+      assert.ok(/use PowerShell/i.test(finder.errorLog[0]), 'expect error')
+      assert.ok(!info, 'no data')
+    })
+  })
+
+  it('wrong JSON from PowerShell', function () {
+    const finder = new TestVisualStudioFinder(semverV1, null, null)
+
+    finder.parseData(null, '{}', '', (info) => {
+      assert.ok(/use PowerShell/i.test(finder.errorLog[0]), 'expect error')
+      assert.ok(!info, 'no data')
+    })
+  })
+
+  it('empty JSON from PowerShell', function () {
+    const finder = new TestVisualStudioFinder(semverV1, null, null)
+
+    finder.parseData(null, '[]', '', (info) => {
+      assert.ok(/find .* Visual Studio/i.test(finder.errorLog[0]), 'expect error')
+      assert.ok(!info, 'no data')
+    })
+  })
+
+  it('future version', function () {
+    const finder = new TestVisualStudioFinder(semverV1, null, null)
+
+    finder.parseData(null, JSON.stringify([{
+      packages: [
+        'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+        'Microsoft.VisualStudio.Component.Windows10SDK.17763',
+        'Microsoft.VisualStudio.VC.MSBuild.Base'
+      ],
+      path: 'C:\\VS',
+      version: '9999.9999.9999.9999'
+    }]), '', (info) => {
+      assert.ok(/unknown version/i.test(finder.errorLog[0]), 'expect error')
+      assert.ok(/find .* Visual Studio/i.test(finder.errorLog[1]), 'expect error')
+      assert.ok(!info, 'no data')
+    })
+  })
+
+  it('single unusable VS2017', function () {
+    const finder = new TestVisualStudioFinder(semverV1, null, null)
+
     const file = path.join(__dirname, 'fixtures', 'VS_2017_Unusable.txt')
     const data = fs.readFileSync(file)
-    finder.parseData(null, data, '', cb)
-  }
-  finder.regSearchKeys = (keys, value, addOpts, cb) => {
-    for (var i = 0; i < keys.length; ++i) {
-      const fullName = `${keys[i]}\\${value}`
-      switch (fullName) {
-        case 'HKLM\\Software\\Microsoft\\VisualStudio\\SxS\\VC7\\14.0':
-        case 'HKLM\\Software\\Wow6432Node\\Microsoft\\VisualStudio\\SxS\\VC7\\14.0':
-          continue
-        default:
-          t.fail(`unexpected search for registry value ${fullName}`)
-      }
+    finder.parseData(null, data, '', (info) => {
+      assert.ok(/checking/i.test(finder.errorLog[0]), 'expect error')
+      assert.ok(/find .* Visual Studio/i.test(finder.errorLog[2]), 'expect error')
+      assert.ok(!info, 'no data')
+    })
+  })
+
+  it('minimal VS2017 Build Tools', function () {
+    const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(info, {
+        msBuild: 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\' +
+          'BuildTools\\MSBuild\\15.0\\Bin\\MSBuild.exe',
+        path:
+          'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools',
+        sdk: '10.0.17134.0',
+        toolset: 'v141',
+        version: '15.9.28307.665',
+        versionMajor: 15,
+        versionMinor: 9,
+        versionYear: 2017
+      })
+    })
+
+    poison(finder, 'regSearchKeys')
+    finder.findVisualStudio2017OrNewer = (cb) => {
+      const file = path.join(__dirname, 'fixtures',
+        'VS_2017_BuildTools_minimal.txt')
+      const data = fs.readFileSync(file)
+      finder.parseData(null, data, '', cb)
     }
-    return cb(new Error())
-  }
-  finder.findVisualStudio()
-})
-
-test('VS2015', function (t) {
-  t.plan(4)
-
-  const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
-    t.strictEqual(err, null)
-    t.deepEqual(info, {
-      msBuild: 'C:\\MSBuild14\\MSBuild.exe',
-      path: 'C:\\VS2015',
-      sdk: null,
-      toolset: 'v140',
-      version: '14.0',
-      versionMajor: 14,
-      versionMinor: 0,
-      versionYear: 2015
-    })
+    finder.findVisualStudio()
   })
 
-  finder.findVisualStudio2017OrNewer = (cb) => {
-    finder.parseData(new Error(), '', '', cb)
-  }
-  finder.regSearchKeys = (keys, value, addOpts, cb) => {
-    for (var i = 0; i < keys.length; ++i) {
-      const fullName = `${keys[i]}\\${value}`
-      switch (fullName) {
-        case 'HKLM\\Software\\Microsoft\\VisualStudio\\SxS\\VC7\\14.0':
-          t.pass(`expected search for registry value ${fullName}`)
-          return cb(null, 'C:\\VS2015\\VC\\')
-        case 'HKLM\\Software\\Microsoft\\MSBuild\\ToolsVersions\\14.0\\MSBuildToolsPath':
-          t.pass(`expected search for registry value ${fullName}`)
-          return cb(null, 'C:\\MSBuild14\\')
-        default:
-          t.fail(`unexpected search for registry value ${fullName}`)
-      }
+  it('VS2017 Community with C++ workload', function () {
+    const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(info, {
+        msBuild: 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\' +
+          'Community\\MSBuild\\15.0\\Bin\\MSBuild.exe',
+        path:
+          'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community',
+        sdk: '10.0.17763.0',
+        toolset: 'v141',
+        version: '15.9.28307.665',
+        versionMajor: 15,
+        versionMinor: 9,
+        versionYear: 2017
+      })
+    })
+
+    poison(finder, 'regSearchKeys')
+    finder.findVisualStudio2017OrNewer = (cb) => {
+      const file = path.join(__dirname, 'fixtures',
+        'VS_2017_Community_workload.txt')
+      const data = fs.readFileSync(file)
+      finder.parseData(null, data, '', cb)
     }
-    return cb(new Error())
-  }
-  finder.findVisualStudio()
-})
-
-test('error from PowerShell', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, null, null)
-
-  finder.parseData(new Error(), '', '', (info) => {
-    t.ok(/use PowerShell/i.test(finder.errorLog[0]), 'expect error')
-    t.false(info, 'no data')
+    finder.findVisualStudio()
   })
-})
 
-test('empty output from PowerShell', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, null, null)
-
-  finder.parseData(null, '', '', (info) => {
-    t.ok(/use PowerShell/i.test(finder.errorLog[0]), 'expect error')
-    t.false(info, 'no data')
-  })
-})
-
-test('output from PowerShell not JSON', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, null, null)
-
-  finder.parseData(null, 'AAAABBBB', '', (info) => {
-    t.ok(/use PowerShell/i.test(finder.errorLog[0]), 'expect error')
-    t.false(info, 'no data')
-  })
-})
-
-test('wrong JSON from PowerShell', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, null, null)
-
-  finder.parseData(null, '{}', '', (info) => {
-    t.ok(/use PowerShell/i.test(finder.errorLog[0]), 'expect error')
-    t.false(info, 'no data')
-  })
-})
-
-test('empty JSON from PowerShell', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, null, null)
-
-  finder.parseData(null, '[]', '', (info) => {
-    t.ok(/find .* Visual Studio/i.test(finder.errorLog[0]), 'expect error')
-    t.false(info, 'no data')
-  })
-})
-
-test('future version', function (t) {
-  t.plan(3)
-
-  const finder = new TestVisualStudioFinder(semverV1, null, null)
-
-  finder.parseData(null, JSON.stringify([{
-    packages: [
-      'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
-      'Microsoft.VisualStudio.Component.Windows10SDK.17763',
-      'Microsoft.VisualStudio.VC.MSBuild.Base'
-    ],
-    path: 'C:\\VS',
-    version: '9999.9999.9999.9999'
-  }]), '', (info) => {
-    t.ok(/unknown version/i.test(finder.errorLog[0]), 'expect error')
-    t.ok(/find .* Visual Studio/i.test(finder.errorLog[1]), 'expect error')
-    t.false(info, 'no data')
-  })
-})
-
-test('single unusable VS2017', function (t) {
-  t.plan(3)
-
-  const finder = new TestVisualStudioFinder(semverV1, null, null)
-
-  const file = path.join(__dirname, 'fixtures', 'VS_2017_Unusable.txt')
-  const data = fs.readFileSync(file)
-  finder.parseData(null, data, '', (info) => {
-    t.ok(/checking/i.test(finder.errorLog[0]), 'expect error')
-    t.ok(/find .* Visual Studio/i.test(finder.errorLog[2]), 'expect error')
-    t.false(info, 'no data')
-  })
-})
-
-test('minimal VS2017 Build Tools', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
-    t.strictEqual(err, null)
-    t.deepEqual(info, {
-      msBuild: 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\' +
-        'BuildTools\\MSBuild\\15.0\\Bin\\MSBuild.exe',
-      path:
-        'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools',
-      sdk: '10.0.17134.0',
-      toolset: 'v141',
-      version: '15.9.28307.665',
-      versionMajor: 15,
-      versionMinor: 9,
-      versionYear: 2017
+  it('VS2017 Express', function () {
+    const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(info, {
+        msBuild: 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\' +
+          'WDExpress\\MSBuild\\15.0\\Bin\\MSBuild.exe',
+        path:
+          'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\WDExpress',
+        sdk: '10.0.17763.0',
+        toolset: 'v141',
+        version: '15.9.28307.858',
+        versionMajor: 15,
+        versionMinor: 9,
+        versionYear: 2017
+      })
     })
-  })
 
-  poison(finder, 'regSearchKeys')
-  finder.findVisualStudio2017OrNewer = (cb) => {
-    const file = path.join(__dirname, 'fixtures',
-      'VS_2017_BuildTools_minimal.txt')
-    const data = fs.readFileSync(file)
-    finder.parseData(null, data, '', cb)
-  }
-  finder.findVisualStudio()
-})
-
-test('VS2017 Community with C++ workload', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
-    t.strictEqual(err, null)
-    t.deepEqual(info, {
-      msBuild: 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\' +
-        'Community\\MSBuild\\15.0\\Bin\\MSBuild.exe',
-      path:
-        'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community',
-      sdk: '10.0.17763.0',
-      toolset: 'v141',
-      version: '15.9.28307.665',
-      versionMajor: 15,
-      versionMinor: 9,
-      versionYear: 2017
-    })
-  })
-
-  poison(finder, 'regSearchKeys')
-  finder.findVisualStudio2017OrNewer = (cb) => {
-    const file = path.join(__dirname, 'fixtures',
-      'VS_2017_Community_workload.txt')
-    const data = fs.readFileSync(file)
-    finder.parseData(null, data, '', cb)
-  }
-  finder.findVisualStudio()
-})
-
-test('VS2017 Express', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
-    t.strictEqual(err, null)
-    t.deepEqual(info, {
-      msBuild: 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\' +
-        'WDExpress\\MSBuild\\15.0\\Bin\\MSBuild.exe',
-      path:
-        'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\WDExpress',
-      sdk: '10.0.17763.0',
-      toolset: 'v141',
-      version: '15.9.28307.858',
-      versionMajor: 15,
-      versionMinor: 9,
-      versionYear: 2017
-    })
-  })
-
-  poison(finder, 'regSearchKeys')
-  finder.findVisualStudio2017OrNewer = (cb) => {
-    const file = path.join(__dirname, 'fixtures', 'VS_2017_Express.txt')
-    const data = fs.readFileSync(file)
-    finder.parseData(null, data, '', cb)
-  }
-  finder.findVisualStudio()
-})
-
-test('VS2019 Preview with C++ workload', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
-    t.strictEqual(err, null)
-    t.deepEqual(info, {
-      msBuild: 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\' +
-        'Preview\\MSBuild\\Current\\Bin\\MSBuild.exe',
-      path:
-        'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Preview',
-      sdk: '10.0.17763.0',
-      toolset: 'v142',
-      version: '16.0.28608.199',
-      versionMajor: 16,
-      versionMinor: 0,
-      versionYear: 2019
-    })
-  })
-
-  poison(finder, 'regSearchKeys')
-  finder.findVisualStudio2017OrNewer = (cb) => {
-    const file = path.join(__dirname, 'fixtures',
-      'VS_2019_Preview.txt')
-    const data = fs.readFileSync(file)
-    finder.parseData(null, data, '', cb)
-  }
-  finder.findVisualStudio()
-})
-
-test('minimal VS2019 Build Tools', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
-    t.strictEqual(err, null)
-    t.deepEqual(info, {
-      msBuild: 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\' +
-        'BuildTools\\MSBuild\\Current\\Bin\\MSBuild.exe',
-      path:
-        'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools',
-      sdk: '10.0.17134.0',
-      toolset: 'v142',
-      version: '16.1.28922.388',
-      versionMajor: 16,
-      versionMinor: 1,
-      versionYear: 2019
-    })
-  })
-
-  poison(finder, 'regSearchKeys')
-  finder.findVisualStudio2017OrNewer = (cb) => {
-    const file = path.join(__dirname, 'fixtures',
-      'VS_2019_BuildTools_minimal.txt')
-    const data = fs.readFileSync(file)
-    finder.parseData(null, data, '', cb)
-  }
-  finder.findVisualStudio()
-})
-
-test('VS2019 Community with C++ workload', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
-    t.strictEqual(err, null)
-    t.deepEqual(info, {
-      msBuild: 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\' +
-        'Community\\MSBuild\\Current\\Bin\\MSBuild.exe',
-      path:
-        'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community',
-      sdk: '10.0.17763.0',
-      toolset: 'v142',
-      version: '16.1.28922.388',
-      versionMajor: 16,
-      versionMinor: 1,
-      versionYear: 2019
-    })
-  })
-
-  poison(finder, 'regSearchKeys')
-  finder.findVisualStudio2017OrNewer = (cb) => {
-    const file = path.join(__dirname, 'fixtures',
-      'VS_2019_Community_workload.txt')
-    const data = fs.readFileSync(file)
-    finder.parseData(null, data, '', cb)
-  }
-  finder.findVisualStudio()
-})
-
-test('VS2022 Preview with C++ workload', function (t) {
-  t.plan(2)
-
-  const msBuildPath = process.arch === 'arm64'
-    ? 'C:\\Program Files\\Microsoft Visual Studio\\2022\\' +
-      'Community\\MSBuild\\Current\\Bin\\arm64\\MSBuild.exe'
-    : 'C:\\Program Files\\Microsoft Visual Studio\\2022\\' +
-      'Community\\MSBuild\\Current\\Bin\\MSBuild.exe'
-
-  const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
-    t.strictEqual(err, null)
-    t.deepEqual(info, {
-      msBuild: msBuildPath,
-      path:
-        'C:\\Program Files\\Microsoft Visual Studio\\2022\\Community',
-      sdk: '10.0.22621.0',
-      toolset: 'v143',
-      version: '17.4.33213.308',
-      versionMajor: 17,
-      versionMinor: 4,
-      versionYear: 2022
-    })
-  })
-
-  poison(finder, 'regSearchKeys')
-  finder.msBuildPathExists = (path) => {
-    return true
-  }
-  finder.findVisualStudio2017OrNewer = (cb) => {
-    const file = path.join(__dirname, 'fixtures',
-      'VS_2022_Community_workload.txt')
-    const data = fs.readFileSync(file)
-    finder.parseData(null, data, '', cb)
-  }
-  finder.findVisualStudio()
-})
-
-function allVsVersions (t, finder) {
-  finder.findVisualStudio2017OrNewer = (cb) => {
-    const data0 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures',
-      'VS_2017_Unusable.txt')))
-    const data1 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures',
-      'VS_2017_BuildTools_minimal.txt')))
-    const data2 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures',
-      'VS_2017_Community_workload.txt')))
-    const data3 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures',
-      'VS_2017_Express.txt')))
-    const data4 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures',
-      'VS_2019_Preview.txt')))
-    const data5 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures',
-      'VS_2019_BuildTools_minimal.txt')))
-    const data6 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures',
-      'VS_2019_Community_workload.txt')))
-    const data7 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures',
-      'VS_2022_Community_workload.txt')))
-    const data = JSON.stringify(data0.concat(data1, data2, data3, data4,
-      data5, data6, data7))
-    finder.parseData(null, data, '', cb)
-  }
-  finder.regSearchKeys = (keys, value, addOpts, cb) => {
-    for (var i = 0; i < keys.length; ++i) {
-      const fullName = `${keys[i]}\\${value}`
-      switch (fullName) {
-        case 'HKLM\\Software\\Microsoft\\VisualStudio\\SxS\\VC7\\14.0':
-        case 'HKLM\\Software\\Microsoft\\VisualStudio\\SxS\\VC7\\12.0':
-          continue
-        case 'HKLM\\Software\\Wow6432Node\\Microsoft\\VisualStudio\\SxS\\VC7\\12.0':
-          return cb(null, 'C:\\VS2013\\VC\\')
-        case 'HKLM\\Software\\Microsoft\\MSBuild\\ToolsVersions\\12.0\\MSBuildToolsPath':
-          return cb(null, 'C:\\MSBuild12\\')
-        case 'HKLM\\Software\\Wow6432Node\\Microsoft\\VisualStudio\\SxS\\VC7\\14.0':
-          return cb(null, 'C:\\VS2015\\VC\\')
-        case 'HKLM\\Software\\Microsoft\\MSBuild\\ToolsVersions\\14.0\\MSBuildToolsPath':
-          return cb(null, 'C:\\MSBuild14\\')
-        default:
-          t.fail(`unexpected search for registry value ${fullName}`)
-      }
+    poison(finder, 'regSearchKeys')
+    finder.findVisualStudio2017OrNewer = (cb) => {
+      const file = path.join(__dirname, 'fixtures', 'VS_2017_Express.txt')
+      const data = fs.readFileSync(file)
+      finder.parseData(null, data, '', cb)
     }
-    return cb(new Error())
+    finder.findVisualStudio()
+  })
+
+  it('VS2019 Preview with C++ workload', function () {
+    const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(info, {
+        msBuild: 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\' +
+          'Preview\\MSBuild\\Current\\Bin\\MSBuild.exe',
+        path:
+          'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Preview',
+        sdk: '10.0.17763.0',
+        toolset: 'v142',
+        version: '16.0.28608.199',
+        versionMajor: 16,
+        versionMinor: 0,
+        versionYear: 2019
+      })
+    })
+
+    poison(finder, 'regSearchKeys')
+    finder.findVisualStudio2017OrNewer = (cb) => {
+      const file = path.join(__dirname, 'fixtures',
+        'VS_2019_Preview.txt')
+      const data = fs.readFileSync(file)
+      finder.parseData(null, data, '', cb)
+    }
+    finder.findVisualStudio()
+  })
+
+  it('minimal VS2019 Build Tools', function () {
+    const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(info, {
+        msBuild: 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\' +
+          'BuildTools\\MSBuild\\Current\\Bin\\MSBuild.exe',
+        path:
+          'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools',
+        sdk: '10.0.17134.0',
+        toolset: 'v142',
+        version: '16.1.28922.388',
+        versionMajor: 16,
+        versionMinor: 1,
+        versionYear: 2019
+      })
+    })
+
+    poison(finder, 'regSearchKeys')
+    finder.findVisualStudio2017OrNewer = (cb) => {
+      const file = path.join(__dirname, 'fixtures',
+        'VS_2019_BuildTools_minimal.txt')
+      const data = fs.readFileSync(file)
+      finder.parseData(null, data, '', cb)
+    }
+    finder.findVisualStudio()
+  })
+
+  it('VS2019 Community with C++ workload', function () {
+    const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(info, {
+        msBuild: 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\' +
+          'Community\\MSBuild\\Current\\Bin\\MSBuild.exe',
+        path:
+          'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community',
+        sdk: '10.0.17763.0',
+        toolset: 'v142',
+        version: '16.1.28922.388',
+        versionMajor: 16,
+        versionMinor: 1,
+        versionYear: 2019
+      })
+    })
+
+    poison(finder, 'regSearchKeys')
+    finder.findVisualStudio2017OrNewer = (cb) => {
+      const file = path.join(__dirname, 'fixtures',
+        'VS_2019_Community_workload.txt')
+      const data = fs.readFileSync(file)
+      finder.parseData(null, data, '', cb)
+    }
+    finder.findVisualStudio()
+  })
+
+  it('VS2022 Preview with C++ workload', function () {
+    const msBuildPath = process.arch === 'arm64'
+      ? 'C:\\Program Files\\Microsoft Visual Studio\\2022\\' +
+        'Community\\MSBuild\\Current\\Bin\\arm64\\MSBuild.exe'
+      : 'C:\\Program Files\\Microsoft Visual Studio\\2022\\' +
+        'Community\\MSBuild\\Current\\Bin\\MSBuild.exe'
+
+    const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(info, {
+        msBuild: msBuildPath,
+        path:
+          'C:\\Program Files\\Microsoft Visual Studio\\2022\\Community',
+        sdk: '10.0.22621.0',
+        toolset: 'v143',
+        version: '17.4.33213.308',
+        versionMajor: 17,
+        versionMinor: 4,
+        versionYear: 2022
+      })
+    })
+
+    poison(finder, 'regSearchKeys')
+    finder.msBuildPathExists = (path) => {
+      return true
+    }
+    finder.findVisualStudio2017OrNewer = (cb) => {
+      const file = path.join(__dirname, 'fixtures',
+        'VS_2022_Community_workload.txt')
+      const data = fs.readFileSync(file)
+      finder.parseData(null, data, '', cb)
+    }
+    finder.findVisualStudio()
+  })
+
+  function allVsVersions (finder) {
+    finder.findVisualStudio2017OrNewer = (cb) => {
+      const data0 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures',
+        'VS_2017_Unusable.txt')))
+      const data1 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures',
+        'VS_2017_BuildTools_minimal.txt')))
+      const data2 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures',
+        'VS_2017_Community_workload.txt')))
+      const data3 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures',
+        'VS_2017_Express.txt')))
+      const data4 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures',
+        'VS_2019_Preview.txt')))
+      const data5 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures',
+        'VS_2019_BuildTools_minimal.txt')))
+      const data6 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures',
+        'VS_2019_Community_workload.txt')))
+      const data7 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures',
+        'VS_2022_Community_workload.txt')))
+      const data = JSON.stringify(data0.concat(data1, data2, data3, data4,
+        data5, data6, data7))
+      finder.parseData(null, data, '', cb)
+    }
+    finder.regSearchKeys = (keys, value, addOpts, cb) => {
+      for (var i = 0; i < keys.length; ++i) {
+        const fullName = `${keys[i]}\\${value}`
+        switch (fullName) {
+          case 'HKLM\\Software\\Microsoft\\VisualStudio\\SxS\\VC7\\14.0':
+          case 'HKLM\\Software\\Microsoft\\VisualStudio\\SxS\\VC7\\12.0':
+            continue
+          case 'HKLM\\Software\\Wow6432Node\\Microsoft\\VisualStudio\\SxS\\VC7\\12.0':
+            return cb(null, 'C:\\VS2013\\VC\\')
+          case 'HKLM\\Software\\Microsoft\\MSBuild\\ToolsVersions\\12.0\\MSBuildToolsPath':
+            return cb(null, 'C:\\MSBuild12\\')
+          case 'HKLM\\Software\\Wow6432Node\\Microsoft\\VisualStudio\\SxS\\VC7\\14.0':
+            return cb(null, 'C:\\VS2015\\VC\\')
+          case 'HKLM\\Software\\Microsoft\\MSBuild\\ToolsVersions\\14.0\\MSBuildToolsPath':
+            return cb(null, 'C:\\MSBuild14\\')
+          default:
+            assert.fail(`unexpected search for registry value ${fullName}`)
+        }
+      }
+      return cb(new Error())
+    }
   }
-}
 
-test('fail when looking for invalid path', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, 'AABB', (err, info) => {
-    t.ok(/find .* Visual Studio/i.test(err), 'expect error')
-    t.false(info, 'no data')
-  })
-
-  allVsVersions(t, finder)
-  finder.findVisualStudio()
-})
-
-test('look for VS2013 by version number', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, '2013', (err, info) => {
-    t.strictEqual(err, null)
-    t.deepEqual(info.versionYear, 2013)
-  })
-
-  allVsVersions(t, finder)
-  finder.findVisualStudio()
-})
-
-test('look for VS2013 by installation path', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, 'C:\\VS2013',
-    (err, info) => {
-      t.strictEqual(err, null)
-      t.deepEqual(info.path, 'C:\\VS2013')
+  it('fail when looking for invalid path', function () {
+    const finder = new TestVisualStudioFinder(semverV1, 'AABB', (err, info) => {
+      assert.ok(/find .* Visual Studio/i.test(err), 'expect error')
+      assert.ok(!info, 'no data')
     })
 
-  allVsVersions(t, finder)
-  finder.findVisualStudio()
-})
-
-test('look for VS2015 by version number', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, '2015', (err, info) => {
-    t.strictEqual(err, null)
-    t.deepEqual(info.versionYear, 2015)
+    allVsVersions(finder)
+    finder.findVisualStudio()
   })
 
-  allVsVersions(t, finder)
-  finder.findVisualStudio()
-})
-
-test('look for VS2015 by installation path', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, 'C:\\VS2015',
-    (err, info) => {
-      t.strictEqual(err, null)
-      t.deepEqual(info.path, 'C:\\VS2015')
+  it('look for VS2013 by version number', function () {
+    const finder = new TestVisualStudioFinder(semverV1, '2013', (err, info) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(info.versionYear, 2013)
     })
 
-  allVsVersions(t, finder)
-  finder.findVisualStudio()
-})
-
-test('look for VS2017 by version number', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, '2017', (err, info) => {
-    t.strictEqual(err, null)
-    t.deepEqual(info.versionYear, 2017)
+    allVsVersions(finder)
+    finder.findVisualStudio()
   })
 
-  allVsVersions(t, finder)
-  finder.findVisualStudio()
-})
+  it('look for VS2013 by installation path', function () {
+    const finder = new TestVisualStudioFinder(semverV1, 'C:\\VS2013',
+      (err, info) => {
+        assert.strictEqual(err, null)
+        assert.deepStrictEqual(info.path, 'C:\\VS2013')
+      })
 
-test('look for VS2017 by installation path', function (t) {
-  t.plan(2)
+    allVsVersions(finder)
+    finder.findVisualStudio()
+  })
 
-  const finder = new TestVisualStudioFinder(semverV1,
-    'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community',
-    (err, info) => {
-      t.strictEqual(err, null)
-      t.deepEqual(info.path,
-        'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community')
+  it('look for VS2015 by version number', function () {
+    const finder = new TestVisualStudioFinder(semverV1, '2015', (err, info) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(info.versionYear, 2015)
     })
 
-  allVsVersions(t, finder)
-  finder.findVisualStudio()
-})
-
-test('look for VS2019 by version number', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, '2019', (err, info) => {
-    t.strictEqual(err, null)
-    t.deepEqual(info.versionYear, 2019)
+    allVsVersions(finder)
+    finder.findVisualStudio()
   })
 
-  allVsVersions(t, finder)
-  finder.findVisualStudio()
-})
+  it('look for VS2015 by installation path', function () {
+    const finder = new TestVisualStudioFinder(semverV1, 'C:\\VS2015',
+      (err, info) => {
+        assert.strictEqual(err, null)
+        assert.deepStrictEqual(info.path, 'C:\\VS2015')
+      })
 
-test('look for VS2019 by installation path', function (t) {
-  t.plan(2)
+    allVsVersions(finder)
+    finder.findVisualStudio()
+  })
 
-  const finder = new TestVisualStudioFinder(semverV1,
-    'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools',
-    (err, info) => {
-      t.strictEqual(err, null)
-      t.deepEqual(info.path,
+  it('look for VS2017 by version number', function () {
+    const finder = new TestVisualStudioFinder(semverV1, '2017', (err, info) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(info.versionYear, 2017)
+    })
+
+    allVsVersions(finder)
+    finder.findVisualStudio()
+  })
+
+  it('look for VS2017 by installation path', function () {
+    const finder = new TestVisualStudioFinder(semverV1,
+      'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community',
+      (err, info) => {
+        assert.strictEqual(err, null)
+        assert.deepStrictEqual(info.path,
+          'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community')
+      })
+
+    allVsVersions(finder)
+    finder.findVisualStudio()
+  })
+
+  it('look for VS2019 by version number', function () {
+    const finder = new TestVisualStudioFinder(semverV1, '2019', (err, info) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(info.versionYear, 2019)
+    })
+
+    allVsVersions(finder)
+    finder.findVisualStudio()
+  })
+
+  it('look for VS2019 by installation path', function () {
+    const finder = new TestVisualStudioFinder(semverV1,
+      'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools',
+      (err, info) => {
+        assert.strictEqual(err, null)
+        assert.deepStrictEqual(info.path,
+          'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools')
+      })
+
+    allVsVersions(finder)
+    finder.findVisualStudio()
+  })
+
+  it('look for VS2022 by version number', function () {
+    const finder = new TestVisualStudioFinder(semverV1, '2022', (err, info) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(info.versionYear, 2022)
+    })
+
+    finder.msBuildPathExists = (path) => {
+      return true
+    }
+
+    allVsVersions(finder)
+    finder.findVisualStudio()
+  })
+
+  it('msvs_version match should be case insensitive', function () {
+    const finder = new TestVisualStudioFinder(semverV1,
+      'c:\\program files (x86)\\microsoft visual studio\\2019\\BUILDTOOLS',
+      (err, info) => {
+        assert.strictEqual(err, null)
+        assert.deepStrictEqual(info.path,
+          'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools')
+      })
+
+    allVsVersions(finder)
+    finder.findVisualStudio()
+  })
+
+  it('latest version should be found by default', function () {
+    const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(info.versionYear, 2022)
+    })
+
+    finder.msBuildPathExists = (path) => {
+      return true
+    }
+
+    allVsVersions(finder)
+    finder.findVisualStudio()
+  })
+
+  it('run on a usable VS Command Prompt', function () {
+    process.env.VCINSTALLDIR = 'C:\\VS2015\\VC'
+    // VSINSTALLDIR is not defined on Visual C++ Build Tools 2015
+    delete process.env.VSINSTALLDIR
+
+    const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(info.path, 'C:\\VS2015')
+    })
+
+    allVsVersions(finder)
+    finder.findVisualStudio()
+  })
+
+  it('VCINSTALLDIR match should be case insensitive', function () {
+    process.env.VCINSTALLDIR =
+      'c:\\program files (x86)\\microsoft visual studio\\2019\\BUILDTOOLS\\VC'
+
+    const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(info.path,
         'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools')
     })
 
-  allVsVersions(t, finder)
-  finder.findVisualStudio()
-})
-
-test('look for VS2022 by version number', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, '2022', (err, info) => {
-    t.strictEqual(err, null)
-    t.deepEqual(info.versionYear, 2022)
+    allVsVersions(finder)
+    finder.findVisualStudio()
   })
 
-  finder.msBuildPathExists = (path) => {
-    return true
-  }
+  it('run on a unusable VS Command Prompt', function () {
+    process.env.VCINSTALLDIR =
+      'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildToolsUnusable\\VC'
 
-  allVsVersions(t, finder)
-  finder.findVisualStudio()
-})
-
-test('msvs_version match should be case insensitive', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1,
-    'c:\\program files (x86)\\microsoft visual studio\\2019\\BUILDTOOLS',
-    (err, info) => {
-      t.strictEqual(err, null)
-      t.deepEqual(info.path,
-        'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools')
+    const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
+      assert.ok(/find .* Visual Studio/i.test(err), 'expect error')
+      assert.ok(!info, 'no data')
     })
 
-  allVsVersions(t, finder)
-  finder.findVisualStudio()
-})
-
-test('latest version should be found by default', function (t) {
-  t.plan(2)
-
-  const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
-    t.strictEqual(err, null)
-    t.deepEqual(info.versionYear, 2022)
+    allVsVersions(finder)
+    finder.findVisualStudio()
   })
 
-  finder.msBuildPathExists = (path) => {
-    return true
-  }
+  it('run on a VS Command Prompt with matching msvs_version', function () {
+    process.env.VCINSTALLDIR = 'C:\\VS2015\\VC'
 
-  allVsVersions(t, finder)
-  finder.findVisualStudio()
-})
+    const finder = new TestVisualStudioFinder(semverV1, 'C:\\VS2015',
+      (err, info) => {
+        assert.strictEqual(err, null)
+        assert.deepStrictEqual(info.path, 'C:\\VS2015')
+      })
 
-test('run on a usable VS Command Prompt', function (t) {
-  t.plan(2)
-
-  process.env.VCINSTALLDIR = 'C:\\VS2015\\VC'
-  // VSINSTALLDIR is not defined on Visual C++ Build Tools 2015
-  delete process.env.VSINSTALLDIR
-
-  const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
-    t.strictEqual(err, null)
-    t.deepEqual(info.path, 'C:\\VS2015')
+    allVsVersions(finder)
+    finder.findVisualStudio()
   })
 
-  allVsVersions(t, finder)
-  finder.findVisualStudio()
-})
+  it('run on a VS Command Prompt with mismatched msvs_version', function () {
+    process.env.VCINSTALLDIR =
+      'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC'
 
-test('VCINSTALLDIR match should be case insensitive', function (t) {
-  t.plan(2)
+    const finder = new TestVisualStudioFinder(semverV1, 'C:\\VS2015',
+      (err, info) => {
+        assert.ok(/find .* Visual Studio/i.test(err), 'expect error')
+        assert.ok(!info, 'no data')
+      })
 
-  process.env.VCINSTALLDIR =
-    'c:\\program files (x86)\\microsoft visual studio\\2019\\BUILDTOOLS\\VC'
-
-  const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
-    t.strictEqual(err, null)
-    t.deepEqual(info.path,
-      'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools')
+    allVsVersions(finder)
+    finder.findVisualStudio()
   })
-
-  allVsVersions(t, finder)
-  finder.findVisualStudio()
-})
-
-test('run on a unusable VS Command Prompt', function (t) {
-  t.plan(2)
-
-  process.env.VCINSTALLDIR =
-    'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildToolsUnusable\\VC'
-
-  const finder = new TestVisualStudioFinder(semverV1, null, (err, info) => {
-    t.ok(/find .* Visual Studio/i.test(err), 'expect error')
-    t.false(info, 'no data')
-  })
-
-  allVsVersions(t, finder)
-  finder.findVisualStudio()
-})
-
-test('run on a VS Command Prompt with matching msvs_version', function (t) {
-  t.plan(2)
-
-  process.env.VCINSTALLDIR = 'C:\\VS2015\\VC'
-
-  const finder = new TestVisualStudioFinder(semverV1, 'C:\\VS2015',
-    (err, info) => {
-      t.strictEqual(err, null)
-      t.deepEqual(info.path, 'C:\\VS2015')
-    })
-
-  allVsVersions(t, finder)
-  finder.findVisualStudio()
-})
-
-test('run on a VS Command Prompt with mismatched msvs_version', function (t) {
-  t.plan(2)
-
-  process.env.VCINSTALLDIR =
-    'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC'
-
-  const finder = new TestVisualStudioFinder(semverV1, 'C:\\VS2015',
-    (err, info) => {
-      t.ok(/find .* Visual Studio/i.test(err), 'expect error')
-      t.false(info, 'no data')
-    })
-
-  allVsVersions(t, finder)
-  finder.findVisualStudio()
 })

--- a/test/test-install.js
+++ b/test/test-install.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { test } = require('tap')
+const { describe, it, after } = require('mocha')
+const assert = require('assert')
 const path = require('path')
 const os = require('os')
 const util = require('util')
@@ -14,117 +15,123 @@ const streamPipeline = util.promisify(stream.pipeline)
 
 log.level = 'error' // we expect a warning
 
-test('EACCES retry once', async (t) => {
-  t.plan(3)
-
-  const fs = {
-    promises: {
-      stat (_) {
-        const err = new Error()
-        err.code = 'EACCES'
-        t.ok(true)
-        throw err
+describe('install', function () {
+  it('EACCES retry once', async () => {
+    const fs = {
+      promises: {
+        stat (_) {
+          const err = new Error()
+          err.code = 'EACCES'
+          assert.ok(true)
+          throw err
+        }
       }
     }
-  }
 
-  const Gyp = {
-    devDir: __dirname,
-    opts: {
-      ensure: true
-    },
-    commands: {
-      install (argv, cb) {
-        install(fs, Gyp, argv).then(cb, cb)
+    const Gyp = {
+      devDir: __dirname,
+      opts: {
+        ensure: true
       },
-      remove (_, cb) {
-        cb()
+      commands: {
+        install (argv, cb) {
+          install(fs, Gyp, argv).then(cb, cb)
+        },
+        remove (_, cb) {
+          cb()
+        }
       }
     }
-  }
 
-  try {
-    await install(fs, Gyp, [])
-  } catch (err) {
-    t.ok(true)
-    if (/"pre" versions of node cannot be installed/.test(err.message)) {
-      t.ok(true)
+    try {
+      await install(fs, Gyp, [])
+    } catch (err) {
+      assert.ok(true)
+      if (/"pre" versions of node cannot be installed/.test(err.message)) {
+        assert.ok(true)
+      }
     }
-  }
-})
-
-// only run these tests if we are running a version of Node with predictable version path behavior
-const skipParallelInstallTests = process.env.FAST_TEST ||
-  process.release.name !== 'node' ||
-  semver.prerelease(process.version) !== null ||
-  semver.satisfies(process.version, '<10')
-
-async function parallelInstallsTest (t, fs, devDir, prog) {
-  if (skipParallelInstallTests) {
-    return t.skip('Skipping parallel installs test due to test environment configuration')
-  }
-
-  t.tearDown(async () => {
-    await util.promisify(rimraf)(devDir)
   })
 
-  const expectedDir = path.join(devDir, process.version.replace(/^v/, ''))
-  await util.promisify(rimraf)(expectedDir)
+  // only run these tests if we are running a version of Node with predictable version path behavior
+  const skipParallelInstallTests = process.env.FAST_TEST ||
+    process.release.name !== 'node' ||
+    semver.prerelease(process.version) !== null ||
+    semver.satisfies(process.version, '<10')
 
-  await Promise.all([
-    install(fs, prog, []),
-    install(fs, prog, []),
-    install(fs, prog, []),
-    install(fs, prog, []),
-    install(fs, prog, []),
-    install(fs, prog, []),
-    install(fs, prog, []),
-    install(fs, prog, []),
-    install(fs, prog, []),
-    install(fs, prog, [])
-  ])
-}
+  async function parallelInstallsTest (test, fs, devDir, prog) {
+    if (skipParallelInstallTests) {
+      return test.skip('Skipping parallel installs test due to test environment configuration')
+    }
 
-test('parallel installs (ensure=true)', async (t) => {
-  const fs = require('graceful-fs')
-  const devDir = await util.promisify(fs.mkdtemp)(path.join(os.tmpdir(), 'node-gyp-test-'))
+    after(async () => {
+      await util.promisify(rimraf)(devDir)
+    })
 
-  const prog = gyp()
-  prog.parseArgv([])
-  prog.devDir = devDir
-  prog.opts.ensure = true
-  log.level = 'warn'
+    const expectedDir = path.join(devDir, process.version.replace(/^v/, ''))
+    await util.promisify(rimraf)(expectedDir)
 
-  await parallelInstallsTest(t, fs, devDir, prog)
-})
+    await Promise.all([
+      install(fs, prog, []),
+      install(fs, prog, []),
+      install(fs, prog, []),
+      install(fs, prog, []),
+      install(fs, prog, []),
+      install(fs, prog, []),
+      install(fs, prog, []),
+      install(fs, prog, []),
+      install(fs, prog, []),
+      install(fs, prog, [])
+    ])
+  }
 
-test('parallel installs (ensure=false)', async (t) => {
-  const fs = require('graceful-fs')
-  const devDir = await util.promisify(fs.mkdtemp)(path.join(os.tmpdir(), 'node-gyp-test-'))
+  it('parallel installs (ensure=true)', async function () {
+    this.timeout(600000)
 
-  const prog = gyp()
-  prog.parseArgv([])
-  prog.devDir = devDir
-  prog.opts.ensure = false
-  log.level = 'warn'
+    const fs = require('graceful-fs')
+    const devDir = await util.promisify(fs.mkdtemp)(path.join(os.tmpdir(), 'node-gyp-test-'))
 
-  await parallelInstallsTest(t, fs, devDir, prog)
-})
+    const prog = gyp()
+    prog.parseArgv([])
+    prog.devDir = devDir
+    prog.opts.ensure = true
+    log.level = 'warn'
 
-test('parallel installs (tarball)', async (t) => {
-  const fs = require('graceful-fs')
-  const devDir = await util.promisify(fs.mkdtemp)(path.join(os.tmpdir(), 'node-gyp-test-'))
+    await parallelInstallsTest(this, fs, devDir, prog)
+  })
 
-  const prog = gyp()
-  prog.parseArgv([])
-  prog.devDir = devDir
-  prog.opts.tarball = path.join(devDir, 'node-headers.tar.gz')
-  log.level = 'warn'
+  it('parallel installs (ensure=false)', async function () {
+    this.timeout(600000)
 
-  await streamPipeline(
-    (await download(prog, 'https://nodejs.org/dist/v16.0.0/node-v16.0.0.tar.gz')).body,
-    fs.createWriteStream(prog.opts.tarball)
-  )
+    const fs = require('graceful-fs')
+    const devDir = await util.promisify(fs.mkdtemp)(path.join(os.tmpdir(), 'node-gyp-test-'))
 
-  await parallelInstallsTest(t, fs, devDir, prog)
+    const prog = gyp()
+    prog.parseArgv([])
+    prog.devDir = devDir
+    prog.opts.ensure = false
+    log.level = 'warn'
+
+    await parallelInstallsTest(this, fs, devDir, prog)
+  })
+
+  it('parallel installs (tarball)', async function () {
+    this.timeout(600000)
+
+    const fs = require('graceful-fs')
+    const devDir = await util.promisify(fs.mkdtemp)(path.join(os.tmpdir(), 'node-gyp-test-'))
+
+    const prog = gyp()
+    prog.parseArgv([])
+    prog.devDir = devDir
+    prog.opts.tarball = path.join(devDir, 'node-headers.tar.gz')
+    log.level = 'warn'
+
+    await streamPipeline(
+      (await download(prog, `https://nodejs.org/dist/${process.version}/node-${process.version}.tar.gz`)).body,
+      fs.createWriteStream(prog.opts.tarball)
+    )
+
+    await parallelInstallsTest(this, fs, devDir, prog)
+  })
 })

--- a/test/test-options.js
+++ b/test/test-options.js
@@ -1,42 +1,41 @@
 'use strict'
 
-const test = require('tap').test
+const { describe, it } = require('mocha')
+const assert = require('assert')
 const gyp = require('../lib/node-gyp')
 
-test('options in environment', (t) => {
-  t.plan(1)
+describe('options', function () {
+  it('options in environment', () => {
+    // `npm test` dumps a ton of npm_config_* variables in the environment.
+    Object.keys(process.env)
+      .filter((key) => /^npm_config_/.test(key))
+      .forEach((key) => { delete process.env[key] })
 
-  // `npm test` dumps a ton of npm_config_* variables in the environment.
-  Object.keys(process.env)
-    .filter((key) => /^npm_config_/.test(key))
-    .forEach((key) => { delete process.env[key] })
+    // in some platforms, certain keys are stubborn and cannot be removed
+    const keys = Object.keys(process.env)
+      .filter((key) => /^npm_config_/.test(key))
+      .map((key) => key.substring('npm_config_'.length))
+      .concat('argv', 'x')
 
-  // in some platforms, certain keys are stubborn and cannot be removed
-  const keys = Object.keys(process.env)
-    .filter((key) => /^npm_config_/.test(key))
-    .map((key) => key.substring('npm_config_'.length))
-    .concat('argv', 'x')
+    // Zero-length keys should get filtered out.
+    process.env.npm_config_ = '42'
+    // Other keys should get added.
+    process.env.npm_config_x = '42'
+    // Except loglevel.
+    process.env.npm_config_loglevel = 'debug'
 
-  // Zero-length keys should get filtered out.
-  process.env.npm_config_ = '42'
-  // Other keys should get added.
-  process.env.npm_config_x = '42'
-  // Except loglevel.
-  process.env.npm_config_loglevel = 'debug'
+    const g = gyp()
+    g.parseArgv(['rebuild']) // Also sets opts.argv.
 
-  const g = gyp()
-  g.parseArgv(['rebuild']) // Also sets opts.argv.
+    assert.deepStrictEqual(Object.keys(g.opts).sort(), keys.sort())
+  })
 
-  t.deepEqual(Object.keys(g.opts).sort(), keys.sort())
-})
+  it('options with spaces in environment', () => {
+    process.env.npm_config_force_process_config = 'true'
 
-test('options with spaces in environment', (t) => {
-  t.plan(1)
+    const g = gyp()
+    g.parseArgv(['rebuild']) // Also sets opts.argv.
 
-  process.env.npm_config_force_process_config = 'true'
-
-  const g = gyp()
-  g.parseArgv(['rebuild']) // Also sets opts.argv.
-
-  t.equal(g.opts['force-process-config'], 'true')
+    assert.strictEqual(g.opts['force-process-config'], 'true')
+  })
 })

--- a/test/test-process-release.js
+++ b/test/test-process-release.js
@@ -1,434 +1,401 @@
 'use strict'
 
-const test = require('tap').test
+const { describe, it } = require('mocha')
+const assert = require('assert')
 const processRelease = require('../lib/process-release')
 
-test('test process release - process.version = 0.8.20', function (t) {
-  t.plan(2)
+describe('process-release', function () {
+  it('test process release - process.version = 0.8.20', function () {
+    var release = processRelease([], { opts: {} }, 'v0.8.20', null)
 
-  var release = processRelease([], { opts: {} }, 'v0.8.20', null)
+    assert.strictEqual(release.semver.version, '0.8.20')
+    delete release.semver
 
-  t.equal(release.semver.version, '0.8.20')
-  delete release.semver
-
-  t.deepEqual(release, {
-    version: '0.8.20',
-    name: 'node',
-    baseUrl: 'https://nodejs.org/dist/v0.8.20/',
-    tarballUrl: 'https://nodejs.org/dist/v0.8.20/node-v0.8.20.tar.gz',
-    shasumsUrl: 'https://nodejs.org/dist/v0.8.20/SHASUMS256.txt',
-    versionDir: '0.8.20',
-    ia32: { libUrl: 'https://nodejs.org/dist/v0.8.20/node.lib', libPath: 'node.lib' },
-    x64: { libUrl: 'https://nodejs.org/dist/v0.8.20/x64/node.lib', libPath: 'x64/node.lib' },
-    arm64: { libUrl: 'https://nodejs.org/dist/v0.8.20/arm64/node.lib', libPath: 'arm64/node.lib' }
-  })
-})
-
-test('test process release - process.version = 0.10.21', function (t) {
-  t.plan(2)
-
-  var release = processRelease([], { opts: {} }, 'v0.10.21', null)
-
-  t.equal(release.semver.version, '0.10.21')
-  delete release.semver
-
-  t.deepEqual(release, {
-    version: '0.10.21',
-    name: 'node',
-    baseUrl: 'https://nodejs.org/dist/v0.10.21/',
-    tarballUrl: 'https://nodejs.org/dist/v0.10.21/node-v0.10.21.tar.gz',
-    shasumsUrl: 'https://nodejs.org/dist/v0.10.21/SHASUMS256.txt',
-    versionDir: '0.10.21',
-    ia32: { libUrl: 'https://nodejs.org/dist/v0.10.21/node.lib', libPath: 'node.lib' },
-    x64: { libUrl: 'https://nodejs.org/dist/v0.10.21/x64/node.lib', libPath: 'x64/node.lib' },
-    arm64: { libUrl: 'https://nodejs.org/dist/v0.10.21/arm64/node.lib', libPath: 'arm64/node.lib' }
-  })
-})
-
-// prior to -headers.tar.gz
-test('test process release - process.version = 0.12.9', function (t) {
-  t.plan(2)
-
-  var release = processRelease([], { opts: {} }, 'v0.12.9', null)
-
-  t.equal(release.semver.version, '0.12.9')
-  delete release.semver
-
-  t.deepEqual(release, {
-    version: '0.12.9',
-    name: 'node',
-    baseUrl: 'https://nodejs.org/dist/v0.12.9/',
-    tarballUrl: 'https://nodejs.org/dist/v0.12.9/node-v0.12.9.tar.gz',
-    shasumsUrl: 'https://nodejs.org/dist/v0.12.9/SHASUMS256.txt',
-    versionDir: '0.12.9',
-    ia32: { libUrl: 'https://nodejs.org/dist/v0.12.9/node.lib', libPath: 'node.lib' },
-    x64: { libUrl: 'https://nodejs.org/dist/v0.12.9/x64/node.lib', libPath: 'x64/node.lib' },
-    arm64: { libUrl: 'https://nodejs.org/dist/v0.12.9/arm64/node.lib', libPath: 'arm64/node.lib' }
-  })
-})
-
-// prior to -headers.tar.gz
-test('test process release - process.version = 0.10.41', function (t) {
-  t.plan(2)
-
-  var release = processRelease([], { opts: {} }, 'v0.10.41', null)
-
-  t.equal(release.semver.version, '0.10.41')
-  delete release.semver
-
-  t.deepEqual(release, {
-    version: '0.10.41',
-    name: 'node',
-    baseUrl: 'https://nodejs.org/dist/v0.10.41/',
-    tarballUrl: 'https://nodejs.org/dist/v0.10.41/node-v0.10.41.tar.gz',
-    shasumsUrl: 'https://nodejs.org/dist/v0.10.41/SHASUMS256.txt',
-    versionDir: '0.10.41',
-    ia32: { libUrl: 'https://nodejs.org/dist/v0.10.41/node.lib', libPath: 'node.lib' },
-    x64: { libUrl: 'https://nodejs.org/dist/v0.10.41/x64/node.lib', libPath: 'x64/node.lib' },
-    arm64: { libUrl: 'https://nodejs.org/dist/v0.10.41/arm64/node.lib', libPath: 'arm64/node.lib' }
-  })
-})
-
-// has -headers.tar.gz
-test('test process release - process.release ~ node@0.10.42', function (t) {
-  t.plan(2)
-
-  var release = processRelease([], { opts: {} }, 'v0.10.42', null)
-
-  t.equal(release.semver.version, '0.10.42')
-  delete release.semver
-
-  t.deepEqual(release, {
-    version: '0.10.42',
-    name: 'node',
-    baseUrl: 'https://nodejs.org/dist/v0.10.42/',
-    tarballUrl: 'https://nodejs.org/dist/v0.10.42/node-v0.10.42-headers.tar.gz',
-    shasumsUrl: 'https://nodejs.org/dist/v0.10.42/SHASUMS256.txt',
-    versionDir: '0.10.42',
-    ia32: { libUrl: 'https://nodejs.org/dist/v0.10.42/node.lib', libPath: 'node.lib' },
-    x64: { libUrl: 'https://nodejs.org/dist/v0.10.42/x64/node.lib', libPath: 'x64/node.lib' },
-    arm64: { libUrl: 'https://nodejs.org/dist/v0.10.42/arm64/node.lib', libPath: 'arm64/node.lib' }
-  })
-})
-
-// has -headers.tar.gz
-test('test process release - process.release ~ node@0.12.10', function (t) {
-  t.plan(2)
-
-  var release = processRelease([], { opts: {} }, 'v0.12.10', null)
-
-  t.equal(release.semver.version, '0.12.10')
-  delete release.semver
-
-  t.deepEqual(release, {
-    version: '0.12.10',
-    name: 'node',
-    baseUrl: 'https://nodejs.org/dist/v0.12.10/',
-    tarballUrl: 'https://nodejs.org/dist/v0.12.10/node-v0.12.10-headers.tar.gz',
-    shasumsUrl: 'https://nodejs.org/dist/v0.12.10/SHASUMS256.txt',
-    versionDir: '0.12.10',
-    ia32: { libUrl: 'https://nodejs.org/dist/v0.12.10/node.lib', libPath: 'node.lib' },
-    x64: { libUrl: 'https://nodejs.org/dist/v0.12.10/x64/node.lib', libPath: 'x64/node.lib' },
-    arm64: { libUrl: 'https://nodejs.org/dist/v0.12.10/arm64/node.lib', libPath: 'arm64/node.lib' }
-  })
-})
-
-test('test process release - process.release ~ node@4.1.23', function (t) {
-  t.plan(2)
-
-  var release = processRelease([], { opts: {} }, 'v4.1.23', {
-    name: 'node',
-    headersUrl: 'https://nodejs.org/dist/v4.1.23/node-v4.1.23-headers.tar.gz'
+    assert.deepStrictEqual(release, {
+      version: '0.8.20',
+      name: 'node',
+      baseUrl: 'https://nodejs.org/dist/v0.8.20/',
+      tarballUrl: 'https://nodejs.org/dist/v0.8.20/node-v0.8.20.tar.gz',
+      shasumsUrl: 'https://nodejs.org/dist/v0.8.20/SHASUMS256.txt',
+      versionDir: '0.8.20',
+      ia32: { libUrl: 'https://nodejs.org/dist/v0.8.20/node.lib', libPath: 'node.lib' },
+      x64: { libUrl: 'https://nodejs.org/dist/v0.8.20/x64/node.lib', libPath: 'x64/node.lib' },
+      arm64: { libUrl: 'https://nodejs.org/dist/v0.8.20/arm64/node.lib', libPath: 'arm64/node.lib' }
+    })
   })
 
-  t.equal(release.semver.version, '4.1.23')
-  delete release.semver
+  it('test process release - process.version = 0.10.21', function () {
+    var release = processRelease([], { opts: {} }, 'v0.10.21', null)
 
-  t.deepEqual(release, {
-    version: '4.1.23',
-    name: 'node',
-    baseUrl: 'https://nodejs.org/dist/v4.1.23/',
-    tarballUrl: 'https://nodejs.org/dist/v4.1.23/node-v4.1.23-headers.tar.gz',
-    shasumsUrl: 'https://nodejs.org/dist/v4.1.23/SHASUMS256.txt',
-    versionDir: '4.1.23',
-    ia32: { libUrl: 'https://nodejs.org/dist/v4.1.23/win-x86/node.lib', libPath: 'win-x86/node.lib' },
-    x64: { libUrl: 'https://nodejs.org/dist/v4.1.23/win-x64/node.lib', libPath: 'win-x64/node.lib' },
-    arm64: { libUrl: 'https://nodejs.org/dist/v4.1.23/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
-  })
-})
+    assert.strictEqual(release.semver.version, '0.10.21')
+    delete release.semver
 
-test('test process release - process.release ~ node@4.1.23 / corp build', function (t) {
-  t.plan(2)
-
-  var release = processRelease([], { opts: {} }, 'v4.1.23', {
-    name: 'node',
-    headersUrl: 'https://some.custom.location/node-v4.1.23-headers.tar.gz'
+    assert.deepStrictEqual(release, {
+      version: '0.10.21',
+      name: 'node',
+      baseUrl: 'https://nodejs.org/dist/v0.10.21/',
+      tarballUrl: 'https://nodejs.org/dist/v0.10.21/node-v0.10.21.tar.gz',
+      shasumsUrl: 'https://nodejs.org/dist/v0.10.21/SHASUMS256.txt',
+      versionDir: '0.10.21',
+      ia32: { libUrl: 'https://nodejs.org/dist/v0.10.21/node.lib', libPath: 'node.lib' },
+      x64: { libUrl: 'https://nodejs.org/dist/v0.10.21/x64/node.lib', libPath: 'x64/node.lib' },
+      arm64: { libUrl: 'https://nodejs.org/dist/v0.10.21/arm64/node.lib', libPath: 'arm64/node.lib' }
+    })
   })
 
-  t.equal(release.semver.version, '4.1.23')
-  delete release.semver
+  // prior to -headers.tar.gz
+  it('test process release - process.version = 0.12.9', function () {
+    var release = processRelease([], { opts: {} }, 'v0.12.9', null)
 
-  t.deepEqual(release, {
-    version: '4.1.23',
-    name: 'node',
-    baseUrl: 'https://some.custom.location/',
-    tarballUrl: 'https://some.custom.location/node-v4.1.23-headers.tar.gz',
-    shasumsUrl: 'https://some.custom.location/SHASUMS256.txt',
-    versionDir: '4.1.23',
-    ia32: { libUrl: 'https://some.custom.location/win-x86/node.lib', libPath: 'win-x86/node.lib' },
-    x64: { libUrl: 'https://some.custom.location/win-x64/node.lib', libPath: 'win-x64/node.lib' },
-    arm64: { libUrl: 'https://some.custom.location/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
-  })
-})
+    assert.strictEqual(release.semver.version, '0.12.9')
+    delete release.semver
 
-test('test process release - process.release ~ node@12.8.0 Windows', function (t) {
-  t.plan(2)
-
-  var release = processRelease([], { opts: {} }, 'v12.8.0', {
-    name: 'node',
-    sourceUrl: 'https://nodejs.org/download/release/v12.8.0/node-v12.8.0.tar.gz',
-    headersUrl: 'https://nodejs.org/download/release/v12.8.0/node-v12.8.0-headers.tar.gz',
-    libUrl: 'https://nodejs.org/download/release/v12.8.0/win-x64/node.lib'
+    assert.deepStrictEqual(release, {
+      version: '0.12.9',
+      name: 'node',
+      baseUrl: 'https://nodejs.org/dist/v0.12.9/',
+      tarballUrl: 'https://nodejs.org/dist/v0.12.9/node-v0.12.9.tar.gz',
+      shasumsUrl: 'https://nodejs.org/dist/v0.12.9/SHASUMS256.txt',
+      versionDir: '0.12.9',
+      ia32: { libUrl: 'https://nodejs.org/dist/v0.12.9/node.lib', libPath: 'node.lib' },
+      x64: { libUrl: 'https://nodejs.org/dist/v0.12.9/x64/node.lib', libPath: 'x64/node.lib' },
+      arm64: { libUrl: 'https://nodejs.org/dist/v0.12.9/arm64/node.lib', libPath: 'arm64/node.lib' }
+    })
   })
 
-  t.equal(release.semver.version, '12.8.0')
-  delete release.semver
+  // prior to -headers.tar.gz
+  it('test process release - process.version = 0.10.41', function () {
+    var release = processRelease([], { opts: {} }, 'v0.10.41', null)
 
-  t.deepEqual(release, {
-    version: '12.8.0',
-    name: 'node',
-    baseUrl: 'https://nodejs.org/download/release/v12.8.0/',
-    tarballUrl: 'https://nodejs.org/download/release/v12.8.0/node-v12.8.0-headers.tar.gz',
-    shasumsUrl: 'https://nodejs.org/download/release/v12.8.0/SHASUMS256.txt',
-    versionDir: '12.8.0',
-    ia32: { libUrl: 'https://nodejs.org/download/release/v12.8.0/win-x86/node.lib', libPath: 'win-x86/node.lib' },
-    x64: { libUrl: 'https://nodejs.org/download/release/v12.8.0/win-x64/node.lib', libPath: 'win-x64/node.lib' },
-    arm64: { libUrl: 'https://nodejs.org/download/release/v12.8.0/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
-  })
-})
+    assert.strictEqual(release.semver.version, '0.10.41')
+    delete release.semver
 
-test('test process release - process.release ~ node@12.8.0 Windows ARM64', function (t) {
-  t.plan(2)
-
-  var release = processRelease([], { opts: {} }, 'v12.8.0', {
-    name: 'node',
-    sourceUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/node-v12.8.0.tar.gz',
-    headersUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/node-v12.8.0-headers.tar.gz',
-    libUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/win-arm64/node.lib'
+    assert.deepStrictEqual(release, {
+      version: '0.10.41',
+      name: 'node',
+      baseUrl: 'https://nodejs.org/dist/v0.10.41/',
+      tarballUrl: 'https://nodejs.org/dist/v0.10.41/node-v0.10.41.tar.gz',
+      shasumsUrl: 'https://nodejs.org/dist/v0.10.41/SHASUMS256.txt',
+      versionDir: '0.10.41',
+      ia32: { libUrl: 'https://nodejs.org/dist/v0.10.41/node.lib', libPath: 'node.lib' },
+      x64: { libUrl: 'https://nodejs.org/dist/v0.10.41/x64/node.lib', libPath: 'x64/node.lib' },
+      arm64: { libUrl: 'https://nodejs.org/dist/v0.10.41/arm64/node.lib', libPath: 'arm64/node.lib' }
+    })
   })
 
-  t.equal(release.semver.version, '12.8.0')
-  delete release.semver
+  // has -headers.tar.gz
+  it('test process release - process.release ~ node@0.10.42', function () {
+    var release = processRelease([], { opts: {} }, 'v0.10.42', null)
 
-  t.deepEqual(release, {
-    version: '12.8.0',
-    name: 'node',
-    baseUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/',
-    tarballUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/node-v12.8.0-headers.tar.gz',
-    shasumsUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/SHASUMS256.txt',
-    versionDir: '12.8.0',
-    ia32: { libUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/win-x86/node.lib', libPath: 'win-x86/node.lib' },
-    x64: { libUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/win-x64/node.lib', libPath: 'win-x64/node.lib' },
-    arm64: { libUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
-  })
-})
+    assert.strictEqual(release.semver.version, '0.10.42')
+    delete release.semver
 
-test('test process release - process.release ~ node@4.1.23 --target=0.10.40', function (t) {
-  t.plan(2)
-
-  var release = processRelease([], { opts: { target: '0.10.40' } }, 'v4.1.23', {
-    name: 'node',
-    headersUrl: 'https://nodejs.org/dist/v4.1.23/node-v4.1.23-headers.tar.gz'
+    assert.deepStrictEqual(release, {
+      version: '0.10.42',
+      name: 'node',
+      baseUrl: 'https://nodejs.org/dist/v0.10.42/',
+      tarballUrl: 'https://nodejs.org/dist/v0.10.42/node-v0.10.42-headers.tar.gz',
+      shasumsUrl: 'https://nodejs.org/dist/v0.10.42/SHASUMS256.txt',
+      versionDir: '0.10.42',
+      ia32: { libUrl: 'https://nodejs.org/dist/v0.10.42/node.lib', libPath: 'node.lib' },
+      x64: { libUrl: 'https://nodejs.org/dist/v0.10.42/x64/node.lib', libPath: 'x64/node.lib' },
+      arm64: { libUrl: 'https://nodejs.org/dist/v0.10.42/arm64/node.lib', libPath: 'arm64/node.lib' }
+    })
   })
 
-  t.equal(release.semver.version, '0.10.40')
-  delete release.semver
+  // has -headers.tar.gz
+  it('test process release - process.release ~ node@0.12.10', function () {
+    var release = processRelease([], { opts: {} }, 'v0.12.10', null)
 
-  t.deepEqual(release, {
-    version: '0.10.40',
-    name: 'node',
-    baseUrl: 'https://nodejs.org/dist/v0.10.40/',
-    tarballUrl: 'https://nodejs.org/dist/v0.10.40/node-v0.10.40.tar.gz',
-    shasumsUrl: 'https://nodejs.org/dist/v0.10.40/SHASUMS256.txt',
-    versionDir: '0.10.40',
-    ia32: { libUrl: 'https://nodejs.org/dist/v0.10.40/node.lib', libPath: 'node.lib' },
-    x64: { libUrl: 'https://nodejs.org/dist/v0.10.40/x64/node.lib', libPath: 'x64/node.lib' },
-    arm64: { libUrl: 'https://nodejs.org/dist/v0.10.40/arm64/node.lib', libPath: 'arm64/node.lib' }
-  })
-})
+    assert.strictEqual(release.semver.version, '0.12.10')
+    delete release.semver
 
-test('test process release - process.release ~ node@4.1.23 --dist-url=https://foo.bar/baz', function (t) {
-  t.plan(2)
-
-  var release = processRelease([], { opts: { 'dist-url': 'https://foo.bar/baz' } }, 'v4.1.23', {
-    name: 'node',
-    headersUrl: 'https://nodejs.org/dist/v4.1.23/node-v4.1.23-headers.tar.gz'
+    assert.deepStrictEqual(release, {
+      version: '0.12.10',
+      name: 'node',
+      baseUrl: 'https://nodejs.org/dist/v0.12.10/',
+      tarballUrl: 'https://nodejs.org/dist/v0.12.10/node-v0.12.10-headers.tar.gz',
+      shasumsUrl: 'https://nodejs.org/dist/v0.12.10/SHASUMS256.txt',
+      versionDir: '0.12.10',
+      ia32: { libUrl: 'https://nodejs.org/dist/v0.12.10/node.lib', libPath: 'node.lib' },
+      x64: { libUrl: 'https://nodejs.org/dist/v0.12.10/x64/node.lib', libPath: 'x64/node.lib' },
+      arm64: { libUrl: 'https://nodejs.org/dist/v0.12.10/arm64/node.lib', libPath: 'arm64/node.lib' }
+    })
   })
 
-  t.equal(release.semver.version, '4.1.23')
-  delete release.semver
+  it('test process release - process.release ~ node@4.1.23', function () {
+    var release = processRelease([], { opts: {} }, 'v4.1.23', {
+      name: 'node',
+      headersUrl: 'https://nodejs.org/dist/v4.1.23/node-v4.1.23-headers.tar.gz'
+    })
 
-  t.deepEqual(release, {
-    version: '4.1.23',
-    name: 'node',
-    baseUrl: 'https://foo.bar/baz/v4.1.23/',
-    tarballUrl: 'https://foo.bar/baz/v4.1.23/node-v4.1.23-headers.tar.gz',
-    shasumsUrl: 'https://foo.bar/baz/v4.1.23/SHASUMS256.txt',
-    versionDir: '4.1.23',
-    ia32: { libUrl: 'https://foo.bar/baz/v4.1.23/win-x86/node.lib', libPath: 'win-x86/node.lib' },
-    x64: { libUrl: 'https://foo.bar/baz/v4.1.23/win-x64/node.lib', libPath: 'win-x64/node.lib' },
-    arm64: { libUrl: 'https://foo.bar/baz/v4.1.23/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
-  })
-})
+    assert.strictEqual(release.semver.version, '4.1.23')
+    delete release.semver
 
-test('test process release - process.release ~ frankenstein@4.1.23', function (t) {
-  t.plan(2)
-
-  var release = processRelease([], { opts: {} }, 'v4.1.23', {
-    name: 'frankenstein',
-    headersUrl: 'https://frankensteinjs.org/dist/v4.1.23/frankenstein-v4.1.23-headers.tar.gz'
+    assert.deepStrictEqual(release, {
+      version: '4.1.23',
+      name: 'node',
+      baseUrl: 'https://nodejs.org/dist/v4.1.23/',
+      tarballUrl: 'https://nodejs.org/dist/v4.1.23/node-v4.1.23-headers.tar.gz',
+      shasumsUrl: 'https://nodejs.org/dist/v4.1.23/SHASUMS256.txt',
+      versionDir: '4.1.23',
+      ia32: { libUrl: 'https://nodejs.org/dist/v4.1.23/win-x86/node.lib', libPath: 'win-x86/node.lib' },
+      x64: { libUrl: 'https://nodejs.org/dist/v4.1.23/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+      arm64: { libUrl: 'https://nodejs.org/dist/v4.1.23/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
+    })
   })
 
-  t.equal(release.semver.version, '4.1.23')
-  delete release.semver
+  it('test process release - process.release ~ node@4.1.23 / corp build', function () {
+    var release = processRelease([], { opts: {} }, 'v4.1.23', {
+      name: 'node',
+      headersUrl: 'https://some.custom.location/node-v4.1.23-headers.tar.gz'
+    })
 
-  t.deepEqual(release, {
-    version: '4.1.23',
-    name: 'frankenstein',
-    baseUrl: 'https://frankensteinjs.org/dist/v4.1.23/',
-    tarballUrl: 'https://frankensteinjs.org/dist/v4.1.23/frankenstein-v4.1.23-headers.tar.gz',
-    shasumsUrl: 'https://frankensteinjs.org/dist/v4.1.23/SHASUMS256.txt',
-    versionDir: 'frankenstein-4.1.23',
-    ia32: { libUrl: 'https://frankensteinjs.org/dist/v4.1.23/win-x86/frankenstein.lib', libPath: 'win-x86/frankenstein.lib' },
-    x64: { libUrl: 'https://frankensteinjs.org/dist/v4.1.23/win-x64/frankenstein.lib', libPath: 'win-x64/frankenstein.lib' },
-    arm64: { libUrl: 'https://frankensteinjs.org/dist/v4.1.23/win-arm64/frankenstein.lib', libPath: 'win-arm64/frankenstein.lib' }
-  })
-})
+    assert.strictEqual(release.semver.version, '4.1.23')
+    delete release.semver
 
-test('test process release - process.release ~ frankenstein@4.1.23 --dist-url=http://foo.bar/baz/', function (t) {
-  t.plan(2)
-
-  var release = processRelease([], { opts: { 'dist-url': 'http://foo.bar/baz/' } }, 'v4.1.23', {
-    name: 'frankenstein',
-    headersUrl: 'https://frankensteinjs.org/dist/v4.1.23/frankenstein-v4.1.23.tar.gz'
+    assert.deepStrictEqual(release, {
+      version: '4.1.23',
+      name: 'node',
+      baseUrl: 'https://some.custom.location/',
+      tarballUrl: 'https://some.custom.location/node-v4.1.23-headers.tar.gz',
+      shasumsUrl: 'https://some.custom.location/SHASUMS256.txt',
+      versionDir: '4.1.23',
+      ia32: { libUrl: 'https://some.custom.location/win-x86/node.lib', libPath: 'win-x86/node.lib' },
+      x64: { libUrl: 'https://some.custom.location/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+      arm64: { libUrl: 'https://some.custom.location/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
+    })
   })
 
-  t.equal(release.semver.version, '4.1.23')
-  delete release.semver
+  it('test process release - process.release ~ node@12.8.0 Windows', function () {
+    var release = processRelease([], { opts: {} }, 'v12.8.0', {
+      name: 'node',
+      sourceUrl: 'https://nodejs.org/download/release/v12.8.0/node-v12.8.0.tar.gz',
+      headersUrl: 'https://nodejs.org/download/release/v12.8.0/node-v12.8.0-headers.tar.gz',
+      libUrl: 'https://nodejs.org/download/release/v12.8.0/win-x64/node.lib'
+    })
 
-  t.deepEqual(release, {
-    version: '4.1.23',
-    name: 'frankenstein',
-    baseUrl: 'http://foo.bar/baz/v4.1.23/',
-    tarballUrl: 'http://foo.bar/baz/v4.1.23/frankenstein-v4.1.23-headers.tar.gz',
-    shasumsUrl: 'http://foo.bar/baz/v4.1.23/SHASUMS256.txt',
-    versionDir: 'frankenstein-4.1.23',
-    ia32: { libUrl: 'http://foo.bar/baz/v4.1.23/win-x86/frankenstein.lib', libPath: 'win-x86/frankenstein.lib' },
-    x64: { libUrl: 'http://foo.bar/baz/v4.1.23/win-x64/frankenstein.lib', libPath: 'win-x64/frankenstein.lib' },
-    arm64: { libUrl: 'http://foo.bar/baz/v4.1.23/win-arm64/frankenstein.lib', libPath: 'win-arm64/frankenstein.lib' }
+    assert.strictEqual(release.semver.version, '12.8.0')
+    delete release.semver
+
+    assert.deepStrictEqual(release, {
+      version: '12.8.0',
+      name: 'node',
+      baseUrl: 'https://nodejs.org/download/release/v12.8.0/',
+      tarballUrl: 'https://nodejs.org/download/release/v12.8.0/node-v12.8.0-headers.tar.gz',
+      shasumsUrl: 'https://nodejs.org/download/release/v12.8.0/SHASUMS256.txt',
+      versionDir: '12.8.0',
+      ia32: { libUrl: 'https://nodejs.org/download/release/v12.8.0/win-x86/node.lib', libPath: 'win-x86/node.lib' },
+      x64: { libUrl: 'https://nodejs.org/download/release/v12.8.0/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+      arm64: { libUrl: 'https://nodejs.org/download/release/v12.8.0/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
+    })
   })
-})
 
-test('test process release - process.release ~ node@4.0.0-rc.4', function (t) {
-  t.plan(2)
+  it('test process release - process.release ~ node@12.8.0 Windows ARM64', function () {
+    var release = processRelease([], { opts: {} }, 'v12.8.0', {
+      name: 'node',
+      sourceUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/node-v12.8.0.tar.gz',
+      headersUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/node-v12.8.0-headers.tar.gz',
+      libUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/win-arm64/node.lib'
+    })
 
-  var release = processRelease([], { opts: {} }, 'v4.0.0-rc.4', {
-    name: 'node',
-    headersUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/node-v4.0.0-rc.4-headers.tar.gz'
+    assert.strictEqual(release.semver.version, '12.8.0')
+    delete release.semver
+
+    assert.deepStrictEqual(release, {
+      version: '12.8.0',
+      name: 'node',
+      baseUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/',
+      tarballUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/node-v12.8.0-headers.tar.gz',
+      shasumsUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/SHASUMS256.txt',
+      versionDir: '12.8.0',
+      ia32: { libUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/win-x86/node.lib', libPath: 'win-x86/node.lib' },
+      x64: { libUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+      arm64: { libUrl: 'https://unofficial-builds.nodejs.org/download/release/v12.8.0/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
+    })
   })
 
-  t.equal(release.semver.version, '4.0.0-rc.4')
-  delete release.semver
+  it('test process release - process.release ~ node@4.1.23 --target=0.10.40', function () {
+    var release = processRelease([], { opts: { target: '0.10.40' } }, 'v4.1.23', {
+      name: 'node',
+      headersUrl: 'https://nodejs.org/dist/v4.1.23/node-v4.1.23-headers.tar.gz'
+    })
 
-  t.deepEqual(release, {
-    version: '4.0.0-rc.4',
-    name: 'node',
-    baseUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/',
-    tarballUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/node-v4.0.0-rc.4-headers.tar.gz',
-    shasumsUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/SHASUMS256.txt',
-    versionDir: '4.0.0-rc.4',
-    ia32: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x86/node.lib', libPath: 'win-x86/node.lib' },
-    x64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x64/node.lib', libPath: 'win-x64/node.lib' },
-    arm64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
+    assert.strictEqual(release.semver.version, '0.10.40')
+    delete release.semver
+
+    assert.deepStrictEqual(release, {
+      version: '0.10.40',
+      name: 'node',
+      baseUrl: 'https://nodejs.org/dist/v0.10.40/',
+      tarballUrl: 'https://nodejs.org/dist/v0.10.40/node-v0.10.40.tar.gz',
+      shasumsUrl: 'https://nodejs.org/dist/v0.10.40/SHASUMS256.txt',
+      versionDir: '0.10.40',
+      ia32: { libUrl: 'https://nodejs.org/dist/v0.10.40/node.lib', libPath: 'node.lib' },
+      x64: { libUrl: 'https://nodejs.org/dist/v0.10.40/x64/node.lib', libPath: 'x64/node.lib' },
+      arm64: { libUrl: 'https://nodejs.org/dist/v0.10.40/arm64/node.lib', libPath: 'arm64/node.lib' }
+    })
   })
-})
 
-test('test process release - process.release ~ node@4.0.0-rc.4 passed as argv[0]', function (t) {
-  t.plan(2)
+  it('test process release - process.release ~ node@4.1.23 --dist-url=https://foo.bar/baz', function () {
+    var release = processRelease([], { opts: { 'dist-url': 'https://foo.bar/baz' } }, 'v4.1.23', {
+      name: 'node',
+      headersUrl: 'https://nodejs.org/dist/v4.1.23/node-v4.1.23-headers.tar.gz'
+    })
 
+    assert.strictEqual(release.semver.version, '4.1.23')
+    delete release.semver
+
+    assert.deepStrictEqual(release, {
+      version: '4.1.23',
+      name: 'node',
+      baseUrl: 'https://foo.bar/baz/v4.1.23/',
+      tarballUrl: 'https://foo.bar/baz/v4.1.23/node-v4.1.23-headers.tar.gz',
+      shasumsUrl: 'https://foo.bar/baz/v4.1.23/SHASUMS256.txt',
+      versionDir: '4.1.23',
+      ia32: { libUrl: 'https://foo.bar/baz/v4.1.23/win-x86/node.lib', libPath: 'win-x86/node.lib' },
+      x64: { libUrl: 'https://foo.bar/baz/v4.1.23/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+      arm64: { libUrl: 'https://foo.bar/baz/v4.1.23/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
+    })
+  })
+
+  it('test process release - process.release ~ frankenstein@4.1.23', function () {
+    var release = processRelease([], { opts: {} }, 'v4.1.23', {
+      name: 'frankenstein',
+      headersUrl: 'https://frankensteinjs.org/dist/v4.1.23/frankenstein-v4.1.23-headers.tar.gz'
+    })
+
+    assert.strictEqual(release.semver.version, '4.1.23')
+    delete release.semver
+
+    assert.deepStrictEqual(release, {
+      version: '4.1.23',
+      name: 'frankenstein',
+      baseUrl: 'https://frankensteinjs.org/dist/v4.1.23/',
+      tarballUrl: 'https://frankensteinjs.org/dist/v4.1.23/frankenstein-v4.1.23-headers.tar.gz',
+      shasumsUrl: 'https://frankensteinjs.org/dist/v4.1.23/SHASUMS256.txt',
+      versionDir: 'frankenstein-4.1.23',
+      ia32: { libUrl: 'https://frankensteinjs.org/dist/v4.1.23/win-x86/frankenstein.lib', libPath: 'win-x86/frankenstein.lib' },
+      x64: { libUrl: 'https://frankensteinjs.org/dist/v4.1.23/win-x64/frankenstein.lib', libPath: 'win-x64/frankenstein.lib' },
+      arm64: { libUrl: 'https://frankensteinjs.org/dist/v4.1.23/win-arm64/frankenstein.lib', libPath: 'win-arm64/frankenstein.lib' }
+    })
+  })
+
+  it('test process release - process.release ~ frankenstein@4.1.23 --dist-url=http://foo.bar/baz/', function () {
+    var release = processRelease([], { opts: { 'dist-url': 'http://foo.bar/baz/' } }, 'v4.1.23', {
+      name: 'frankenstein',
+      headersUrl: 'https://frankensteinjs.org/dist/v4.1.23/frankenstein-v4.1.23.tar.gz'
+    })
+
+    assert.strictEqual(release.semver.version, '4.1.23')
+    delete release.semver
+
+    assert.deepStrictEqual(release, {
+      version: '4.1.23',
+      name: 'frankenstein',
+      baseUrl: 'http://foo.bar/baz/v4.1.23/',
+      tarballUrl: 'http://foo.bar/baz/v4.1.23/frankenstein-v4.1.23-headers.tar.gz',
+      shasumsUrl: 'http://foo.bar/baz/v4.1.23/SHASUMS256.txt',
+      versionDir: 'frankenstein-4.1.23',
+      ia32: { libUrl: 'http://foo.bar/baz/v4.1.23/win-x86/frankenstein.lib', libPath: 'win-x86/frankenstein.lib' },
+      x64: { libUrl: 'http://foo.bar/baz/v4.1.23/win-x64/frankenstein.lib', libPath: 'win-x64/frankenstein.lib' },
+      arm64: { libUrl: 'http://foo.bar/baz/v4.1.23/win-arm64/frankenstein.lib', libPath: 'win-arm64/frankenstein.lib' }
+    })
+  })
+
+  it('test process release - process.release ~ node@4.0.0-rc.4', function () {
+    var release = processRelease([], { opts: {} }, 'v4.0.0-rc.4', {
+      name: 'node',
+      headersUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/node-v4.0.0-rc.4-headers.tar.gz'
+    })
+
+    assert.strictEqual(release.semver.version, '4.0.0-rc.4')
+    delete release.semver
+
+    assert.deepStrictEqual(release, {
+      version: '4.0.0-rc.4',
+      name: 'node',
+      baseUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/',
+      tarballUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/node-v4.0.0-rc.4-headers.tar.gz',
+      shasumsUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/SHASUMS256.txt',
+      versionDir: '4.0.0-rc.4',
+      ia32: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x86/node.lib', libPath: 'win-x86/node.lib' },
+      x64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+      arm64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
+    })
+  })
+
+  it('test process release - process.release ~ node@4.0.0-rc.4 passed as argv[0]', function () {
   // note the missing 'v' on the arg, it should normalise when checking
-  // whether we're on the default or not
-  var release = processRelease(['4.0.0-rc.4'], { opts: {} }, 'v4.0.0-rc.4', {
-    name: 'node',
-    headersUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/node-v4.0.0-rc.4-headers.tar.gz'
+    // whether we're on the default or not
+    var release = processRelease(['4.0.0-rc.4'], { opts: {} }, 'v4.0.0-rc.4', {
+      name: 'node',
+      headersUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/node-v4.0.0-rc.4-headers.tar.gz'
+    })
+
+    assert.strictEqual(release.semver.version, '4.0.0-rc.4')
+    delete release.semver
+
+    assert.deepStrictEqual(release, {
+      version: '4.0.0-rc.4',
+      name: 'node',
+      baseUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/',
+      tarballUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/node-v4.0.0-rc.4-headers.tar.gz',
+      shasumsUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/SHASUMS256.txt',
+      versionDir: '4.0.0-rc.4',
+      ia32: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x86/node.lib', libPath: 'win-x86/node.lib' },
+      x64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+      arm64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
+    })
   })
 
-  t.equal(release.semver.version, '4.0.0-rc.4')
-  delete release.semver
-
-  t.deepEqual(release, {
-    version: '4.0.0-rc.4',
-    name: 'node',
-    baseUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/',
-    tarballUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/node-v4.0.0-rc.4-headers.tar.gz',
-    shasumsUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/SHASUMS256.txt',
-    versionDir: '4.0.0-rc.4',
-    ia32: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x86/node.lib', libPath: 'win-x86/node.lib' },
-    x64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x64/node.lib', libPath: 'win-x64/node.lib' },
-    arm64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
-  })
-})
-
-test('test process release - process.release ~ node@4.0.0-rc.4 - bogus string passed as argv[0]', function (t) {
-  t.plan(2)
-
+  it('test process release - process.release ~ node@4.0.0-rc.4 - bogus string passed as argv[0]', function () {
   // additional arguments can be passed in on the commandline that should be ignored if they
-  // are not specifying a valid version @ position 0
-  var release = processRelease(['this is no version!'], { opts: {} }, 'v4.0.0-rc.4', {
-    name: 'node',
-    headersUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/node-v4.0.0-rc.4-headers.tar.gz'
+    // are not specifying a valid version @ position 0
+    var release = processRelease(['this is no version!'], { opts: {} }, 'v4.0.0-rc.4', {
+      name: 'node',
+      headersUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/node-v4.0.0-rc.4-headers.tar.gz'
+    })
+
+    assert.strictEqual(release.semver.version, '4.0.0-rc.4')
+    delete release.semver
+
+    assert.deepStrictEqual(release, {
+      version: '4.0.0-rc.4',
+      name: 'node',
+      baseUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/',
+      tarballUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/node-v4.0.0-rc.4-headers.tar.gz',
+      shasumsUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/SHASUMS256.txt',
+      versionDir: '4.0.0-rc.4',
+      ia32: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x86/node.lib', libPath: 'win-x86/node.lib' },
+      x64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+      arm64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
+    })
   })
 
-  t.equal(release.semver.version, '4.0.0-rc.4')
-  delete release.semver
+  it('test process release - NODEJS_ORG_MIRROR', function () {
+    process.env.NODEJS_ORG_MIRROR = 'http://foo.bar'
 
-  t.deepEqual(release, {
-    version: '4.0.0-rc.4',
-    name: 'node',
-    baseUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/',
-    tarballUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/node-v4.0.0-rc.4-headers.tar.gz',
-    shasumsUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/SHASUMS256.txt',
-    versionDir: '4.0.0-rc.4',
-    ia32: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x86/node.lib', libPath: 'win-x86/node.lib' },
-    x64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-x64/node.lib', libPath: 'win-x64/node.lib' },
-    arm64: { libUrl: 'https://nodejs.org/download/rc/v4.0.0-rc.4/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
+    var release = processRelease([], { opts: {} }, 'v4.1.23', {
+      name: 'node',
+      headersUrl: 'https://nodejs.org/dist/v4.1.23/node-v4.1.23-headers.tar.gz'
+    })
+
+    assert.strictEqual(release.semver.version, '4.1.23')
+    delete release.semver
+
+    assert.deepStrictEqual(release, {
+      version: '4.1.23',
+      name: 'node',
+      baseUrl: 'http://foo.bar/v4.1.23/',
+      tarballUrl: 'http://foo.bar/v4.1.23/node-v4.1.23-headers.tar.gz',
+      shasumsUrl: 'http://foo.bar/v4.1.23/SHASUMS256.txt',
+      versionDir: '4.1.23',
+      ia32: { libUrl: 'http://foo.bar/v4.1.23/win-x86/node.lib', libPath: 'win-x86/node.lib' },
+      x64: { libUrl: 'http://foo.bar/v4.1.23/win-x64/node.lib', libPath: 'win-x64/node.lib' },
+      arm64: { libUrl: 'http://foo.bar/v4.1.23/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
+    })
+
+    delete process.env.NODEJS_ORG_MIRROR
   })
-})
-
-test('test process release - NODEJS_ORG_MIRROR', function (t) {
-  t.plan(2)
-
-  process.env.NODEJS_ORG_MIRROR = 'http://foo.bar'
-
-  var release = processRelease([], { opts: {} }, 'v4.1.23', {
-    name: 'node',
-    headersUrl: 'https://nodejs.org/dist/v4.1.23/node-v4.1.23-headers.tar.gz'
-  })
-
-  t.equal(release.semver.version, '4.1.23')
-  delete release.semver
-
-  t.deepEqual(release, {
-    version: '4.1.23',
-    name: 'node',
-    baseUrl: 'http://foo.bar/v4.1.23/',
-    tarballUrl: 'http://foo.bar/v4.1.23/node-v4.1.23-headers.tar.gz',
-    shasumsUrl: 'http://foo.bar/v4.1.23/SHASUMS256.txt',
-    versionDir: '4.1.23',
-    ia32: { libUrl: 'http://foo.bar/v4.1.23/win-x86/node.lib', libPath: 'win-x86/node.lib' },
-    x64: { libUrl: 'http://foo.bar/v4.1.23/win-x64/node.lib', libPath: 'win-x64/node.lib' },
-    arm64: { libUrl: 'http://foo.bar/v4.1.23/win-arm64/node.lib', libPath: 'win-arm64/node.lib' }
-  })
-
-  delete process.env.NODEJS_ORG_MIRROR
 })


### PR DESCRIPTION
##### Checklist
- [x] `npm install && npm test` passes
- [x] tests are included
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
After the `make-fetch-happen` update in https://github.com/nodejs/node-gyp/commit/02480f6b6894a6bb81dd3e1365bc4df6d5336f7c, GitHub Actions started failing. Migrating from `tap` to `mocha` testing framework as issues only happened in GitHub Actions (tested locally with various node/python combinations, didn't reproduce any failures). This PR is made based on investigation and work done in https://github.com/nodejs/node-gyp/pull/2837 as the simplest and probably the cleanest solution. With these changes, `Mocha` replaces `tap` completely, thus restoring GitHub Actions stability.