### PR TITLE
Lint Python: Ignore ruff rule PLC0415

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: astral-sh/ruff-action@v3
       with:
-        args: "check --select=E,F,PLC,PLE,UP,W,YTT --ignore=E721,PLC0206,PLC1901,S101,UP031 --target-version=py39"
+        args: "check --select=E,F,PLC,PLE,UP,W,YTT --ignore=E721,PLC0206,PLC0415,PLC1901,S101,UP031 --target-version=py39"
 
   lint-js:
     name: Lint JS


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/import-outside-top-level

There are several valid reasons for conditionally importing Python modules, especially for OS-specific code, so let's intentionally ignore this rule.

% `ruff check --select=PLC0415`
```
Error: gyp/pylib/gyp/MSVSVersion.py:222:5: PLC0415 `import` should be at the top-level of a file
Error: gyp/pylib/gyp/__init__.py:492:9: PLC0415 `import` should be at the top-level of a file
Error: gyp/pylib/gyp/generator/make.py:81:9: PLC0415 `import` should be at the top-level of a file
Error: gyp/pylib/gyp/generator/ninja.py:1998:9: PLC0415 `import` should be at the top-level of a file
Error: gyp/pylib/gyp/generator/ninja.py:2021:9: PLC0415 `import` should be at the top-level of a file
Error: gyp/pylib/gyp/generator/ninja.py:2091:9: PLC0415 `import` should be at the top-level of a file
Error: gyp/pylib/gyp/mac_tool.py:145:9: PLC0415 `import` should be at the top-level of a file
Error: gyp/test_gyp.py:151:9: PLC0415 `import` should be at the top-level of a file
Error: gyp/test_gyp.py:157:9: PLC0415 `import` should be at the top-level of a file
```

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

