### PR TITLE
refactor: replace tar extraction with modern-tar

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -1,12 +1,13 @@
 'use strict'
 
-const { createWriteStream, promises: fs } = require('graceful-fs')
+const { createReadStream, createWriteStream, promises: fs } = require('graceful-fs')
 const os = require('os')
 const { backOff } = require('exponential-backoff')
-const tar = require('tar')
+const { unpackTar } = require('modern-tar/fs')
 const path = require('path')
 const { Transform, promises: { pipeline } } = require('stream')
 const crypto = require('crypto')
+const { createGunzip } = require('zlib')
 const log = require('./log')
 const semver = require('semver')
 const { download } = require('./download')
@@ -173,7 +174,6 @@ async function install (gyp, argv) {
 
     // now download the node tarball
     const tarPath = gyp.opts.tarball
-    let extractErrors = false
     let extractCount = 0
     const contentShasums = {}
     const expectShasums = {}
@@ -192,10 +192,11 @@ async function install (gyp, argv) {
       return isValid
     }
 
-    function onwarn (code, message) {
-      extractErrors = true
-      log.error('error while extracting tarball', code, message)
-    }
+    const extract = () => unpackTar(tarExtractDir, {
+      strict: true,
+      strip: 1,
+      filter: header => isValid(header.name)
+    })
 
     // download the tarball and extract!
     // Omitted on Windows if only new node.lib is required
@@ -208,13 +209,8 @@ async function install (gyp, argv) {
     try {
       if (shouldDownloadTarball) {
         if (tarPath) {
-          await tar.extract({
-            file: tarPath,
-            strip: 1,
-            filter: isValid,
-            onwarn,
-            cwd: tarExtractDir
-          })
+          // modern-tar recommends 256 KiB chunks for optimal extraction performance
+          await pipeline(createReadStream(tarPath, { highWaterMark: 256 * 1024 }), createGunzip(), extract())
         } else {
           try {
             const res = await download(gyp, release.tarballUrl)
@@ -231,12 +227,8 @@ async function install (gyp, argv) {
                 contentShasums[filename] = checksum
                 log.verbose('content checksum', filename, checksum)
               }),
-              tar.extract({
-                strip: 1,
-                cwd: tarExtractDir,
-                filter: isValid,
-                onwarn
-              })
+              createGunzip(),
+              extract()
             )
           } catch (err) {
           // something went wrong downloading the tarball?
@@ -250,7 +242,7 @@ async function install (gyp, argv) {
         }
 
         // invoked after the tarball has finished being extracted
-        if (extractErrors || extractCount === 0) {
+        if (extractCount === 0) {
           throw new Error('There was a fatal problem while downloading/extracting the tarball')
         }
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "nopt": "^10.0.0",
     "proc-log": "^7.0.0",
     "semver": "^7.3.5",
-    "tar": "^7.5.4",
+    "modern-tar": "^0.8.4",
     "tinyglobby": "^0.2.12",
     "undici": "^8.4.1",
     "which": "^7.0.0"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

Replaces `tar` with [`modern-tar`](https://www.npmjs.com/package/modern-tar). Cuts dependencies from 6 --> 1. 4MB on disk --> 95KB on disk.

<img width="1253" height="670" alt="image" src="https://github.com/user-attachments/assets/700f9e86-a8e7-4a0e-a918-141d13c1a7a3" />

_Ref: https://npmgraph.js.org/?q=node-gyp#select=tar%407.5.22_

Similar to the motivation of #3133. Thanks for everyone's time!


