### PR TITLE
fix: use temp dir for tar extraction on all platforms

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -200,10 +200,10 @@ async function install (gyp, argv) {
     // download the tarball and extract!
     // Ommited on Windows if only new node.lib is required
 
-    // on Windows there can be file errors from tar if parallel installs
+    // there can be file errors from tar if parallel installs
     // are happening (not uncommon with multiple native modules) so
     // extract the tarball to a temp directory first and then copy over
-    const tarExtractDir = win ? await fs.mkdtemp(path.join(os.tmpdir(), 'node-gyp-tmp-')) : devDir
+    const tarExtractDir = await fs.mkdtemp(path.join(os.tmpdir(), 'node-gyp-tmp-'))
 
     try {
       if (shouldDownloadTarball) {
@@ -277,17 +277,13 @@ async function install (gyp, argv) {
       }
 
       // copy over the files from the temp tarball extract directory to devDir
-      if (tarExtractDir !== devDir) {
-        await copyDirectory(tarExtractDir, devDir)
-      }
+      await copyDirectory(tarExtractDir, devDir)
     } finally {
-      if (tarExtractDir !== devDir) {
-        try {
-          // try to cleanup temp dir
-          await fs.rm(tarExtractDir, { recursive: true, maxRetries: 3 })
-        } catch {
-          log.warn('failed to clean up temp tarball extract directory')
-        }
+      try {
+        // try to cleanup temp dir
+        await fs.rm(tarExtractDir, { recursive: true, maxRetries: 3 })
+      } catch {
+        log.warn('failed to clean up temp tarball extract directory')
       }
     }
 


### PR DESCRIPTION
fixes #3165

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

