### PR TITLE
Ensure Consistent Order of build_files in WriteAutoRegenerationRule

### DIFF
--- a/gyp/pylib/gyp/generator/make.py
+++ b/gyp/pylib/gyp/generator/make.py
@@ -2383,7 +2383,7 @@ def WriteAutoRegenerationRule(params, root_makefile, makefile_name, build_files)
         % {
             "makefile_name": makefile_name,
             "deps": replace_sep(
-                " ".join(SourceifyAndQuoteSpaces(bf) for bf in build_files)
+                " ".join(SourceifyAndQuoteSpaces(bf) for bf in sorted(build_files))
             ),
             "cmd": replace_sep(gyp.common.EncodePOSIXShellList(
                 [gyp_binary, "-fmake"] + gyp.RegenerateFlags(options) + build_files_args


### PR DESCRIPTION
This PR addresses an issue with the WriteAutoRegenerationRule function in node-gyp, where the build_files set was passed without sorting, leading to an inconsistent order of dependencies in the generated Makefile.

Changes:

Wrapped the build_files set in the sorted() function before it is processed in WriteAutoRegenerationRule. This ensures that the order of files is consistent across all runs, preventing issues in CI environments that rely on file hash comparisons.
Impact:
This change stabilizes the output of the Makefile generation process, resolving the issue of inconsistent file order and reducing false positives in CI checks.

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [ ] ~~tests are included~~ NO, There are no tests for this code area
- [ ] ~~documentation is changed or added~~ There is not documantation for this code area
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

