### PR TITLE
fix(ci): do not ruff format gyp example code in markdown files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,8 @@ jobs:
     - uses: astral-sh/ruff-action@v4.1.0
       with:
         args: "check --select=E,F,PLC,PLE,UP,W,YTT --ignore=E721,PLC0206,PLC0415,PLC1901,S101,UP031 --target-version=py39"
-    - run: ruff format --check --diff
+    # Do not ruff format gyp example code in markdown files.
+    - run: ruff format --check --diff --config="extend-exclude=['README.md', 'docs/Linking-to-OpenSSL.md']"
 
   lint-js:
     name: Lint JS


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the requirements below.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Describe the change -->

[`ruff format`](https://docs.astral.sh/ruff/formatter) is modifying Gyp examples in Markdown files to match Python standards.
This is Gyp code, so it does not benefit from adapting to Python coding standards.