### PR TITLE
docs: use Visual Studio 2026 in Windows setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Depending on your operating system, you will need to install:
 
 ### On Windows
 
-Install tools with [Chocolatey](https://chocolatey.org):
+Install tools with [Chocolatey](https://community.chocolatey.org/) using the
+[visualstudio2026-workload-vctools](https://community.chocolatey.org/packages/visualstudio2026-workload-vctools) package:
 ``` bash
 choco install python visualstudio2026-workload-vctools -y
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Depending on your operating system, you will need to install:
 
 Install tools with [Chocolatey](https://chocolatey.org):
 ``` bash
-choco install python visualstudio2022-workload-vctools -y
+choco install python visualstudio2026-workload-vctools -y
 ```
 
 Or install and configure Python and Visual Studio tools manually:


### PR DESCRIPTION
##### Description of change

Update the Windows Chocolatey installation command in README.md from `visualstudio2022-workload-vctools` to `visualstudio2026-workload-vctools` so new installations use the latest Visual Studio generation. Point the Chocolatey link to the community site and link the workload package directly from the installation instructions.

The [Visual Studio 2026 workload package](https://community.chocolatey.org/packages/visualstudio2026-workload-vctools) is available, and node-gyp already supports Visual Studio 2026 detection.

##### Validation

- `npm run lint` passed.
- `NODE_GYP_NULL_LOGGER=true npm exec -- mocha --timeout 30000 --bail test/test-find-visualstudio.js` passed: 43 tests, including Visual Studio 2026 detection.
- `git diff --check` passed.
- The Chocolatey installation command was not executed; validation ran on Linux.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows the conventional commit guidelines
