### PR TITLE
test: fix missing cb in fs.unlink

### DIFF
--- a/test/test-addon.js
+++ b/test/test-addon.js
@@ -111,7 +111,7 @@ describe('addon', function () {
     ]
     const [err, stdout, logLines] = await execFile(cmd)
     try {
-      fs.unlink(testNodeDir)
+      fs.unlinkSync(testNodeDir)
     } catch (err) {
       assert.fail(err)
     }


### PR DESCRIPTION
Fix CI failure in https://github.com/nodejs/gyp-next/pull/357.

```
  1) addon
       build simple addon in path with non-ascii characters:
     TypeError [ERR_INVALID_ARG_TYPE]: The "cb" argument must be of type function. Received undefined
      at makeCallback (node:fs:186:3)
      at Object.unlink (node:fs:1989:14)
      at Context.<anonymous> (test\test-addon.js:114:10)
      at process.processTicksAndRejections (node:internal/process/task_queues:104:5)

```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm install && npm run lint && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
