### PR TITLE
Update `nopt` and `proc-log` to latest major versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "exponential-backoff": "^3.1.1",
     "graceful-fs": "^4.2.6",
     "make-fetch-happen": "^15.0.0",
-    "nopt": "^8.0.0",
+    "nopt": "^9.0.0",
     "proc-log": "^6.0.0",
     "semver": "^7.3.5",
     "tar": "^7.5.2",


### PR DESCRIPTION
After the engines bump in #3199, these dependencies can now be updated to their latest major versions to align with npm.
