### PR TITLE
Replace uses of python `distutils` library

### DIFF
--- a/gyp/pylib/gyp/input.py
+++ b/gyp/pylib/gyp/input.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 import threading
 import traceback
-from distutils.version import StrictVersion
+from packaging.version import Version
 from gyp.common import GypError
 from gyp.common import OrderedSet
 
@@ -1183,7 +1183,7 @@ def EvalSingleCondition(cond_expr, true_dict, false_dict, phase, variables, buil
         else:
             ast_code = compile(cond_expr_expanded, "<string>", "eval")
             cached_conditions_asts[cond_expr_expanded] = ast_code
-        env = {"__builtins__": {}, "v": StrictVersion}
+        env = {"__builtins__": {}, "v": Version}
         if eval(ast_code, env, variables):
             return true_dict
         return false_dict


### PR DESCRIPTION
It is not available anymore in Python 3.12: https://peps.python.org/pep-0632/