### PR TITLE
chore: retry wasi-sdk download in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,7 +129,27 @@ jobs:
         shell: pwsh
         if: runner.os == 'Windows'
         run: |
-          Start-BitsTransfer -Source https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${env:WASI_VERSION}/wasi-sdk-${env:WASI_VERSION_FULL}-x86_64-windows.tar.gz
+          $MaxRetries = 3
+          $RetryDelay = 10
+          $Attempt = 0
+          while ($Attempt -lt $MaxRetries) {
+            try {
+              Start-BitsTransfer -Source https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${env:WASI_VERSION}/wasi-sdk-${env:WASI_VERSION_FULL}-x86_64-windows.tar.gz
+              break
+            }
+            catch {
+              Write-Host "Error: $($_.Exception.Message)"
+              $Attempt++
+              if ($Attempt -lt $MaxRetries) {
+                Write-Host "Retrying in $RetryDelay seconds"
+                Start-Sleep -Seconds $RetryDelay
+              }
+              else {
+                Write-Host "Max retries reached. Download failed."
+                exit 1
+              }
+            }
+          }
           New-Item -ItemType Directory -Path ${env:WASI_SDK_PATH}
           tar -zxvf wasi-sdk-${env:WASI_VERSION_FULL}-x86_64-windows.tar.gz -C ${env:WASI_SDK_PATH} --strip 1
       - name: Install Dependencies


### PR DESCRIPTION
Downloading `wasi-sdk` was failing intermittently in CI with the following error:

```
Start-BitsTransfer: D:\a\_temp\2d842915-cf29-4e19-ad5c-0579032af0fb.ps1:2
Line |
   2 |  Start-BitsTransfer -Source https://github.com/WebAssembly/wasi-sdk/re …
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | The connection with the server was terminated abnormally 
Error: Process completed with exit code 1.
```

[Ref to CI run](https://github.com/nodejs/node-gyp/actions/runs/14196147703/job/39771631687?pr=3135#step:6:16)

This PR retries the download 3 times since I've only seen this error be transient so far.