### PR TITLE
win: add an arch check to VS 2019

### DIFF
--- a/lib/find-visualstudio.js
+++ b/lib/find-visualstudio.js
@@ -363,7 +363,11 @@ class VisualStudioFinder {
         return path.join(info.path, 'MSBuild', '15.0', 'Bin', 'MSBuild.exe')
       }
       if (versionYear === 2019) {
-        return msbuildPath
+        if (process.arch === 'arm64' && this.msBuildPathExists(msbuildPathArm64)) {
+          return msbuildPathArm64
+        } else {
+          return msbuildPath
+        }
       }
     }
     /**

--- a/test/test-find-visualstudio.js
+++ b/test/test-find-visualstudio.js
@@ -21,13 +21,7 @@ class TestVisualStudioFinder extends VisualStudioFinder {
   }
 }
 
-const shouldSkip = process.platform !== 'win32'
-
 describe('find-visualstudio', function () {
-  if (shouldSkip) {
-    return
-  }
-
   this.beforeAll(function () {
     // Condition to skip the test suite
     if (process.env.SystemRoot === undefined) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes


##### Description of change
<!-- Provide a description of the change -->
The `msbuildPath` was wrong on ARM64 machines when Visual Studio 2019 was used. I've fixed this by using the corresponding path for the ARM64 machines if the Visual Studio version is 2019.

I also removed the workaround here: https://github.com/nodejs/node-gyp/commit/0bab6a071bbc7bafb0804eccf0e2e81e1815d481#diff-c4ed6cb32588722371276d96a40ec39364f8c4a8ab39d9489cd5b939c05147b6

Fixes: https://github.com/nodejs/node-gyp/issues/3014
