### PR TITLE
Revert "build(deps): bump env-paths from 2.2.1 to 3.0.0 (#3235)"

### DIFF
--- a/bin/node-gyp.js
+++ b/bin/node-gyp.js
@@ -4,7 +4,7 @@
 
 process.title = 'node-gyp'
 
-const { default: envPaths } = require('env-paths')
+const envPaths = require('env-paths')
 const gyp = require('../')
 const log = require('../lib/log')
 const os = require('os')

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "bin": "./bin/node-gyp.js",
   "main": "./lib/node-gyp.js",
   "dependencies": {
-    "env-paths": "^3.0.0",
+    "env-paths": "^2.2.0",
     "exponential-backoff": "^3.1.1",
     "graceful-fs": "^4.2.6",
     "make-fetch-happen": "^15.0.0",

--- a/test/common.js
+++ b/test/common.js
@@ -1,4 +1,4 @@
-const { default: envPaths } = require('env-paths')
+const envPaths = require('env-paths')
 const semver = require('semver')
 
 module.exports.devDir = envPaths('node-gyp', { suffix: '' }).cache


### PR DESCRIPTION
This reverts commit 5fffb2ffee304cc898fdea7a0cd9e41d54c53839.

Fixes #3239 