### PR TITLE
build: add adaptation for OpenHarmony platform

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -195,7 +195,7 @@
           '_FILE_OFFSET_BITS=64'
         ],
       }],
-      [ 'OS in "freebsd openbsd netbsd solaris android" or \
+      [ 'OS in "freebsd openbsd netbsd solaris android openharmony" or \
          (OS=="linux" and target_arch!="ia32")', {
         'cflags': [ '-fPIC' ],
       }],


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

When I build the addon on the OpenHarmony operating system, I encounter errors related to linker parameters.

For example, this is the error log I encountered when building [bufferutil](https://www.npmjs.com/package/bufferutil).

```log
# npm install bufferutil
npm error code 1
npm error path /data/test0826/node_modules/bufferutil
npm error command failed
npm error command sh -c node-gyp-build
npm error make: Entering directory '/data/test0826/node_modules/bufferutil/build'
npm error   CC(target) Release/obj.target/bufferutil/src/bufferutil.o
npm error   SOLINK_MODULE(target) Release/obj.target/bufferutil.node
npm error make: Leaving directory '/data/test0826/node_modules/bufferutil/build'
npm error gyp info it worked if it ends with ok
npm error gyp info using node-gyp@11.2.0
npm error gyp info using node@24.2.0 | openharmony | arm64
npm error gyp info find Python using Python version 3.12.9 found at "/data/opt/python3.12/bin/python3.12"
npm error gyp http GET https://nodejs.org/download/release/v24.2.0/node-v24.2.0-headers.tar.gz
npm error gyp http 200 https://nodejs.org/download/release/v24.2.0/node-v24.2.0-headers.tar.gz
npm error gyp http GET https://nodejs.org/download/release/v24.2.0/SHASUMS256.txt
npm error gyp http 200 https://nodejs.org/download/release/v24.2.0/SHASUMS256.txt
npm error gyp info spawn /data/opt/python3.12/bin/python3.12
npm error gyp info spawn args [
npm error gyp info spawn args '/data/opt/node-v24.2.0-openharmony-arm64/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
npm error gyp info spawn args 'binding.gyp',
npm error gyp info spawn args '-f',
npm error gyp info spawn args 'make',
npm error gyp info spawn args '-I',
npm error gyp info spawn args '/data/test0826/node_modules/bufferutil/build/config.gypi',
npm error gyp info spawn args '-I',
npm error gyp info spawn args '/data/opt/node-v24.2.0-openharmony-arm64/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
npm error gyp info spawn args '-I',
npm error gyp info spawn args '/data/.cache/node-gyp/24.2.0/include/node/common.gypi',
npm error gyp info spawn args '-Dlibrary=shared_library',
npm error gyp info spawn args '-Dvisibility=default',
npm error gyp info spawn args '-Dnode_root_dir=/data/.cache/node-gyp/24.2.0',
npm error gyp info spawn args '-Dnode_gyp_dir=/data/opt/node-v24.2.0-openharmony-arm64/lib/node_modules/npm/node_modules/node-gyp',
npm error gyp info spawn args '-Dnode_lib_file=/data/.cache/node-gyp/24.2.0/<(target_arch)/node.lib',
npm error gyp info spawn args '-Dmodule_root_dir=/data/test0826/node_modules/bufferutil',
npm error gyp info spawn args '-Dnode_engine=v8',
npm error gyp info spawn args '--depth=.',
npm error gyp info spawn args '--no-parallel',
npm error gyp info spawn args '--generator-output',
npm error gyp info spawn args 'build',
npm error gyp info spawn args '-Goutput_dir=.'
npm error gyp info spawn args ]
npm error gyp info spawn make
npm error gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
npm error ld.lld: error: relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol 'Mask'; recompile with -fPIC
npm error >>> defined in Release/obj.target/bufferutil/src/bufferutil.o
npm error >>> referenced by bufferutil.c
npm error >>>               Release/obj.target/bufferutil/src/bufferutil.o:(Init)
npm error
npm error ld.lld: error: relocation R_AARCH64_ADD_ABS_LO12_NC cannot be used against symbol 'Mask'; recompile with -fPIC
npm error >>> defined in Release/obj.target/bufferutil/src/bufferutil.o
npm error >>> referenced by bufferutil.c
npm error >>>               Release/obj.target/bufferutil/src/bufferutil.o:(Init)
npm error
npm error ld.lld: error: relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol 'Unmask'; recompile with -fPIC
npm error >>> defined in Release/obj.target/bufferutil/src/bufferutil.o
npm error >>> referenced by bufferutil.c
npm error >>>               Release/obj.target/bufferutil/src/bufferutil.o:(Init)
npm error
npm error ld.lld: error: relocation R_AARCH64_ADD_ABS_LO12_NC cannot be used against symbol 'Unmask'; recompile with -fPIC
npm error >>> defined in Release/obj.target/bufferutil/src/bufferutil.o
npm error >>> referenced by bufferutil.c
npm error >>>               Release/obj.target/bufferutil/src/bufferutil.o:(Init)
npm error clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
npm error make: *** [bufferutil.target.mk:132: Release/obj.target/bufferutil.node] Error 1
npm error gyp ERR! build error
npm error gyp ERR! stack Error: `make` failed with exit code: 2
```

The cause of this error is that the `addon.gypi` in node-gyp is not adapted to the OpenHarmony. This PR adds adaptation for this platform.