### PR TITLE
win: improve Add-Type with -IgnoreWarnings

### DIFF
--- a/lib/find-visualstudio.js
+++ b/lib/find-visualstudio.js
@@ -247,7 +247,7 @@ class VisualStudioFinder {
       'Unrestricted',
       '-NoProfile',
       '-Command',
-      '&{Add-Type -Path \'' + csFile + '\';' + '[VisualStudioConfiguration.Main]::PrintJson()}'
+      '&{Add-Type -IgnoreWarnings -Path \'' + csFile + '\';' + '[VisualStudioConfiguration.Main]::PrintJson()}'
     ]
 
     this.log.silly('Running', ps, psArgs)


### PR DESCRIPTION
This PR takes advice from the referenced issue and makes the logic for finding Visual Studio more robust.

Refs: https://github.com/nodejs/node-gyp/issues/3276