### PR TITLE
fix: `python` is no longer a valid npm config setting

### DIFF
--- a/lib/find-python.js
+++ b/lib/find-python.js
@@ -86,14 +86,10 @@ class PythonFinder {
         {
           before: () => {
             if (!this.configPython) {
-              this.addLog(
-                'Python is not set from command line or npm configuration')
+              this.addLog('--python was not set on the command line')
               return SKIP
             }
-            this.addLog('checking Python explicitly set from command line or ' +
-              'npm configuration')
-            this.addLog('- "--python=" or "npm config get python" is ' +
-              `"${this.configPython}"`)
+            this.addLog(`--python=${this.configPython} was set on the command line`)
           },
           check: () => this.checkCommand(this.configPython)
         },
@@ -295,8 +291,6 @@ class PythonFinder {
       `- Use the switch --python="${pathExample}"`,
       '  (accepted by both node-gyp and npm)',
       '- Set the environment variable PYTHON',
-      '- Set the npm configuration variable python:',
-      `  npm config set python "${pathExample}"`,
       'For more information consult the documentation at:',
       'https://github.com/nodejs/node-gyp#installation',
       '**********************************************************'


### PR DESCRIPTION
Like #3257
* #3257

Remove misleading warnings.
% `npm config list -l | grep python ` # no hits
% `npm config set python=3.14`
> npm error `python` is not a valid npm option

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

