### PR TITLE
docs: remove outdated Node versions from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ addons.
 
 Note that `node-gyp` is _not_ used to build Node.js itself.
 
-Multiple target versions of Node.js are supported (i.e. `0.8`, ..., `4`, `5`, `6`,
-etc.), regardless of what version of Node.js is actually installed on your system
-(`node-gyp` downloads the necessary development files or headers for the target version).
+All current and LTS target versions of Node.js are supported. Depending on what version of Node.js is actually installed on your system
+`node-gyp` downloads the necessary development files or headers for the target version. List of stable Node.js versions can be found on [Node.js website](https://nodejs.org/en/about/previous-releases).
 
 ## Features
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/node-gyp/issues/2953

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
Readme contains outdated Node versions which may be misleading for some users. Replaced specific versions with more abstract 'current and lts versions'.
