### PR TITLE
readme: update Python manual install instructions for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ choco install python visualstudio2022-workload-vctools -y
 
 Or install and configure Python and Visual Studio tools manually:
 
-  * Install the current [version of Python](https://devguide.python.org/versions/) from the
-  [Microsoft Store](https://apps.microsoft.com/store/search?publisher=Python+Software+Foundation).
+  * Follow the instructions in [Using Python on Windows](https://docs.python.org/3/using/windows.html) to install
+    the current [version of Python](https://www.python.org/downloads/).
 
    * Install Visual C++ Build Environment: For Visual Studio 2019 or later, use the `Desktop development with C++` workload from [Visual Studio Community](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community).  For a version older than Visual Studio 2019, install [Visual Studio Build Tools](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools) with the `Visual C++ build tools` option.
 


### PR DESCRIPTION
- closes https://github.com/nodejs/node-gyp/issues/3264

## Checklist

- [X] `npm install && npm run lint && npm test` passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

### Situation

Python instructions to install on Windows changed with the release of Python 3.14 in October 2025.

[Python 3.14 documentation](https://docs.python.org/3/using/windows.html) says:

> To obtain Python from the CPython team, use the Python Install Manager. This is a standalone tool that makes Python available as global commands on your Windows machine, integrates with the system, and supports updates over time. You can download the Python Install Manager from [python.org/downloads](https://www.python.org/downloads/) or through the [Microsoft Store app](https://apps.microsoft.com/detail/9NQ7512CXL7T).

Python 3.14 is not available as a separate package in the [Microsoft Store](https://apps.microsoft.com/store/search?publisher=Python+Software+Foundation), unlike Python 3.12 and 3.13.

The Python Install Manager can be used to install 3.14 and other versions.

### Description of change

In the [README > On Windows](https://github.com/nodejs/node-gyp/blob/main/README.md#on-windows) section change the manual install instructions to:

> Follow the instructions in [Using Python on Windows](https://docs.python.org/3/using/windows.html) to install the current [version of Python](https://www.python.org/downloads/).


