### PR TITLE
fix(ci): test on npm@12

### DIFF
--- a/.github/workflows/lint-commit.yml
+++ b/.github/workflows/lint-commit.yml
@@ -18,6 +18,7 @@ jobs:
     - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 22.x
+    - run: npm install --global npm@12
     - run: npm install
     - name: Lint first PR commit message
       run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,5 +43,5 @@ jobs:
         with:
           node-version: lts/*
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install npm@11 -g # Use npm@11 to publish with OIDC
+      - run: npm install npm@12 -g # Use npm@12 to publish with OIDC
       - run: npm publish --provenance --access public

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,7 @@ jobs:
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 22.x
+    - run: npm install --global npm@12
     - name: Install Dependencies
       run: npm install
     - name: Lint
@@ -56,6 +57,7 @@ jobs:
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 22.x
+    - run: npm install --global npm@12
     - name: Install Dependencies
       run: npm install
     - name: Check Engines
@@ -77,6 +79,7 @@ jobs:
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 22.x
+    - run: npm install --global npm@12
     - name: Update npm
       run: |
         npm install npm@~11.10.0 -g # Workaround for https://github.com/npm/cli/issues/9151
@@ -135,6 +138,7 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node }}
+      - run: npm install --global npm@12
       - name: Use Python ${{ matrix.python }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:


### PR DESCRIPTION
### Do not merge.  This is just a temporary test to find npm@12 issues before our users do.
https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/

Added a step to install npm version 12 globally in multiple job sections.
```diff
+     - run: npm install --global npm@12
```

Related to:
* nodejs/gyp-next#356

# Proof of the need for:
* #3261 

<!--
Thank you for your pull request. Please review the requirements below.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Describe the change -->

