### PR TITLE
chore: fix npm-publish dependencies and add provenance

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,45 +4,40 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 jobs:
   release-please:
     outputs:
-      pr: ${{ steps.release.outputs.pr }}
+      release_created:  ${{ steps.release.outputs.release_created }}
     permissions:
       contents: write # to create release commit (googleapis/release-please-action)
       pull-requests: write # to create release PR (googleapis/release-please-action)
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-    - uses: googleapis/release-please-action@v4
-      id: release
-        # Standard Conventional Commits: `feat` and `fix`
-        # node-gyp subdirectories: `bin`, `gyp`, `lib`, `src`, `test`
-        # node-gyp subcommands: `build`, `clean`, `configure`, `install`, `list`, `rebuild`, `remove`
-        # Core abstract category: `deps`
-        # Languages/platforms: `python`, `lin`, `linux`, `mac`, `macos`, `win`, `window`, `zos`
-        # Documentation: `doc`, `docs`, `readme`
-        # Standard Conventional Commits: `chore` (under "Miscellaneous")
-        # Miscellaneous abstract categories: `refactor`, `ci`, `meta`
-
-  test:
-    name: Release Test
-    needs: [ release-please ]
-    if: needs.release-please.outputs.pr || startsWith(github.head_ref, 'release-please--')
-    uses: ./.github/workflows/tests.yml
+      - uses: googleapis/release-please-action@v4
+        id: release
+          # Standard Conventional Commits: `feat` and `fix`
+          # node-gyp subdirectories: `bin`, `gyp`, `lib`, `src`, `test`
+          # node-gyp subcommands: `build`, `clean`, `configure`, `install`, `list`, `rebuild`, `remove`
+          # Core abstract category: `deps`
+          # Languages/platforms: `python`, `lin`, `linux`, `mac`, `macos`, `win`, `window`, `zos`
+          # Documentation: `doc`, `docs`, `readme`
+          # Standard Conventional Commits: `chore` (under "Miscellaneous")
+          # Miscellaneous abstract categories: `refactor`, `ci`, `meta`
 
   npm-publish:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # to generate npm provenance statements
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
           registry-url: 'https://registry.npmjs.org'
-      - run: npm publish --access public
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: pip install --user ruff
-    - run: ruff check --output-format=github --select="E,F,PLC,PLE,UP,W,YTT" --ignore="E721,PLC1901,S101,UP031" --target-version=py38 .
+    # Excluding `/gyp` directory as it is been checked in https://github.com/nodejs/gyp-next/ already
+    - run: ruff check --output-format=github --extend-exclude=gyp --select="E,F,PLC,PLE,UP,W,YTT" --ignore="E721,PLC1901,S101,UP031" --target-version=py38 .
 
   lint-js:
     name: Lint JS


### PR DESCRIPTION
The `npm-publish` steps depends on output variable `release-please.outputs.release_created`. Without this variable the steps are skipped, e.g. https://github.com/nodejs/node-gyp/actions/runs/12087642317.

---

Adds npm provenance statements: https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow.

---

The release-please bot created PR needs an additional token to trigger CI runs: 
>    When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs.
>    https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow

Removing the always skipped release tests for now.