### PR TITLE
feat: add VCToolsVersion for msvs (#2906)

### DIFF
--- a/gyp/pylib/gyp/easy_xml_test.py
+++ b/gyp/pylib/gyp/easy_xml_test.py
@@ -76,6 +76,7 @@ class TestSequenceFunctions(unittest.TestCase):
             '\'Debug|Win32\'" Label="Configuration">'
             "<ConfigurationType>Application</ConfigurationType>"
             "<CharacterSet>Unicode</CharacterSet>"
+            "<VCToolsVersion>14.36.32532</VCToolsVersion>"
             "</PropertyGroup>"
             "</Project>"
         )
@@ -99,6 +100,7 @@ class TestSequenceFunctions(unittest.TestCase):
                     },
                     ["ConfigurationType", "Application"],
                     ["CharacterSet", "Unicode"],
+                    ["VCToolsVersion", "14.36.32532"],
                 ],
             ]
         )

--- a/gyp/pylib/gyp/generator/msvs.py
+++ b/gyp/pylib/gyp/generator/msvs.py
@@ -3013,6 +3013,7 @@ def _GetMSBuildConfigurationDetails(spec, build_file):
         msbuild_attributes = _GetMSBuildAttributes(spec, settings, build_file)
         condition = _GetConfigurationCondition(name, settings, spec)
         character_set = msbuild_attributes.get("CharacterSet")
+        vctools_version = msbuild_attributes.get("VCToolsVersion")
         config_type = msbuild_attributes.get("ConfigurationType")
         _AddConditionalProperty(properties, condition, "ConfigurationType", config_type)
         if config_type == "Driver":
@@ -3024,6 +3025,11 @@ def _GetMSBuildConfigurationDetails(spec, build_file):
             if "msvs_enable_winrt" not in spec:
                 _AddConditionalProperty(
                     properties, condition, "CharacterSet", character_set
+                )
+        if vctools_version:
+            if "msvs_enable_winrt" not in spec:
+                _AddConditionalProperty(
+                    properties, condition, "VCToolsVersion", vctools_version
                 )
     return _GetMSBuildPropertyGroup(spec, "Configuration", properties)
 
@@ -3104,6 +3110,8 @@ def _ConvertMSVSBuildAttributes(spec, config, build_file):
             msbuild_attributes[a] = _ConvertMSVSCharacterSet(msvs_attributes[a])
         elif a == "ConfigurationType":
             msbuild_attributes[a] = _ConvertMSVSConfigurationType(msvs_attributes[a])
+        elif a == "VCToolsVersion":
+            msbuild_attributes[a] = msvs_attributes[a]
         else:
             print("Warning: Do not know how to convert MSVS attribute " + a)
     return msbuild_attributes


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

Add the ability to specify the 'MSVC toolset version' \<VCToolsVersion\> for the VisualStudio platform.

Usage example for binding.gyp

```
'targets': [
 {
   'configurations': {
     'Debug': {
       "msvs_configuration_attributes": {
         "VCToolsVersion": "14.36.32532",
```
----
ps. The following FAILED is displayed in npm test, but I think it is unrelated to this case.
```
  Failed test details
    1.'addon build simple addon in path with non-ascii characters'
      Name: TypeError
      Message: Callback must be a function. Received undefined
      Code: ERR_INVALID_CALLBACK
      Stack: TypeError [ERR_INVALID_CALLBACK]: Callback must be a function. Received undefined
```
----

Thank you and best regards.
