### PR TITLE
README.md: Installation -- Python >= v3.12 requires `node-gyp` >= v10

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ All current and LTS target versions of Node.js are supported. Depending on what 
 
 ## Installation
 
+> [!Important]
+> Python >= v3.12 requires `node-gyp` >= v10
+
 You can install `node-gyp` using `npm`:
 
 ``` bash


### PR DESCRIPTION
We are getting a lot of issues opened on this topic so add this notice to our installation instructions.

> [!Important]
> Python >= v3.12 requires `node-gyp` >= v10

Related to:
* #2869

Uses [GitHub Markdown alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts):
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

