### PR TITLE
test: remove deprecated Node.js and Python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
       max-parallel: 15
       matrix:
-        node: [14.x, 16.x, 18.x]
-        python: ["3.7", "3.9", "3.11"]
+        node: [16.x, 18.x, 20.x]
+        python: ["3.9", "3.11"]
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       max-parallel: 15
       matrix:
         node: [16.x, 18.x, 20.x]
-        python: ["3.9", "3.11"]
+        python: ["3.8", "3.11"]
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
##### Description of change
Since Node.js v14 has reached its EOL, this PR removes it from GitHub Actions for testing.

