### PR TITLE
src: add support for locally installed headers

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -39,7 +39,7 @@ async function configure (gyp, argv) {
       const prefix = process.config.variables.node_prefix
       let availVersion
       try {
-        const nodeVersionH = fsSync.readFileSync(path.join(prefix,
+        const nodeVersionH = readFileSync(path.join(prefix,
           'include', 'node', 'node_version.h'), { encoding: 'utf8' })
         const major = nodeVersionH.match(majorRe)[1]
         const minor = nodeVersionH.match(minorRe)[1]

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -32,11 +32,11 @@ async function configure (gyp, argv) {
     // 'python' should be set by now
     process.env.PYTHON = python
 
-    const prefix = process.config.variables.node_prefix
     if (!gyp.opts.nodedir &&
         process.config.variables.use_prefix_to_find_headers) {
       // check if the headers can be found using the prefix specified
       // at build time. Use them if they match the version expected
+      const prefix = process.config.variables.node_prefix
       let availVersion
       try {
         const nodeVersionH = fsSync.readFileSync(path.join(prefix,

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { promises: fs, readFileSync } = require('graceful-fs')
-const fsSync = require('graceful-fs')
 const path = require('path')
 const log = require('./log')
 const os = require('os')

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { promises: fs } = require('graceful-fs')
+const { promises: fs, readFileSync } = require('graceful-fs')
 const fsSync = require('graceful-fs')
 const path = require('path')
 const log = require('./log')

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { promises: fs } = require('graceful-fs')
+const fsSync = require('graceful-fs')
 const path = require('path')
 const log = require('./log')
 const os = require('os')
@@ -12,6 +13,10 @@ const { format: msgFormat } = require('util')
 const { findAccessibleSync } = require('./util')
 const { findPython } = require('./find-python')
 const { findVisualStudio } = win ? require('./find-visualstudio') : {}
+
+const majorRe = /^#define NODE_MAJOR_VERSION (\d+)/m
+const minorRe = /^#define NODE_MINOR_VERSION (\d+)/m
+const patchRe = /^#define NODE_PATCH_VERSION (\d+)/m
 
 async function configure (gyp, argv) {
   const buildDir = path.resolve('build')
@@ -26,6 +31,28 @@ async function configure (gyp, argv) {
   async function getNodeDir () {
     // 'python' should be set by now
     process.env.PYTHON = python
+
+    const prefix = process.config.variables.node_prefix
+    if (!gyp.opts.nodedir &&
+        process.config.variables.use_prefix_to_find_headers) {
+      // check if the headers can be found using the prefix specified
+      // at build time. Use them if they match the version expected
+      let availVersion
+      try {
+        const nodeVersionH = fsSync.readFileSync(path.join(prefix,
+          'include', 'node', 'node_version.h'), { encoding: 'utf8' })
+        const major = nodeVersionH.match(majorRe)[1]
+        const minor = nodeVersionH.match(minorRe)[1]
+        const patch = nodeVersionH.match(patchRe)[1]
+        availVersion = major + '.' + minor + '.' + patch
+      } catch {}
+      if (availVersion === release.version) {
+        // ok version matches, use the headers
+        gyp.opts.nodedir = prefix
+        log.verbose('using local node headers based on prefix',
+          'setting nodedir to ' + gyp.opts.nodedir)
+      }
+    }
 
     if (gyp.opts.nodedir) {
       // --nodedir was specified. use that for the dev files

--- a/test/test-configure-nodedir.js
+++ b/test/test-configure-nodedir.js
@@ -3,6 +3,7 @@
 const { describe, it } = require('mocha')
 const assert = require('assert')
 const path = require('path')
+const os = require('os')
 const gyp = require('../lib/node-gyp')
 const requireInject = require('require-inject')
 const semver = require('semver')
@@ -43,6 +44,17 @@ const configure2 = requireInject('../lib/configure', {
 
 const SPAWN_RESULT = cb => ({ on: function () { cb() } })
 
+const driveLetter = os.platform() === 'win32' ? `${process.cwd().split(path.sep)[0]}` : ''
+function checkTargetPath (target, value) {
+  let targetPath = path.join(path.sep, target, 'include',
+    'node', 'common.gypi')
+  if (process.platform === 'win32') {
+    targetPath = driveLetter + targetPath
+  }
+
+  return targetPath.localeCompare(value) === 0
+}
+
 describe('configure-nodedir', function () {
   it('configure nodedir with node-gyp command line', function (done) {
     const prog = gyp()
@@ -50,8 +62,7 @@ describe('configure-nodedir', function () {
 
     prog.spawn = function (program, args) {
       for (let i = 0; i < args.length; i++) {
-        if (path.join(path.sep, 'usr', 'include', 'node',
-          'common.gypi').localeCompare(args[i]) === 0) {
+        if (checkTargetPath('usr', args[i])) {
           return SPAWN_RESULT(done)
         }
       };
@@ -68,8 +79,7 @@ describe('configure-nodedir', function () {
       prog.spawn = function (program, args) {
         for (let i = 0; i < args.length; i++) {
           const nodedir = process.config.variables.node_prefix
-          if (path.join(path.sep, nodedir, 'include', 'node',
-            'common.gypi').localeCompare(args[i]) === 0) {
+          if (checkTargetPath(nodedir, args[i])) {
             return SPAWN_RESULT(done)
           }
         };
@@ -85,8 +95,7 @@ describe('configure-nodedir', function () {
       prog.spawn = function (program, args) {
         for (let i = 0; i < args.length; i++) {
           const nodedir = process.config.variables.node_prefix
-          if (path.join(path.sep, nodedir, 'include', 'node',
-            'common.gypi').localeCompare(args[i]) === 0) {
+          if (checkTargetPath(nodedir, args[i])) {
             assert.fail()
           }
         };
@@ -102,8 +111,7 @@ describe('configure-nodedir', function () {
       prog.spawn = function (program, args) {
         for (let i = 0; i < args.length; i++) {
           const nodedir = process.config.variables.node_prefix
-          if (path.join(path.sep, nodedir, 'include', 'node',
-            'common.gypi').localeCompare(args[i]) === 0) {
+          if (checkTargetPath(nodedir, args[i])) {
             assert.fail()
           }
         };

--- a/test/test-configure-nodedir.js
+++ b/test/test-configure-nodedir.js
@@ -1,0 +1,115 @@
+'use strict'
+
+const { describe, it } = require('mocha')
+const assert = require('assert')
+const path = require('path')
+const gyp = require('../lib/node-gyp')
+const requireInject = require('require-inject')
+const semver = require('semver')
+
+const versionSemver = semver.parse(process.version)
+
+const configure = requireInject('../lib/configure', {
+  'graceful-fs': {
+    openSync: () => 0,
+    closeSync: () => {},
+    existsSync: () => true,
+    readFileSync: () => '#define NODE_MAJOR_VERSION ' + versionSemver.major + '\n' +
+        '#define NODE_MINOR_VERSION ' + versionSemver.minor + '\n' +
+        '#define NODE_PATCH_VERSION ' + versionSemver.patch + '\n',
+    promises: {
+      stat: async () => ({}),
+      mkdir: async () => {},
+      writeFile: async () => {}
+    }
+  }
+})
+
+const configure2 = requireInject('../lib/configure', {
+  'graceful-fs': {
+    openSync: () => 0,
+    closeSync: () => {},
+    existsSync: () => true,
+    readFileSync: () => '#define NODE_MAJOR_VERSION 8\n' +
+        '#define NODE_MINOR_VERSION 0\n' +
+        '#define NODE_PATCH_VERSION 0\n',
+    promises: {
+      stat: async () => ({}),
+      mkdir: async () => {},
+      writeFile: async () => {}
+    }
+  }
+})
+
+const SPAWN_RESULT = cb => ({ on: function () { cb() } })
+
+describe('configure-nodedir', function () {
+  it('configure nodedir with node-gyp command line', function (done) {
+    const prog = gyp()
+    prog.parseArgv(['dummy_prog', 'dummy_script', '--nodedir=/usr'])
+
+    prog.spawn = function (program, args) {
+      for (let i = 0; i < args.length; i++) {
+        if (path.join(path.sep, 'usr', 'include', 'node',
+          'common.gypi').localeCompare(args[i]) === 0) {
+          return SPAWN_RESULT(done)
+        }
+      };
+      assert.fail()
+    }
+    configure(prog, [], assert.fail)
+  })
+
+  if (process.config.variables.use_prefix_to_find_headers) {
+    it('use-prefix-to-find-headers build time option - match', function (done) {
+      const prog = gyp()
+      prog.parseArgv(['dummy_prog', 'dummy_script'])
+
+      prog.spawn = function (program, args) {
+        for (let i = 0; i < args.length; i++) {
+          const nodedir = process.config.variables.node_prefix
+          if (path.join(path.sep, nodedir, 'include', 'node',
+            'common.gypi').localeCompare(args[i]) === 0) {
+            return SPAWN_RESULT(done)
+          }
+        };
+        assert.fail()
+      }
+      configure(prog, [], assert.fail)
+    })
+
+    it('use-prefix-to-find-headers build time option - no match', function (done) {
+      const prog = gyp()
+      prog.parseArgv(['dummy_prog', 'dummy_script'])
+
+      prog.spawn = function (program, args) {
+        for (let i = 0; i < args.length; i++) {
+          const nodedir = process.config.variables.node_prefix
+          if (path.join(path.sep, nodedir, 'include', 'node',
+            'common.gypi').localeCompare(args[i]) === 0) {
+            assert.fail()
+          }
+        };
+        return SPAWN_RESULT(done)
+      }
+      configure2(prog, [], assert.fail)
+    })
+
+    it('use-prefix-to-find-headers build time option, target specified', function (done) {
+      const prog = gyp()
+      prog.parseArgv(['dummy_prog', 'dummy_script', '--target=8.0.0'])
+
+      prog.spawn = function (program, args) {
+        for (let i = 0; i < args.length; i++) {
+          const nodedir = process.config.variables.node_prefix
+          if (path.join(path.sep, nodedir, 'include', 'node',
+            'common.gypi').localeCompare(args[i]) === 0) {
+            assert.fail()
+          }
+        };
+        return SPAWN_RESULT(done)
+      }
+      configure(prog, [], assert.fail)
+    })
+  }
+})

--- a/test/test-configure-nodedir.js
+++ b/test/test-configure-nodedir.js
@@ -46,7 +46,7 @@ const SPAWN_RESULT = cb => ({ on: function () { cb() } })
 describe('configure-nodedir', function () {
   it('configure nodedir with node-gyp command line', function (done) {
     const prog = gyp()
-    prog.parseArgv(['dummy_prog', 'dummy_script', '--nodedir=/usr'])
+    prog.parseArgv(['dummy_prog', 'dummy_script', '--nodedir=' + path.sep + 'usr'])
 
     prog.spawn = function (program, args) {
       for (let i = 0; i < args.length; i++) {

--- a/test/test-configure-python.js
+++ b/test/test-configure-python.js
@@ -11,6 +11,7 @@ const configure = requireInject('../lib/configure', {
   'graceful-fs': {
     openSync: () => 0,
     closeSync: () => {},
+    existsSync: () => {},
     promises: {
       stat: async () => ({}),
       mkdir: async () => {},


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

Some linux distros allow headers to be installed through tools like rpm. If the runtime sets
process.config.variables.use_prefix_to_find_headers, look for matching headers based on the directory set for the prefix in process.config.variables.prefix

