### PR TITLE
GitHub Actions: npm test is failing Windows tests on M1 Macs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,11 +93,15 @@ jobs:
       fail-fast: false
       max-parallel: 15
       matrix:
-        os: [macos, ubuntu, windows]
+        os: [macos-latest, ubuntu-latest, windows-latest]
         python: ["3.8", "3.10", "3.12"]
         node: [16.x, 18.x, 20.x]
+        include:  # `npm test` is running Windows find-visualstudio tests on an M1 Mac!!!
+          - os: macos-14
+            python: "3.12"
+            node: 20.x
     name: ${{ matrix.os }} - ${{ matrix.python }} - ${{ matrix.node }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -116,20 +120,20 @@ jobs:
           npm install
           pip install pytest
       - name: Set Windows Env
-        if: runner.os == 'Windows'
+        if: startsWith(matrix.os, 'windows')
         run: |
           echo 'GYP_MSVS_VERSION=2015' >> $Env:GITHUB_ENV
           echo 'GYP_MSVS_OVERRIDE_PATH=C:\\Dummy' >> $Env:GITHUB_ENV
       - name: Run Python Tests
         run: python -m pytest
       - name: Run Tests (macOS or Linux)
-        if: runner.os != 'Windows'
+        if: "!startsWith(matrix.os, 'windows')"
         shell: bash
         run: npm test --python="${pythonLocation}/python"
         env:
           FULL_TEST: ${{ (matrix.node == '20.x' && matrix.python == '3.12') && '1' || '0' }}
       - name: Run Tests (Windows)
-        if: runner.os == 'Windows'
+        if: startsWith(matrix.os, 'windows')
         shell: pwsh
         run: npm run test --python="${env:pythonLocation}\\python.exe"
         env:

--- a/test/test-find-visualstudio.js
+++ b/test/test-find-visualstudio.js
@@ -21,12 +21,13 @@ class TestVisualStudioFinder extends VisualStudioFinder {
   }
 }
 
-// Only run "Find Visual Studio" tests on Windows.
-if  (process.platform !== 'win32') {
-  return
-}
+const shouldSkip = process.platform !== 'win32'
 
 describe('find-visualstudio', function () {
+  if (shouldSkip) {
+    return
+  }
+
   this.beforeAll(function () {
     // Condition to skip the test suite
     if (process.env.SystemRoot === undefined) {

--- a/test/test-find-visualstudio.js
+++ b/test/test-find-visualstudio.js
@@ -21,6 +21,11 @@ class TestVisualStudioFinder extends VisualStudioFinder {
   }
 }
 
+// Only run "Find Visual Studio" tests on Windows.
+if  (process.platform !== 'win32') {
+  return
+}
+
 describe('find-visualstudio', function () {
   this.beforeAll(function () {
     // Condition to skip the test suite


### PR DESCRIPTION
## Why are Windows tests running on Macs?

Fixes #2993

`npm test` is running and **failing** Windows `find-visualstudio` tests on an M1 Mac!!!

These tests are either not being run or are not failing on Intel Macs.

GitHub Actions blog:
> Over the next 12 weeks, jobs using the `macos-latest` runner label will migrate from macOS 12 (Monterey) to macOS 14 (Sonoma).

https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image

Discovered by @GeoffreyPlitt in:
* #2992
* #2993

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm run lint && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->
@jarig
