### PR TITLE
lib: find python checks order changed on windows

### DIFF
--- a/lib/find-python.js
+++ b/lib/find-python.js
@@ -15,7 +15,7 @@ const programFiles = process.env.ProgramW6432 || process.env.ProgramFiles || `${
 const programFilesX86 = process.env['ProgramFiles(x86)'] || `${programFiles} (x86)`
 
 const winDefaultLocationsArray = []
-for (const majorMinor of ['39', '38', '37', '36']) {
+for (const majorMinor of ['311', '310', '39', '38']) {
   if (foundLocalAppData) {
     winDefaultLocationsArray.push(
       `${localAppData}\\Programs\\Python\\Python${majorMinor}\\python.exe`,
@@ -114,7 +114,20 @@ PythonFinder.prototype = {
           },
           check: this.checkCommand,
           arg: this.env.PYTHON
-        },
+        }
+      ]
+
+      if (this.win) {
+        checks.push({
+          before: () => {
+            this.addLog(
+              'checking if the py launcher can be used to find Python 3')
+          },
+          check: this.checkPyLauncher
+        })
+      }
+
+      checks.push(...[
         {
           before: () => { this.addLog('checking if "python3" can be used') },
           check: this.checkCommand,
@@ -125,7 +138,7 @@ PythonFinder.prototype = {
           check: this.checkCommand,
           arg: 'python'
         }
-      ]
+      ])
 
       if (this.win) {
         for (var i = 0; i < this.winDefaultLocations.length; ++i) {
@@ -139,13 +152,6 @@ PythonFinder.prototype = {
             arg: location
           })
         }
-        checks.push({
-          before: () => {
-            this.addLog(
-              'checking if the py launcher can be used to find Python 3')
-          },
-          check: this.checkPyLauncher
-        })
       }
 
       return checks


### PR DESCRIPTION
##### Description of change
These changes favor the py launcher check over other checks excluding command line or npm configuration and environment variable checks on Windows

Also, updated supported Python versions list.

Fixes: https://github.com/nodejs/node-gyp/issues/2871