### PR TITLE
feat: prohibit compiling with ClangCL on Windows

### DIFF
--- a/lib/create-config-gypi.js
+++ b/lib/create-config-gypi.js
@@ -96,6 +96,9 @@ async function getCurrentConfigGypi ({ gyp, nodeDir, vsInfo, python }) {
       }
     }
     variables.msbuild_path = vsInfo.msBuild
+    if (config.variables.clang === 1) {
+      config.variables.clang = 0
+    }
   }
 
   // loop through the rest of the opts and add the unknown ones as variables.


### PR DESCRIPTION
This PR is opened based on https://github.com/nodejs/node/pull/55784 as it is required to enable running native (addon) tests for the ClangCL-produced binaries on Windows. The original PR is reviewed and approved in the Node.js repo and I'm moving to the next phase now - landing the changes in their respective repositories. Node-gyp is the only dependency that needs changing outside Node.js, so I've decided to start with it.