### PR TITLE
support Node.js 26

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         python: ["3.10", "3.12", "3.14"]
-        node: [20.x, 22.x, 24.x]
+        node: [20.x, 22.x, 24.x, 26.x]
         include:
           - os: macos-15-intel  # macOS on Intel
             python: "3.14"

--- a/lib/download.js
+++ b/lib/download.js
@@ -1,5 +1,5 @@
 const { Readable } = require('stream')
-const { Agent, EnvHttpProxyAgent, RetryAgent } = require('undici')
+const { Agent, EnvHttpProxyAgent, RetryAgent, fetch } = require('undici')
 const { promises: fs } = require('graceful-fs')
 const log = require('./log')
 


### PR DESCRIPTION
Add support for Node.js v26


BEGIN_COMMIT_OVERRIDE
fix: support Node.js 26
END_COMMIT_OVERRIDE