### PR TITLE
Normalize win32 library names

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -179,7 +179,7 @@
           '-loleaut32.lib',
           '-luuid.lib',
           '-lodbc32.lib',
-          '-lDelayImp.lib',
+          '-ldelayimp.lib',
           '-l"<(node_lib_file)"'
         ],
         'msvs_disabled_warnings': [


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

I ran into this cross-compiling on a case-sensitive file-system. The official sdk includes this file:

`VC/Tools/MSVC/14.44.35207/lib/x64/delayimp.lib`

which does not have any casing. For simplicity, its easiest to list libraries with lower case names.