### PR TITLE
fix: accept --msvs_version as the README documents it

### DIFF
--- a/lib/node-gyp.js
+++ b/lib/node-gyp.js
@@ -58,6 +58,9 @@ class Gyp extends EventEmitter {
     C: '--directory',
     debug: '--debug',
     j: '--jobs',
+    // the README documents --msvs_version, but the option is declared as
+    // msvs-version, and only npm_config_* env vars get underscores converted
+    msvs_version: '--msvs-version',
     silly: '--loglevel=silly',
     verbose: '--loglevel=verbose',
     silent: '--loglevel=silent'

--- a/test/test-options.js
+++ b/test/test-options.js
@@ -69,4 +69,34 @@ describe('options', function () {
 
     assert.strictEqual(g.opts['msvs-version'], '2017')
   })
+
+  it('--msvs_version on the command line, as the README documents it', () => {
+    // the environment is read after argv, so the previous test would win here
+    delete process.env.npm_config_msvs_version
+
+    const g = gyp()
+    g.parseArgv(['node', 'node-gyp', 'configure', '--msvs_version=2022'])
+
+    assert.strictEqual(g.opts['msvs-version'], '2022')
+    assert.deepStrictEqual(g.opts.argv.remain, ['configure'])
+  })
+
+  it('--msvs_version with a separate value', () => {
+    delete process.env.npm_config_msvs_version
+
+    const g = gyp()
+    g.parseArgv(['node', 'node-gyp', 'configure', '--msvs_version', '2022'])
+
+    assert.strictEqual(g.opts['msvs-version'], '2022')
+    assert.deepStrictEqual(g.opts.argv.remain, ['configure'])
+  })
+
+  it('--msvs-version on the command line', () => {
+    delete process.env.npm_config_msvs_version
+
+    const g = gyp()
+    g.parseArgv(['node', 'node-gyp', 'configure', '--msvs-version=2022'])
+
+    assert.strictEqual(g.opts['msvs-version'], '2022')
+  })
 })


### PR DESCRIPTION
`--msvs_version` has no effect on the command line. The option is declared as `msvs-version` in `lib/node-gyp.js:37` and read as `gyp.opts['msvs-version']` in `lib/configure.js:112`, but the README documents the underscore spelling in three places (lines 134, 137 and 230). nopt puts the underscore form in `opts.msvs_version`, which nothing reads, so the value is dropped and left behind in `argv.remain`.

Running node-gyp's own nopt config:

```
--msvs_version=2022      opts['msvs-version'] = undefined   argv.remain = ['configure', '2022']
--msvs-version=2022      opts['msvs-version'] = '2022'
```

The environment path has always worked, which is why this went unnoticed. `lib/node-gyp.js:154` converts underscores to dashes, but only for `npm_config_*` variables, so `npm_config_msvs_version` lands correctly while argv does not. The only existing test for this option sets the environment variable, so argv was never covered.

This came in with #2644, which renamed the key from `msvs_version` to `'msvs-version'` and fixed the environment path.

I went with a nopt shorthand so both spellings reach the same option and the README stays accurate. The alternative would be changing the README to document the dash spelling, but that breaks anyone currently passing the underscore form through a build script, and the shorthand keeps both working.

The two new tests for the underscore spelling fail without the change. The third, for the dash spelling, passes either way and is there to keep the existing behaviour pinned.

Ran on Windows: `test/test-options.js` 6 passing, full `npm test` 112 passing, `standard` clean.

Related: #3251, where this flag being ignored has been part of the confusion.

---

Disclosure: written with AI assistance. The parser output above is from a run on my machine.
