### PR TITLE
fix: fix no commands in compile_commands.json file when using objc files

### DIFF
--- a/gyp/pylib/gyp/generator/compile_commands_json.py
+++ b/gyp/pylib/gyp/generator/compile_commands_json.py
@@ -62,7 +62,7 @@ def AddCommandsForTarget(cwd, target, params, per_config_commands):
         defines = ["-D" + s for s in defines]
 
         # TODO(bnoordhuis) Handle generated source files.
-        extensions = (".c", ".cc", ".cpp", ".cxx")
+        extensions = (".c", ".cc", ".cpp", ".cxx", ".m", ".mm")
         sources = [s for s in target.get("sources", []) if s.endswith(extensions)]
 
         def resolve(filename):
@@ -81,7 +81,7 @@ def AddCommandsForTarget(cwd, target, params, per_config_commands):
         commands = per_config_commands.setdefault(configuration_name, [])
         for source in sources:
             file = resolve(source)
-            isc = source.endswith(".c")
+            isc = source.endswith(".c") or source.endswith(".m")
             cc = "cc" if isc else "c++"
             cflags = cflags_c if isc else cflags_cc
             command = " ".join(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->
fix no commands in compile_commands.json file when using objc files(.m or .mm source files)

