### PR TITLE
feat: include built package version in error logs

### DIFF
--- a/bin/node-gyp.js
+++ b/bin/node-gyp.js
@@ -125,6 +125,13 @@ function errorMessage () {
   log.error('cwd', process.cwd())
   log.error('node -v', process.version)
   log.error('node-gyp -v', 'v' + prog.package.version)
+  // print the npm package version
+  for (const env of ['npm_package_name', 'npm_package_version']) {
+    const value = process.env[env]
+    if (value != null) {
+      log.error(`$${env}`, value)
+    }
+  }
 }
 
 function issueMessage () {


### PR DESCRIPTION
I'm working on upgrading a lot of packages to node 24 and there are many failures in native modules. Looking at logs alone it's hard to spot which package versions are failing to build. node-gyp prints debug info about node, npm, and node-gyp but not the package that is currently being built.

It doesn't look like node-gyp reads package.json so I opted to read npm_package_ env vars, which is similar to the npm_config_ env vars node-gyp already reads.

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

I didn't write any tests, there's no tests that cover other error messages or even trigger an error.
Not sure what to document for this.

##### Description of change
<!-- Provide a description of the change -->

