### PR TITLE
fix: remove more forcefully

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -209,7 +209,7 @@ async function build (gyp, argv) {
     await new Promise((resolve, reject) => proc.on('exit', async (code, signal) => {
       if (buildBinsDir) {
         // Clean up the build-time dependency symlinks:
-        await fs.rm(buildBinsDir, { recursive: true })
+        await fs.rm(buildBinsDir, { recursive: true, maxRetries: 3 })
       }
 
       if (code !== 0) {

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -8,7 +8,7 @@ async function clean (gyp, argv) {
   const buildDir = 'build'
 
   log.verbose('clean', 'removing "%s" directory', buildDir)
-  await fs.rm(buildDir, { recursive: true, force: true })
+  await fs.rm(buildDir, { recursive: true, force: true, maxRetries: 3 })
 }
 
 module.exports = clean

--- a/lib/install.js
+++ b/lib/install.js
@@ -284,7 +284,7 @@ async function install (gyp, argv) {
       if (tarExtractDir !== devDir) {
         try {
           // try to cleanup temp dir
-          await fs.rm(tarExtractDir, { recursive: true })
+          await fs.rm(tarExtractDir, { recursive: true, maxRetries: 3 })
         } catch {
           log.warn('failed to clean up temp tarball extract directory')
         }

--- a/lib/remove.js
+++ b/lib/remove.js
@@ -36,7 +36,7 @@ async function remove (gyp, argv) {
     throw err
   }
 
-  await fs.rm(versionPath, { recursive: true, force: true })
+  await fs.rm(versionPath, { recursive: true, force: true, maxRetries: 3 })
 }
 
 module.exports = remove


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

on some linux machines, i observed:

```
npm error gyp http fetch GET https://artifacts.electronjs.org/headers/v30.5.1/node-v30.5.1-headers.tar.gz?force_headers_dist=1 attempt 1 failed with ETIMEDOUT
npm error gyp WARN install got an error, rolling back install
npm error gyp ERR! configure error
npm error gyp ERR! stack Error: ENOTEMPTY: directory not empty, rmdir '/home/AzDevOps/.cache/node-gyp/30.5.1/include/node'
```

(side note: i'm not sure why the http fetch is not being retried, or where the "attempt 1" comes from)

unfortunately this leaves the system in a broken state, as a subsequent retries (with my own loop around npm) all fail:

```
npm failed 1, trying again...
...
npm error gyp WARN read config.gypi ENOENT: no such file or directory, open '/home/AzDevOps/.cache/node-gyp/30.5.1/include/node/config.gypi'
```

this is apparently a [known and documented issue](https://github.com/nodejs/node/issues/54561#issuecomment-2449076853). i have implemented the recommended workaround in this PR.
