### PR TITLE
fix: disable msbuild.exe nodeReuse

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -141,6 +141,8 @@ async function build (gyp, argv) {
     if (msvs) {
       // Turn off the Microsoft logo on Windows
       argv.push('/nologo')
+      // No lingering msbuild processes and open file handles
+      argv.push('/nodeReuse:false')
     }
 
     // Specify the build type, Release by default


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

On windows, one may experience errors due to concurrent node-gyp calls (see #3095)

When retrying after such a failure, retries are observed to fail repeatedly with strange
EBUSY and EPERM errors. This turns out to be due to a caching feature where msbuild.exe
will continue to run in the background (for either 15s or 15m depending on VS version),
and keep open file handles to files and directories that the user may be trying to delete
(for example with a new call to `npm ci`).

This behavior is [well](https://stackoverflow.com/questions/51076195/why-is-msbuild-generating-tlog-files-into-cmakefiles-compileridc-and-how-do-i) [documented](https://github.com/dotnet/msbuild/issues/1709), as is the [recommended workaround](https://learn.microsoft.com/en-us/azure/devops/pipelines/troubleshooting/troubleshooting?view=azure-devops#msbuild-and-nodereusefalse) implemented here.
