### PR TITLE
fix(ci): use correct release-please-action domain after organization url was changed

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,12 +11,12 @@ jobs:
     outputs:
       pr: ${{ steps.release.outputs.pr }}
     permissions:
-      contents: write # to create release commit (google-github-actions/release-please-action)
-      pull-requests: write # to create release PR (google-github-actions/release-please-action)
+      contents: write # to create release commit (googleapis/release-please-action)
+      pull-requests: write # to create release PR (googleapis/release-please-action)
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-    - uses: google-github-actions/release-please-action@v4
+    - uses: googleapis/release-please-action@v4
       id: release
         # Standard Conventional Commits: `feat` and `fix`
         # node-gyp subdirectories: `bin`, `gyp`, `lib`, `src`, `test`


### PR DESCRIPTION
##### Checklist

- [X] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
The release-please action URL was recently changed from https://github.com/google-github-actions/release-please-action to https://github.com/googleapis/release-please-action (see https://github.com/googleapis/release-please-action/issues/980). This fixes the release-please action.

