### PR TITLE
Feat/add vs2026 support

### DIFF
--- a/gyp/pylib/gyp/MSVSVersion.py
+++ b/gyp/pylib/gyp/MSVSVersion.py
@@ -550,8 +550,18 @@ def SelectVisualStudioVersion(version="auto", allow_fallback=True):
     if version == "auto":
         version = os.environ.get("GYP_MSVS_VERSION", "auto")
     version_map = {
-        "auto": ("18.0", "17.0", "16.0", "15.0", "14.0",
-        "12.0", "10.0", "9.0", "8.0", "11.0"),
+        "auto": (
+            "18.0",
+            "17.0",
+            "16.0",
+            "15.0",
+            "14.0",
+            "12.0",
+            "10.0",
+            "9.0",
+            "8.0",
+            "11.0",
+        ),
         "2005": ("8.0",),
         "2005e": ("8.0",),
         "2008": ("9.0",),


### PR DESCRIPTION
##### Checklist
- [x] `npm install && npm run lint && npm test` passes
- [x] tests are included 
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
**feat: add support for Visual Studio 2026**

This pull request introduces initial support for the upcoming Visual Studio 2026 (internal version 18.0).

The key changes include:

* **Version Detection:** Added '2026' and version '18.0' to the version maps in `SelectVisualStudioVersion` and `_DetectVisualStudioVersions`. This allows GYP to correctly identify VS 2026 installations.
* **Version Creation:** Included a new `VisualStudioVersion` definition for '2026' in the `_CreateVersion` function.
* **Toolset Update:** Set the `default_toolset` to `v145`. This aligns with the toolset version observed in the Visual Studio 2026 Insider Preview builds, resolving potential `MSB8020` errors for users on the latest previews.

These changes enable developers using early versions of Visual Studio 2026 to generate and build projects with GYP seamlessly.