### PR TITLE
fix: cpu concurrency detection on some platforms

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -163,7 +163,7 @@ async function build (gyp, argv) {
         if (!isNaN(j) && j > 0) {
           argv.push('/m:' + j)
         } else if (jobs.toUpperCase() === 'MAX') {
-          argv.push('/m:' + require('os').cpus().length)
+          argv.push('/m:' + require('os').availableParallelism())
         }
       }
     } else {
@@ -178,7 +178,7 @@ async function build (gyp, argv) {
           argv.push(j)
         } else if (jobs.toUpperCase() === 'MAX') {
           argv.push('--jobs')
-          argv.push(require('os').cpus().length)
+          argv.push(require('os').availableParallelism())
         }
       }
     }


### PR DESCRIPTION
`os.availableParallelism()` should produce more accurate results of how
much parallelism should be used then `os.cpus().length`. The only
breaking change is the newer API requires node versions >= v18.x which
is fine as node-gyp only aims to support latest and LTS releases. And
the oldest LTS release still supported as of this commit is v22.

Fixes #3191

This should improve Android support.

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

