### PR TITLE
ci: fix current failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: astral-sh/ruff-action@v3
       with:
-        args: "check --select=E,F,PLC,PLE,UP,W,YTT --ignore=E721,PLC0206,PLC0415,PLC1901,S101,UP031 --target-version=py39"
+        args: "check --select=E,F,PLC,PLE,UP,W,YTT --ignore=E721,F507,PLC0206,PLC0415,PLC1901,S101,UP031 --target-version=py39"
     - run: ruff format --check --diff
 
   lint-js:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change

Fixes current CI failures that are occurring. One is caused by a known `npm` issue that I've linked, the other looks to be a false positive from a newer version of `ruff`. I didn't find an open issue for the latter, I may open one as follow-up to this.

cc @cclauss