### PR TITLE
fix: add Python 3.15 and update OS versions in tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,13 +107,13 @@ jobs:
       max-parallel: 11
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python: ["3.10", "3.12", "3.14"]
+        python: ["3.10", "3.12", "3.14", "3.15"]
         node: [22.x, 24.x, 26.x]
         include:
-          - os: macos-15-intel  # macOS on Intel
+          - os: macos-26-intel  # macOS on Intel
             python: "3.14"
             node: 26.x
-          - os: ubuntu-24.04-arm  # Ubuntu on ARM
+          - os: ubuntu-26.04-arm  # Ubuntu on ARM
             python: "3.14"
             node: 26.x
           - os: windows-11-arm  # Windows on ARM

--- a/.github/workflows/visual-studio.yml
+++ b/.github/workflows/visual-studio.yml
@@ -14,7 +14,6 @@ jobs:
   visual-studio:
     strategy:
       fail-fast: false
-      max-parallel: 8
       matrix:
         include:
           - os: windows-2022


### PR DESCRIPTION
fix: add Python 3.15 and update OS versions in tests.yml

Failures on Python 3.15 release candidate 2.  The production release is scheduled for Oct. 1st.
* https://peps.python.org/pep-0790

Related to the failures at:
* nodejs/gyp-next#357


<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm run lint && npm test` passes
- [x] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

