### PR TITLE
win,src: fix GetModuleHandle for libnode.dll

### DIFF
--- a/src/win_delay_load_hook.cc
+++ b/src/win_delay_load_hook.cc
@@ -29,7 +29,7 @@ static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
     return NULL;
 
   // try for libnode.dll to compat node.js that using 'vcbuild.bat dll'
-  m = GetModuleHandle("libnode.dll");
+  m = GetModuleHandle(TEXT("libnode.dll"));
   if (m == NULL) m = GetModuleHandle(NULL);
   return (FARPROC) m;
 }


### PR DESCRIPTION
Based on the description in the linked issue, this should fix the problem. There is no strong reason for making a change like this (and for example not using `GetModuleHandleA` or `L"libnode.dll"`). This is the only `GetModuleHandle` call in the entire project, so if someone thinks other approaches are better, let me know and I'll change it.

Fixes: https://github.com/nodejs/node-gyp/issues/3126
Refs: https://github.com/nodejs/node-gyp/pull/2834