### PR TITLE
fix: Patches the variable android_ndk_path

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -248,6 +248,7 @@ async function configure (gyp, argv) {
 
     argv.push('-I', addonGypi)
     argv.push('-I', commonGypi)
+    argv.push('-Dandroid_ndk_path=""')
     argv.push('-Dlibrary=shared_library')
     argv.push('-Dvisibility=default')
     argv.push('-Dnode_root_dir=' + nodeDir)


### PR DESCRIPTION
Patch to fix 'Undefined variable android_ndk_path in binding.gyp while trying to load binding.gyp' on Termux.
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
Specifying a default value for the 'android_ndk_path'' variable fixes this issue at 'https://github.com/termux/termux-app/issues/3858'

