### PR TITLE
ci: add workflow_dispatch trigger to tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches: [ main ]
   workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: read # to fetch code (actions/checkout)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change

It's a lot easier for forks to run CI to verify tests pass if there's a `workflow_dispatch` trigger so you can manually trigger CI for a given branch from the GitHub UI.