### PR TITLE
chore: retry downloads on retryable errors

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -11,7 +11,8 @@ async function download (gyp, url) {
       Connection: 'keep-alive'
     },
     proxy: gyp.opts.proxy,
-    noProxy: gyp.opts.noproxy
+    noProxy: gyp.opts.noproxy,
+    retry: 3
   }
 
   const cafile = gyp.opts.cafile

--- a/test/test-download.js
+++ b/test/test-download.js
@@ -153,6 +153,32 @@ describe('download', function () {
     assert.notStrictEqual(cas[0], cas[1])
   })
 
+  it('download will retry on ECONNRESET', async function () {
+    let requestCount = 0
+    const server = http.createServer((req, res) => {
+      requestCount++
+      if (requestCount < 3) {
+        req.socket.destroy()
+        return
+      }
+      res.end('ok')
+    })
+
+    after(() => new Promise((resolve) => server.close(resolve)))
+
+    const host = 'localhost'
+    await new Promise((resolve) => server.listen(0, host, resolve))
+    const { port } = server.address()
+    const gyp = {
+      opts: {},
+      version: '42'
+    }
+    const url = `http://${host}:${port}`
+    const res = await download(gyp, url)
+    assert.strictEqual(await res.text(), 'ok')
+    assert.ok(requestCount >= 2, `expected at least 2 requests but got ${requestCount}`)
+  })
+
   // only run this test if we are running a version of Node with predictable version path behavior
 
   it('download headers (actual)', async function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change

Fixes #2847

Retries downloads up to 3 times to ensure a transient network error (we've seen `ECONNRESET` from time to time) doesn't cause the whole thing to fail. This will retry for retryable errors (including 429 and 500 response status codes), and I've added test coverage to validate the behavior.