### PR TITLE
fix: test on Node.js v26

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,17 +98,17 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         python: ["3.10", "3.12", "3.14"]
-        node: [20.x, 22.x, 24.x]
+        node: [20.x, 22.x, 24.x, 26.x]
         include:
           - os: macos-15-intel  # macOS on Intel
             python: "3.14"
-            node: 24.x
+            node: 26.x
           - os: ubuntu-24.04-arm  # Ubuntu on ARM
             python: "3.14"
-            node: 24.x
+            node: 26.x
           - os: windows-11-arm  # Windows on ARM
             python: "3.14"
-            node: 24.x
+            node: 26.x
     name: ${{ matrix.os }} - ${{ matrix.python }} - ${{ matrix.node }}
     runs-on: ${{ matrix.os }}
     env:
@@ -171,10 +171,10 @@ jobs:
         shell: bash
         run: npm test --python="${pythonLocation}/python"
         env:
-          FULL_TEST: ${{ (matrix.node == '24.x' && matrix.python == '3.14') && '1' || '0' }}
+          FULL_TEST: ${{ (matrix.node == '26.x' && matrix.python == '3.14') && '1' || '0' }}
       - name: Run Tests (Windows)
         if: runner.os == 'Windows'
         shell: bash # Building wasm on Windows requires using make generator, it only works in bash
         run: npm run test --python="${pythonLocation}\\python.exe"
         env:
-          FULL_TEST: ${{ (matrix.node == '24.x' && matrix.python == '3.14') && '1' || '0' }}
+          FULL_TEST: ${{ (matrix.node == '26.x' && matrix.python == '3.14') && '1' || '0' }}

--- a/lib/download.js
+++ b/lib/download.js
@@ -1,5 +1,5 @@
 const { Readable } = require('stream')
-const { Agent, EnvHttpProxyAgent, RetryAgent } = require('undici')
+const { Agent, EnvHttpProxyAgent, RetryAgent, fetch } = require('undici')
 const { promises: fs } = require('graceful-fs')
 const log = require('./log')
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm run lint && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
Test on Node.js v26

# stack TypeError: this.handler.onConnect is not a function
