### PR TITLE
chore(release): use npm@11 for publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,4 +41,5 @@ jobs:
         with:
           node-version: lts/*
           registry-url: 'https://registry.npmjs.org'
+      - run: npm install npm@11 -g # Use npm@11 to publish with OIDC
       - run: npm publish --provenance --access public


### PR DESCRIPTION
OIDC is only supported in npm >=11.5.1.

Fixes #3201
