### PR TITLE
chore: retry downloads on retryable errors

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -1,5 +1,5 @@
 const { Readable } = require('stream')
-const { EnvHttpProxyAgent } = require('undici')
+const { Agent, EnvHttpProxyAgent, RetryAgent } = require('undici')
 const { promises: fs } = require('graceful-fs')
 const log = require('./log')
 
@@ -48,7 +48,7 @@ async function createDispatcher (gyp) {
   const env = process.env
   const hasProxyEnv = env.http_proxy || env.HTTP_PROXY || env.https_proxy || env.HTTPS_PROXY
   if (!gyp.opts.proxy && !gyp.opts.cafile && !hasProxyEnv) {
-    return undefined
+    return new RetryAgent(new Agent(), { maxRetries: 3 })
   }
 
   const opts = {}
@@ -69,7 +69,7 @@ async function createDispatcher (gyp) {
   if (gyp.opts.noproxy) {
     opts.noProxy = gyp.opts.noproxy
   }
-  return new EnvHttpProxyAgent(opts)
+  return new RetryAgent(new EnvHttpProxyAgent(opts), { maxRetries: 3 })
 }
 
 async function readCAFile (filename) {

--- a/test/test-download.js
+++ b/test/test-download.js
@@ -218,6 +218,32 @@ describe('download', function () {
     assert.notStrictEqual(cas[0], cas[1])
   })
 
+  it('download will retry on ECONNRESET', async function () {
+    let requestCount = 0
+    const server = http.createServer((req, res) => {
+      requestCount++
+      if (requestCount < 3) {
+        req.socket.destroy()
+        return
+      }
+      res.end('ok')
+    })
+
+    after(() => new Promise((resolve) => server.close(resolve)))
+
+    const host = 'localhost'
+    await new Promise((resolve) => server.listen(0, host, resolve))
+    const { port } = server.address()
+    const gyp = {
+      opts: {},
+      version: '42'
+    }
+    const url = `http://${host}:${port}`
+    const res = await download(gyp, url)
+    assert.strictEqual(await res.text(), 'ok')
+    assert.ok(requestCount >= 2, `expected at least 2 requests but got ${requestCount}`)
+  })
+
   // only run this test if we are running a version of Node with predictable version path behavior
 
   it('download headers (actual)', async function () {


### PR DESCRIPTION
Assisted-by: Claude Opus 4.6

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

Fixes #2847

This is a reworking of #3298 after the changes in #3302 landed.

Retries downloads up to 3 times to ensure a transient network error (we've seen `ECONNRESET` from time to time) doesn't cause the whole thing to fail. This will retry for retryable errors (including 429 and 500 response status codes), and I've added test coverage to validate the behavior.