### PR TITLE
fix: use local `util` for `findAccessibleSync()`

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -8,7 +8,8 @@ const processRelease = require('./process-release')
 const win = process.platform === 'win32'
 const findNodeDirectory = require('./find-node-directory')
 const { createConfigGypi } = require('./create-config-gypi')
-const { format: msgFormat, findAccessibleSync } = require('util')
+const { format: msgFormat } = require('util')
+const { findAccessibleSync } = require('./util')
 const { findPython } = require('./find-python')
 const { findVisualStudio } = win ? require('./find-visualstudio') : {}
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

The `findAccessibleSync()` function is in the local `util` module instead of Node.js' builtin `util` module.

Refs: https://github.com/nodejs/node/pull/50493#issuecomment-1790806476

---

Existing tests should cover this, but only on AIX or z/OS, neither of which are available on GitHub Actions (and neither of those OSes are a supported platform for running a self-hosted runner).
