### PR TITLE
lib: print Python executable path using UTF-8

### DIFF
--- a/lib/find-python.js
+++ b/lib/find-python.js
@@ -41,7 +41,7 @@ class PythonFinder {
   static findPython = (...args) => new PythonFinder(...args).findPython()
 
   log = log.withPrefix('find Python')
-  argsExecutable = ['-c', 'import sys; print(sys.executable);']
+  argsExecutable = ['-c', 'import sys; sys.stdout.buffer.write(sys.executable.encode(\'utf-8\'));']
   argsVersion = ['-c', 'import sys; print("%s.%s.%s" % sys.version_info[:3]);']
   semverRange = '>=3.6.0'
 

--- a/test/test-find-python.js
+++ b/test/test-find-python.js
@@ -7,6 +7,9 @@ const assert = require('assert')
 const PythonFinder = require('../lib/find-python')
 const { execFile } = require('../lib/util')
 const { poison } = require('./common')
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
 
 class TestPythonFinder extends PythonFinder {
   constructor (...args) {
@@ -30,6 +33,18 @@ describe('find-python', function () {
     assert.strictEqual(err, null)
     assert.ok(/Python 3/.test(stdout))
     assert.strictEqual(stderr, '')
+  })
+
+  it('find python - encoding', async function () {
+    const found = await PythonFinder.findPython(null)
+    const testFolderPath = fs.mkdtempSync(path.join(os.tmpdir(), 'test-ü-'))
+    const testFilePath = path.join(testFolderPath, 'python.exe')
+    fs.copyFileSync(found, testFilePath)
+
+    const foundTest = await PythonFinder.findPython(testFilePath)
+    fs.unlinkSync(testFilePath)
+    fs.rmdirSync(testFolderPath)
+    assert.strictEqual(foundTest, testFilePath)
   })
 
   it('find python - python', async function () {


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
The Python executable path may have non-ASCII characters, which can make the print function fail if the environment encoding is different. This PR fixes this issue by using `stdout.buffer`, which can be used with UTF-8 encoding for the output, regardless of the environment encoding.

Fixes: https://github.com/nodejs/node-gyp/issues/2829

