### PR TITLE
fix: `msvs_version` is no longer a valid npm config setting

### DIFF
--- a/lib/find-visualstudio.js
+++ b/lib/find-visualstudio.js
@@ -30,7 +30,7 @@ class VisualStudioFinder {
     this.configVersionYear = null
     this.configPath = null
     if (this.configMsvsVersion) {
-      this.addLog('msvs_version was set from command line or npm config')
+      this.addLog(`--msvs_version=${this.configMsvsVersion} was set on the command line`)
       if (this.configMsvsVersion.match(/^\d{4}$/)) {
         this.configVersionYear = parseInt(this.configMsvsVersion, 10)
         this.addLog(
@@ -41,7 +41,7 @@ class VisualStudioFinder {
           `- looking for Visual Studio installed in "${this.configPath}"`)
       }
     } else {
-      this.addLog('msvs_version not set from command line or npm config')
+      this.addLog('--msvs_version was not set on the command line')
     }
 
     if (process.env.VCINSTALLDIR) {


### PR DESCRIPTION
Remove misleading warnings.
% `npm config list -l | grep msvs ` # no hits
% `npm config set msvs_version=2025`
> npm error `msvs_version` is not a valid npm option

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

