### PR TITLE
docs: `node-pre-gyp` is no longer maintained

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,14 +12,16 @@ npm install sass --save
 npm install --global node-sass@latest
 ```
 `node-sass` projects _may_ work by downgrading to Node.js v14 but [that release is end-of-life](https://github.com/nodejs/release#release-schedule).
-But in any case, please avoid opening new `node-sass` issues on this repo because we [cannot help much](https://github.com/nodejs/node-gyp/issues?q=is%3Aissue+label%3A%22Node+Sass+--%3E+Dart+Sass%22+).
+
+In any case, please avoid opening new `node-sass` issues on this repo because we [cannot help much](https://github.com/nodejs/node-gyp/issues?q=is%3Aissue+label%3A%22Node+Sass+--%3E+Dart+Sass%22+).
 
 ## `node-pre-gyp` is no longer maintained
 
 * mapbox/node-pre-gyp#657
 
 Support in the `abi_crosswalk.json` file ends at Node.js v17 but [that release is end-of-life](https://github.com/nodejs/release#release-schedule).
-But in any case, please avoid opening new `node-pre-gyp` issues on this repo because we [cannot help much](https://github.com/nodejs/node-gyp/issues?q=is%3Aissue+label%3A%22node-pre-gyp+is+unmaintained%22).
+
+In any case, please avoid opening new `node-pre-gyp` issues on this repo because we [cannot help much](https://github.com/nodejs/node-gyp/issues?q=is%3Aissue+label%3A%22node-pre-gyp+is+unmaintained%22).
 
 Unsupported __WORKAROUND__ for versions of Node.js > v17
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,8 @@ But in any case, please avoid opening new `node-sass` issues on this repo becaus
 
 * mapbox/node-pre-gyp#657
 
-Support in the `abi_crosswalk.json` file ends at Node.js v17 which is end-of-life.
+Support in the `abi_crosswalk.json` file ends at Node.js v17 but [that release is end-of-life](https://github.com/nodejs/release#release-schedule).
+But in any case, please avoid opening new `node-pre-gyp` issues on this repo because we [cannot help much](https://github.com/nodejs/node-gyp/issues?q=is%3Aissue+label%3A%22node-pre-gyp+is+unmaintained%22).
 
 Unsupported __WORKAROUND__ for versions of Node.js > v17
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-## Versions of `node-gyp` that are earlier than v9.x.x
+## Versions of `node-gyp` that are earlier than v10.x.x
 
 Please look thru your error log for the string `gyp info using node-gyp@` and if that version number is less than the [current release of node-gyp](https://github.com/nodejs/node-gyp/releases) then __please upgrade__ using [these instructions](https://github.com/nodejs/node-gyp/blob/main/docs/Updating-npm-bundled-node-gyp.md) and then try your command again.
 
@@ -14,6 +14,15 @@ npm install --global node-sass@latest
 `node-sass` projects _may_ work by downgrading to Node.js v14 but [that release is end-of-life](https://github.com/nodejs/release#release-schedule).
 But in any case, please avoid opening new `node-sass` issues on this repo because we [cannot help much](https://github.com/nodejs/node-gyp/issues?q=is%3Aissue+label%3A%22Node+Sass+--%3E+Dart+Sass%22+).
 
-## Issues finding the installed Visual Studio
+## `node-pre-gyp` is no longer maintained
 
-In cmd, [`npm config set msvs_version 20xx`](https://github.com/nodejs/node-gyp#on-windows) with ___xx___ matching your locally installed version of Visual Studio.
+* mapbox/node-pre-gyp#657
+
+Support in the `abi_crosswalk.json` file ends at Node.js v17 which is end-of-life.
+
+Unsupported __WORKAROUND__ for versions of Node.js > v17
+```
+npm ci  # mapbox/node-pre-gyp
+npm run update-crosswalk
+# npm audit  # Currently fails on a `Severity: critical` issue
+```


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change

`npm config set msvs_version 2022` is no longer accepted on modern versions on `npm`.

@GeoffreyPlitt Please see the workaround.

