### PR TITLE
chore: migrate from standard to neostandard

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('neostandard')({})

--- a/package.json
+++ b/package.json
@@ -39,13 +39,14 @@
   "devDependencies": {
     "bindings": "^1.5.0",
     "cross-env": "^7.0.3",
+    "eslint": "^9.16.0",
     "mocha": "^11.0.1",
     "nan": "^2.14.2",
-    "require-inject": "^1.4.4",
-    "standard": "^17.0.0"
+    "neostandard": "^0.11.9",
+    "require-inject": "^1.4.4"
   },
   "scripts": {
-    "lint": "standard \"*/*.js\" \"test/**/*.js\" \".github/**/*.js\"",
+    "lint": "eslint \"*/*.js\" \"test/**/*.js\" \".github/**/*.js\"",
     "test": "cross-env NODE_GYP_NULL_LOGGER=true mocha --timeout 15000 test/test-download.js test/test-*"
   }
 }


### PR DESCRIPTION
This is built on #3102.

After updating those dependencies, `standard` was the only dep bringing in anything deprecated. I read https://github.com/standard/standard/issues/1948#issuecomment-2138078249 and opted to migrate to `neostandard` following the instructions here: https://github.com/neostandard/neostandard?tab=readme-ov-file#migrate-from-standard