### PR TITLE
chore: only run release please on push

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write # to create release commit (google-github-actions/release-please-action)
       pull-requests: write # to create release PR (google-github-actions/release-please-action)
-
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
     - uses: google-github-actions/release-please-action@v2
@@ -64,5 +64,5 @@ jobs:
   test:
     name: Release Test
     needs: [ release-please ]
-    if: needs.release-please.outputs.pr
+    if: needs.release-please.outputs.pr || startsWith(github.head_ref, 'release-v')
     uses: ./.github/workflows/tests.yml


### PR DESCRIPTION
https://github.com/nodejs/node-gyp/commit/3032e1061cc2b7b49f83c397d385bafddc6b0214 added `pull_request` to `release-please.yml`. This was necessary to get CI running after a release PR was created since a push by CI will not run other actions.

This updates it further so the `release-please` portion only runs on `push`, and then the post release tests run on either 1) a successful release or 2) a PR where the head ref starts with `release-v`
