### PR TITLE
test: fix undici 8.7.0 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,7 @@ jobs:
   test-pack:
     name: Test Pack
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v7
@@ -111,6 +112,7 @@ jobs:
             node: 26.x
     name: ${{ matrix.os }} - ${{ matrix.python }} - ${{ matrix.node }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     env:
       WASI_VERSION: '25'
       WASI_VERSION_FULL: '25.0'

--- a/.github/workflows/visual-studio.yml
+++ b/.github/workflows/visual-studio.yml
@@ -24,6 +24,7 @@ jobs:
           - os: windows-11-arm
             msvs-version: 2022  # Fix this when Visual Studio 2025 is released
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7

--- a/test/test-download.js
+++ b/test/test-download.js
@@ -77,6 +77,24 @@ describe('download', function () {
 
     let proxyUsed = false
     const pserver = http.createServer()
+    // undici tunnels https requests through the proxy with CONNECT, but forwards
+    // plain http requests to the proxy in absolute-form. Handle both so the test
+    // works regardless of which path undici picks.
+    pserver.on('request', (creq, cres) => {
+      proxyUsed = true
+      const target = new URL(creq.url)
+      const proxyReq = http.request({
+        host: target.hostname,
+        port: target.port,
+        path: target.pathname + target.search,
+        method: creq.method,
+        headers: creq.headers
+      }, (proxyRes) => {
+        cres.writeHead(proxyRes.statusCode, proxyRes.headers)
+        proxyRes.pipe(cres)
+      })
+      creq.pipe(proxyReq)
+    })
     pserver.on('connect', (req, clientSocket, head) => {
       proxyUsed = true
       const [targetHost, targetPort] = req.url.split(':')


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
Previously undici ProxyAgent/EnvHttpProxyAgent tunneled all proxied requests via CONNECT. As of nodejs/undici#5116 (v8.7.0), plain HTTP requests are forwarded to the proxy in absolute-form (a normal request), and only HTTPS still uses a CONNECT tunnel. The node-gyp test proxy only listened for the connect event, so the forwarded HTTP request got no response and the test hung to the 30s timeout.
