### PR TITLE
test: increase mocha timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
   },
   "scripts": {
     "lint": "standard */*.js test/**/*.js",
-    "test": "npm run lint && mocha --reporter=test/reporter.js test/test-download.js test/test-*"
+    "test": "npm run lint && mocha --timeout 15000 --reporter=test/reporter.js test/test-download.js test/test-*"
   }
 }


### PR DESCRIPTION
##### Checklist

- [x] `npm install && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change

Since migrating from Tap to Mocha it can be observed that sometimes tests will fail on Windows because of the "after all" hook is not executed within 2 seconds. This change increases the default timeout affecting that hook in order to avoid failures due to this hook timing out.