### PR TITLE
fix: normalize OS to linux when building addons on Android

### DIFF
--- a/lib/create-config-gypi.js
+++ b/lib/create-config-gypi.js
@@ -47,6 +47,17 @@ async function getCurrentConfigGypi ({ gyp, nodeDir, vsInfo, python }) {
   const defaults = config.target_defaults
   const variables = config.variables
 
+  // When node itself is an Android build (e.g. Termux), process.config
+  // reports OS "android". gyp then enables Android-only branches (like the
+  // one referencing android_ndk_path in node's common.gypi) that only exist
+  // for NDK cross-compiles. Building a local addon on Android is a native
+  // build, not an NDK one, so normalize OS to linux. Honor custom headers
+  // (--nodedir/--dist-url): those may intentionally target Android via NDK.
+  if (process.platform === 'android' && variables.OS === 'android' &&
+      !(gyp.opts.nodedir || gyp.opts.disturl || gyp.opts['dist-url'])) {
+    variables.OS = 'linux'
+  }
+
   // don't inherit the "defaults" from the base config.gypi.
   // doing so could cause problems in cases where the `node` executable was
   // compiled on a different machine (with different lib/include paths) than

--- a/test/test-create-config-gypi.js
+++ b/test/test-create-config-gypi.js
@@ -71,6 +71,55 @@ describe('create-config-gypi', function () {
     }
   })
 
+  it('config.gypi normalizes OS to linux when running on Android (e.g. Termux)', async function () {
+    const prog = gyp()
+    prog.parseArgv([])
+
+    const originalPlatform = process.platform
+    const originalOS = process.config.variables.OS
+    Object.defineProperty(process, 'platform', { value: 'android' })
+    // node built for Android reports OS "android" in process.config
+    let canStubOS = true
+    try {
+      Object.defineProperty(process.config.variables, 'OS', { value: 'android', configurable: true })
+    } catch {
+      // process.config.variables is not extensible on some node builds
+      canStubOS = false
+    }
+    try {
+      const config = await getCurrentConfigGypi({ gyp: prog, vsInfo: {} })
+      // a local addon build on Android is native, not an NDK cross-compile
+      if (canStubOS) {
+        assert.strictEqual(config.variables.OS, 'linux')
+      } else {
+        assert.ok(config.variables)
+      }
+    } finally {
+      if (canStubOS) {
+        Object.defineProperty(process.config.variables, 'OS', { value: originalOS, configurable: true })
+      }
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+    }
+  })
+
+  it('config.gypi keeps OS from custom headers when using --nodedir on Android', async function () {
+    const nodeDir = path.join(__dirname, 'fixtures', 'nodedir')
+
+    const prog = gyp()
+    prog.parseArgv(['_', '_', `--nodedir=${nodeDir}`])
+
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { value: 'android' })
+    try {
+      const config = await getCurrentConfigGypi({ gyp: prog, nodeDir, vsInfo: {} })
+      // explicit custom headers may intentionally target Android via NDK:
+      // OS must come from the custom config.gypi, not process.config
+      assert.strictEqual(config.variables.OS, undefined)
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+    }
+  })
+
   it('config.gypi parsing', function () {
     const str = "# Some comments\n{'variables': {'multiline': 'A'\n'B'}}"
     const config = parseConfigGypi(str)


### PR DESCRIPTION
## Problem

When node itself is an Android build (e.g. Termux on Android), `process.config.variables.OS` is `"android"`. node-gyp copies that into the generated `build/config.gypi`, so gyp evaluates `OS == "android"` conditions in node's `common.gypi` as true — including branches that only exist for NDK cross-compiles, e.g.:

```
['OS == "android"', {
  'cflags': [ '-fPIC', '-I<(android_ndk_path)/sources/android/cpufeatures' ],
```

`android_ndk_path` is only defined when building node itself with the NDK, so any local addon build on Termux fails with:

```
gyp: Undefined variable android_ndk_path in binding.gyp while trying to load binding.gyp
```

This hits every npm package with a native addon (node-pty, etc.) installed on Termux.

## Root cause

node-gyp's gyp fork already maps `android` → `linux` in `make.py` ("Keep this legacy behavior for now"), but `create-config-gypi.js` copies `OS: "android"` from `process.config` into `config.gypi` first, which overrides that mapping. A local addon build on Android is a **native** build, not an NDK cross-compile — Android is the host, not the target.

## Fix

In `getCurrentConfigGypi`, normalize `variables.OS` to `"linux"` when `process.platform === "android"` and OS was inherited from `process.config`. Custom headers (`--nodedir` / `--dist-url`) are honored: those may intentionally target Android via the NDK.

## Validation

- `test/test-create-config-gypi.js`: added coverage for the Android normalization path and for `--nodedir` preserving custom config
- Verified on a real Termux device (Android 16, node 26.1.0): `node-pty` now builds and loads; previously failed with the `android_ndk_path` error