### PR TITLE
Update tinyglobby dependency for a v11 maintenance release

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "proc-log": "^5.0.0",
     "semver": "^7.3.5",
     "tar": "^7.4.3",
-    "tinyglobby": "^0.2.12",
+    "tinyglobby": "^0.2.16",
     "which": "^5.0.0"
   },
   "engines": {


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change

tinyglobby [version 0.2.16](https://github.com/SuperchupuDev/tinyglobby/releases/tag/0.2.16) updates its picomatch dependency from 4.0.3 to 4.0.4 which fixes a couple of security problems:

```text
picomatch  4.0.0 - 4.0.3
Severity: high
Picomatch: Method Injection in POSIX Character Classes causes incorrect Glob Matching - https://github.com/advisories/GHSA-3v7f-55p6-f55p
Picomatch has a ReDoS vulnerability via extglob quantifiers - https://github.com/advisories/GHSA-c2c7-rcm5-vvqj
fix available via `npm audit fix`
node_modules/npm/node_modules/picomatch
```

But why should node-gyp need to make a new release when its tinyglobby dependency is currently specified as 

```json
    "tinyglobby": "^0.2.12",
```

and version 0.2.16 should be upgradable from that? Well because of dependency bundling it is in some case not possible to override dependencies.

In my project `npm ls tinyglobby` produces

```text
└─┬ node-red@4.1.10
  └─┬ @node-red/runtime@4.1.10
    └─┬ @node-red/registry@4.1.10
      └─┬ npm@10.9.8
        └─┬ node-gyp@11.5.0
          └── tinyglobby@0.2.15  
```

and if I then add to package.json

```json
  "overrides": {
     "node-red": {
       "@node-red/runtime": {
         "@node-red/registry": {
           "npm": {
             "node-gyp": {
               "tinyglobby": "^0.2.16"
             }
           }
         }
       }
     }
   },   
```

npm ls then produces

```text
└─┬ node-red@4.1.10 overridden
  └─┬ @node-red/runtime@4.1.10 overridden
    └─┬ @node-red/registry@4.1.10
      └─┬ npm@10.9.8
        └─┬ node-gyp@11.5.0
          └── tinyglobby@0.2.15   
```

where tinyglobby is not overridden like intended. I am not sure about the details, but something about npm's dependency bundling makes tinyglobby non-overridable in this case.

So if node-gyp could make a new maintenance release with updated dependency for tinyglobby, this could then next be picked up by npm.
