### PR TITLE
fix: url.parse deprecation warning

### DIFF
--- a/lib/process-release.js
+++ b/lib/process-release.js
@@ -109,15 +109,15 @@ function processRelease (argv, gyp, defaultVersion, defaultRelease) {
     versionDir: (name !== 'node' ? name + '-' : '') + version,
     ia32: {
       libUrl: libUrl32,
-      libPath: normalizePath(path.relative(url.parse(baseUrl).path, url.parse(libUrl32).path))
+      libPath: normalizePath(path.relative(new URL(baseUrl).pathname, new URL(libUrl32).pathname))
     },
     x64: {
       libUrl: libUrl64,
-      libPath: normalizePath(path.relative(url.parse(baseUrl).path, url.parse(libUrl64).path))
+      libPath: normalizePath(path.relative(new URL(baseUrl).pathname, new URL(libUrl64).pathname))
     },
     arm64: {
       libUrl: libUrlArm64,
-      libPath: normalizePath(path.relative(url.parse(baseUrl).path, url.parse(libUrlArm64).path))
+      libPath: normalizePath(path.relative(new URL(baseUrl).pathname, new URL(libUrlArm64).pathname))
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

url.parse is deprecated ! Let's replace it by `new URL(str).pathname` (ignoring search), because these are file paths.