### PR TITLE
Update engines and make-fetch-happen

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "which": "^5.0.0"
   },
   "engines": {
-    "node": "^18.17.0 || >=20.5.0"
+    "node": "^20.17.0 || >=22.9.0"
   },
   "devDependencies": {
     "bindings": "^1.5.0",


### PR DESCRIPTION
This PR updates the engines from ^18.17.0 || >=20.5.0 to ^20.17.0 || >=22.9.0 and updates make-fetch-happen.

The new engines range was chosen to align with the npm dependency that was updated ([make-fetch-happen](https://github.com/npm/make-fetch-happen/blob/main/package.json#L57)).

@lukekarrys We are going through another update cycle at npm, so I modeled this after https://github.com/nodejs/node-gyp/pull/3102. If I'm breaking protocol with this PR, I'm happy to learn what I should do different next time 😄 