### PR TITLE
feat: define `common_gypi_dir` when running node-gyp configure

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -220,8 +220,13 @@ async function configure (gyp, argv) {
       !gyp.opts.nodedir ? '<(target_arch)' : '$(Configuration)',
       release.name + '.lib')
 
+    let commonGypiDir = path.dirname(commonGypi)
+    if (win) {
+      commonGypiDir = commonGypiDir.replace(/\\/g, '\\\\')
+    }
     argv.push('-I', addonGypi)
     argv.push('-I', commonGypi)
+    argv.push('-Dcommon_gypi_dir=' + commonGypiDir)
     argv.push('-Dlibrary=shared_library')
     argv.push('-Dvisibility=default')
     argv.push('-Dnode_root_dir=' + nodeDir)

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -222,7 +222,7 @@ async function configure (gyp, argv) {
 
     let commonGypiDir = path.dirname(commonGypi)
     if (win) {
-      commonGypiDir = commonGypiDir.replace(/\\/g, '\\\\')
+      commonGypiDir = commonGypiDir.replace(/\\/g, '/')
     }
     argv.push('-I', addonGypi)
     argv.push('-I', commonGypi)


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change

Refs:

- https://github.com/nodejs/gyp-next/pull/222#issuecomment-1910105580
- https://github.com/nodejs/node-gyp/issues/2823

I'm trying to add node-gyp support to [emnapi](https://github.com/toyobayashi/emnapi), some upstream changes are made in nodejs/gyp-next#222. I'd like to add the linker option `--js-library=<(common_gypi_dir)/dist/library_napi.js` in [emnapi's `common.gypi`'](https://github.com/toyobayashi/emnapi/blob/b4e86cf60dd70e8367440462fbd81d7d546311c4/packages/emnapi/common.gypi#L224) (used via `--nodedir`). The `--js-library` need to receive an absolute path because relative path doesn't work when `emcc` runs in `node-gyp build` stage the CWD is `${projectRoot}/build`. But I can't find a way to set the `--js-library` relative to the `nodedir` or `common_gypi_dir`. See https://github.com/nodejs/gyp-next/pull/222#issuecomment-1910105580 for more detail description about this. I know there are `<(node_root_dir)` and `<(nodedir)`, but there is no guarantee that they are absolute path.

Adding a `-D` affects almost nothing. It would be great if someone could tell that there is a better way.

