### PR TITLE
install: don't preserve owner when extracting files

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -212,6 +212,7 @@ async function install (gyp, argv) {
             file: tarPath,
             strip: 1,
             filter: isValid,
+            preserveOwner: false,
             onwarn,
             cwd: tarExtractDir
           })
@@ -235,6 +236,7 @@ async function install (gyp, argv) {
                 strip: 1,
                 cwd: tarExtractDir,
                 filter: isValid,
+                preserveOwner: false,
                 onwarn
               })
             )


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change

tar defaults to `true` for `preserveOwner` when run as root. 

In a user namespace one can be root, but not have the capability to chown files, e.g. because of a seccomp filter. 

It doesn't make sense to preserve the owner anyway, root or not, since the owner in a tar is chosen by the side providing the tar file, so the user name might not be present in the system.  Also, all other files written, would also have a different owner than what was extracted from the tar file. 