### PR TITLE
fix: override host-specific variables when reading headers config.gypi

### DIFF
--- a/lib/create-config-gypi.js
+++ b/lib/create-config-gypi.js
@@ -15,6 +15,40 @@ function parseConfigGypi (config) {
   return JSON.parse(config)
 }
 
+// Variables that describe the build host (the machine running node-gyp), not
+// the target Node binary. The official Node release headers tarball is a
+// single universal artifact whose embedded config.gypi reflects the build
+// farm host (currently Linux x64 / GCC), so when a consumer on a different
+// platform inherits it verbatim via --disturl/--nodedir, these fields end up
+// wrong. The most visible symptom on macOS arm64 is `clang=0` silently
+// dropping the `clang==1` branches in common.gypi (e.g. `-std=gnu++20`),
+// breaking node-addon-api compilation. See PR #2497 for the original code
+// path and electron/rebuild#1209 for the first user report.
+const HOST_SPECIFIC_VARIABLES = [
+  'host_arch',
+  'clang',
+  'llvm_version',
+  'xcode_version',
+  'arm_fpu',
+  'gas_version',
+  'shlib_suffix'
+]
+
+function overrideHostSpecificVariables (config) {
+  if (!config || !config.variables || !process.config || !process.config.variables) {
+    return config
+  }
+  for (const key of HOST_SPECIFIC_VARIABLES) {
+    const value = process.config.variables[key]
+    if (value !== undefined) {
+      config.variables[key] = value
+    } else {
+      delete config.variables[key]
+    }
+  }
+  return config
+}
+
 async function getBaseConfigGypi ({ gyp, nodeDir }) {
   // try reading $nodeDir/include/node/config.gypi first when:
   // 1. --dist-url or --nodedir is specified
@@ -25,7 +59,7 @@ async function getBaseConfigGypi ({ gyp, nodeDir }) {
     try {
       const baseConfigGypiPath = path.resolve(nodeDir, 'include/node/config.gypi')
       const baseConfigGypi = await fs.readFile(baseConfigGypiPath)
-      return parseConfigGypi(baseConfigGypi.toString())
+      return overrideHostSpecificVariables(parseConfigGypi(baseConfigGypi.toString()))
     } catch (err) {
       log.warn('read config.gypi', err.message)
     }

--- a/test/fixtures/nodedir-mismatched-host/include/node/config.gypi
+++ b/test/fixtures/nodedir-mismatched-host/include/node/config.gypi
@@ -1,0 +1,14 @@
+# Test fixture: mimics the official Node release headers tarball, whose
+# embedded config.gypi is produced on a Linux x64 / GCC build farm and ships
+# unchanged to all platforms. The host-specific fields here MUST be
+# overridden by process.config when running on a different host.
+{
+  'variables': {
+    'host_arch': 'x64',
+    'clang': 0,
+    'llvm_version': '0.0',
+    'gas_version': '2.38',
+    'shlib_suffix': 'so.137',
+    'build_with_electron': true
+  }
+}

--- a/test/test-create-config-gypi.js
+++ b/test/test-create-config-gypi.js
@@ -52,6 +52,52 @@ describe('create-config-gypi', function () {
     assert.strictEqual(config.variables.build_with_electron, undefined)
   })
 
+  it('config.gypi overrides host-specific vars from process.config when nodedir is set', async function () {
+    // The fixture mimics a Linux x64 / GCC build farm headers tarball. When
+    // running on a different host (e.g. macOS arm64 / clang), the host-specific
+    // fields must come from process.config, not from the headers tarball,
+    // otherwise binding.gyp / common.gypi `if (clang==1)` branches break
+    // (e.g. -std=gnu++20 is silently dropped, breaking node-addon-api).
+    const nodeDir = path.join(__dirname, 'fixtures', 'nodedir-mismatched-host')
+
+    const prog = gyp()
+    prog.parseArgv(['_', '_', `--nodedir=${nodeDir}`])
+
+    const config = await getCurrentConfigGypi({ gyp: prog, nodeDir, vsInfo: {} })
+
+    // target build config from headers is still preserved (PR #2497 intent).
+    assert.strictEqual(config.variables.build_with_electron, true)
+
+    // host-specific fields come from process.config.
+    assert.strictEqual(config.variables.host_arch, process.config.variables.host_arch)
+    assert.strictEqual(config.variables.clang, process.config.variables.clang)
+    assert.strictEqual(config.variables.llvm_version, process.config.variables.llvm_version)
+
+    // fields that are present in headers but absent in process.config must be
+    // deleted (e.g. gas_version is Linux-only and meaningless on macOS).
+    if (process.config.variables.gas_version === undefined) {
+      assert.strictEqual('gas_version' in config.variables, false)
+    }
+    if (process.config.variables.xcode_version === undefined) {
+      assert.strictEqual('xcode_version' in config.variables, false)
+    }
+  })
+
+  it('config.gypi with --force-process-config bypasses host override too (back-compat)', async function () {
+    const nodeDir = path.join(__dirname, 'fixtures', 'nodedir-mismatched-host')
+
+    const prog = gyp()
+    prog.parseArgv(['_', '_', '--force-process-config', `--nodedir=${nodeDir}`])
+
+    const config = await getCurrentConfigGypi({ gyp: prog, nodeDir, vsInfo: {} })
+
+    // --force-process-config still skips reading the headers entirely.
+    assert.strictEqual(config.variables.build_with_electron, undefined)
+    // And of course the host fields are from process.config (always were).
+    assert.strictEqual(config.variables.host_arch, process.config.variables.host_arch)
+    assert.strictEqual(config.variables.clang, process.config.variables.clang)
+  })
+
   it('config.gypi parsing', function () {
     const str = "# Some comments\n{'variables': {'multiline': 'A'\n'B'}}"
     const config = parseConfigGypi(str)


### PR DESCRIPTION
## Background

`getBaseConfigGypi` reads `\$nodedir/include/node/config.gypi` verbatim whenever `--disturl`, `--dist-url`, or `--nodedir` is set (and `--force-process-config` is not). This was introduced in #2497 to let Electron / NW.js builds pick up target build config from custom headers.

The official Node release headers tarball is, however, **a single universal artifact shipped to all platforms**, and its embedded `config.gypi` reflects the build host of the Node release-engineering machine (currently a Linux x64 / GCC box). When a consumer on a different host inherits it verbatim, host-specific fields end up wrong.

## Symptom on macOS arm64

Field-by-field diff between the cached headers' `config.gypi` and `process.config.variables` on darwin/arm64 with Node v24.13.1:

| field | cache | process.config |
|---|---|---|
| host_arch | x64 | arm64 |
| clang | 0 | 1 |
| llvm_version | \"0.0\" | \"16.0\" |
| xcode_version | \<undef\> | \"16.0\" |
| arm_fpu | \<undef\> | \"neon\" |
| gas_version | \"2.38\" | \<undef\> |
| shlib_suffix | \"so.137\" | \"137.dylib\" |

The killer is `clang=0`: Node's `common.gypi` gates `-std=gnu++20` (and several other flags) on `clang==1`. With `clang=0` those branches never fire, C++ compilation falls back to C++03, and any addon using `node-addon-api` immediately fails with:

\`\`\`
node-addon-api/napi.h: error: a space is required between consecutive right angle brackets (use '> >')
node-addon-api/napi.h: error: no template named 'initializer_list' in namespace 'std'
node-addon-api/napi.h: error: unknown type name 'constexpr'
\`\`\`

For comparison, on Linux x64 / Node v24.13.1 the same diff shows **all 7 host-specific fields are identical** between cache and process.config (the cache literally is a Linux x64 build farm fingerprint), so the fix in this PR is a strict no-op there.

## Minimal repro (no Electron required)

\`\`\`bash
mkdir /tmp/repro && cd /tmp/repro
cat > package.json <<'EOF'
{\"name\":\"r\",\"dependencies\":{\"node-addon-api\":\"^8.0.0\"}}
EOF
cat > binding.gyp <<'EOF'
{\"targets\":[{\"target_name\":\"r\",\"sources\":[\"r.cc\"],
  \"include_dirs\":[\"<!@(node -p \\\"require('node-addon-api').include\\\")\"],
  \"dependencies\":[\"<!(node -p \\\"require('node-addon-api').gyp\\\")\"]}]}
EOF
echo '#include <napi.h>' > r.cc
npm install --ignore-scripts

# Works:
npx node-gyp rebuild

# Fails (anywhere disturl is set):
npm_config_disturl=https://npmmirror.com/mirrors/node npx node-gyp rebuild
\`\`\`

## Affected scope

Anyone with \`disturl\` set in \`~/.npmrc\`, project \`.npmrc\`, or as \`npm_config_disturl\` env var. Common cases:

- China mirrors: \`npmmirror.com\`, \`taobao\`
- Self-hosted: Nexus, JFrog, Verdaccio with \`disturl\` rewriting
- Electron projects via \`electron-rebuild\` (the symptom most users hit; reported separately as electron/rebuild#1209)

## Why \`--force-process-config\` is not a real fix

- It throws away the *target build config* that the headers tarball legitimately carries (the entire point of #2497 / #2490).
- For Electron native modules it produces a `node_module_version` mismatch — Electron then refuses to load the addon. See pulsar-edit/ppm#162 (2025-12, reverting `--force-process-config` after exactly this).
- Electron's [own blog post](https://github.com/electron/website/pull/143#discussion_r749594721) restricts the flag to \"old Electron (<=13, <14.2.0, <15.3.0)\".

## Fix

Override only the host-specific variables from `process.config.variables` after parsing the headers' `config.gypi`:

\`\`\`js
const HOST_SPECIFIC_VARIABLES = [
  'host_arch',
  'clang',
  'llvm_version',
  'xcode_version',
  'arm_fpu',
  'gas_version',
  'shlib_suffix'
]
\`\`\`

PR #2497's intent is preserved — target build config (v8 features, bundled vs shared deps, `node_module_version`, etc.) still comes from the headers tarball; only host (build machine) fields are corrected.

## Verification

- [x] All existing tests pass (`npm test`: 108 passing, 6 pending — unchanged from main).
- [x] Two new tests added in `test/test-create-config-gypi.js` covering the override behaviour and `--force-process-config` back-compat, with a new fixture `test/fixtures/nodedir-mismatched-host/` that mimics a Linux x64 build farm headers tarball.
- [x] No-op verified on Linux x64 (all 7 host fields already match cache / process.config).
- [x] Necessary verified on macOS arm64 (all 7 fields mismatched).
- [x] `npm run lint` clean for changed files.

## Open questions for maintainers

1. Is the `HOST_SPECIFIC_VARIABLES` set complete? It was derived from a full diff on macOS arm64; would appreciate a sanity check on Windows arm64 / FreeBSD / AIX.
2. Should an upstream fix in Node release engineering (ship platform-specific headers, or strip host-specific keys before packaging the universal tarball) take priority? That would fix every node-gyp version retroactively, but turnaround is much slower.

## Related

- #2497 / #2490 — original introduction of the code path
- electron/rebuild#1209 — first user report (filed in the wrong repo, no traction)
- pulsar-edit/ppm#162 — `--force-process-config` side-effect on Electron module_version

Made with [Cursor](https://cursor.com)