### PR TITLE
fix: disable LTO for addon builds on Windows

### DIFF
--- a/lib/create-config-gypi.js
+++ b/lib/create-config-gypi.js
@@ -99,6 +99,11 @@ async function getCurrentConfigGypi ({ gyp, nodeDir, vsInfo, python }) {
     if (config.variables.clang === 1) {
       config.variables.clang = 0
     }
+    // disable LTO for addon builds. node release builds may enable (thin) LTO,
+    // which leaks clang/lld-only flags like -flto=thin and /opt:lldltojobs into
+    // addons built with the default MSVC toolchain, which rejects those flags
+    variables.enable_lto = 'false'
+    variables.enable_thin_lto = 'false'
   }
 
   // loop through the rest of the opts and add the unknown ones as variables.

--- a/test/fixtures/win-lto/include/node/config.gypi
+++ b/test/fixtures/win-lto/include/node/config.gypi
@@ -1,0 +1,8 @@
+# Test configuration simulating a Node.js Windows release built with Thin LTO
+{
+  'variables': {
+    'enable_lto': 'true',
+    'enable_thin_lto': 'true',
+    'lto_jobs': '2'
+  }
+}

--- a/test/test-create-config-gypi.js
+++ b/test/test-create-config-gypi.js
@@ -52,6 +52,25 @@ describe('create-config-gypi', function () {
     assert.strictEqual(config.variables.build_with_electron, undefined)
   })
 
+  it('config.gypi disables LTO for addon builds on Windows', async function () {
+    const nodeDir = path.join(__dirname, 'fixtures', 'win-lto')
+
+    const prog = gyp()
+    prog.parseArgv(['_', '_', `--nodedir=${nodeDir}`])
+
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    try {
+      const config = await getCurrentConfigGypi({ gyp: prog, nodeDir, vsInfo: {} })
+      // thin LTO leaks clang/lld-only flags into the MSVC addon build, so it
+      // must be disabled regardless of how node itself was built
+      assert.strictEqual(config.variables.enable_lto, 'false')
+      assert.strictEqual(config.variables.enable_thin_lto, 'false')
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+    }
+  })
+
   it('config.gypi parsing', function () {
     const str = "# Some comments\n{'variables': {'multiline': 'A'\n'B'}}"
     const config = parseConfigGypi(str)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

Addon builds on Windows were failing because LTO flags from Node's own build leak in through common.gypi and MSVC rejects them. This disables LTO during configure so addons build cleanly.

fixes https://github.com/nodejs/node-gyp/issues/3327