### PR TITLE
Test on Ubuntu-24.04-arm and Node.js v23

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,16 +94,19 @@ jobs:
       fail-fast: false
       max-parallel: 11
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
         python: ["3.9", "3.11", "3.13"]
-        node: [18.x, 20.x, 22.x]
+        node: [18.x, 20.x, 22.x, 23.x]
         include:
           - os: macos-13
             python: "3.13"
-            node: 22.x
+            node: 23.x
+          - os: ubuntu-24.04-arm 
+            python: "3.13"
+            node: 23.x
           - os: windows-2025
             python: "3.13"
-            node: 22.x
+            node: 23.x
     name: ${{ matrix.os }} - ${{ matrix.python }} - ${{ matrix.node }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -119,13 +122,13 @@ jobs:
           python-version: ${{ matrix.python }}
         env:
           PYTHON_VERSION: ${{ matrix.python }}  # Why do this?
-      - uses: seanmiddleditch/gha-setup-ninja@v5
+      - uses: seanmiddleditch/gha-setup-ninja@v6
       - name: Install Dependencies
         run: |
           npm install
           pip install pytest
       - name: Set Windows Env
-        if: startsWith(matrix.os, 'windows')
+        if: runner.os == 'Windows'
         run: |
           echo 'GYP_MSVS_VERSION=2015' >> $Env:GITHUB_ENV
           echo 'GYP_MSVS_OVERRIDE_PATH=C:\\Dummy' >> $Env:GITHUB_ENV


### PR DESCRIPTION
Fixes: #3119 
Blocked by: seanmiddleditch/gha-setup-ninja#31

Also:
* Windows tests are slow so let them run first
* Add Node.js v23 to the testing
* Use [seanmiddleditch/gha-setup-ninja@v6](https://github.com/seanmiddleditch/gha-setup-ninja/releases) for compatibility with Ubuntu on ARM
* [Detect operating system with runner.os](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#detecting-the-operating-system)

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm run lint && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

[Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) --> `os: ubuntu-24.04-arm`

@seanmiddleditch Your review, please.