### PR TITLE
test: fix non-ASCII addon cache path

### DIFF
--- a/test/test-addon.js
+++ b/test/test-addon.js
@@ -61,6 +61,11 @@ describe('addon', function () {
   })
 
   it('build simple addon in path with non-ascii characters', async function () {
+    // On cp1252 Windows with UTF-8 mode disabled, the fixture cannot print the
+    // U+012B in "Latīna" to its stdout pipe, so this guard skips the test.
+    // Python 3.15 enables UTF-8 mode by default (PEP 686): printing succeeds,
+    // while getdefaultlocale() still reports cp1252, selecting the Latīna case.
+    // Python 3.14 with PYTHONUTF8=1 also exercises this previously skipped path.
     if (!checkCharmapValid()) {
       return this.skip('python console app can\'t encode non-ascii character.')
     }
@@ -87,44 +92,48 @@ describe('addon', function () {
     }
     const config = JSON.parse(data.replace(/#.+\n/, ''))
     const nodeDir = config.variables.nodedir
-    const testNodeDir = path.join(addonPath, testDirName)
-    // Create symbol link to path with non-ascii characters
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'node-gyp-addon-'))
+    const testDevDir = path.join(tempDir, testDirName)
     try {
-      fs.symlinkSync(nodeDir, testNodeDir, 'dir')
-    } catch (err) {
-      switch (err.code) {
-        case 'EEXIST': break
-        case 'EPERM':
-          return assert.fail(err, null, 'Please try to running console as an administrator')
-        default:
-          return assert.fail(err)
+      // The downloaded SDK uses <cache>/<version>/<arch>/node.lib on Windows.
+      // Passing nodeDir via --nodedir instead selects $(Configuration)/node.lib
+      // inside that version directory, e.g. Release/node.lib, which is absent.
+      // --devdir expects the cache root: link nodeDir's parent so node-gyp keeps
+      // the <version>/<arch>/node.lib layout under the non-ASCII path.
+      try {
+        fs.symlinkSync(path.dirname(nodeDir), testDevDir, 'dir')
+      } catch (err) {
+        switch (err.code) {
+          case 'EEXIST': break
+          case 'EPERM':
+            return assert.fail(err, null, 'Please try to running console as an administrator')
+          default:
+            return assert.fail(err)
+        }
       }
-    }
 
-    const cmd = [
-      nodeGyp,
-      'rebuild',
-      '-C',
-      addonPath,
-      '--loglevel=verbose',
-      '-nodedir=' + testNodeDir
-    ]
-    const [err, stdout, logLines] = await execFile(cmd)
-    try {
-      fs.unlinkSync(testNodeDir)
-    } catch (err) {
-      assert.fail(err)
+      const cmd = [
+        nodeGyp,
+        'rebuild',
+        '-C',
+        addonPath,
+        '--loglevel=verbose',
+        '--devdir=' + testDevDir
+      ]
+      const [err, stdout, logLines] = await execFile(cmd)
+      if (err) {
+        console.log('-- build stdout (MSBuild/make output) --')
+        console.log(stdout)
+        console.log('-- build stderr (gyp logs) --')
+        console.log(logLines.join('\n'))
+      }
+      const lastLine = logLines[logLines.length - 1]
+      assert.strictEqual(err, null)
+      assert.strictEqual(lastLine, 'gyp info ok', 'should end in ok')
+      assert.strictEqual(runHello(), 'world')
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
     }
-    if (err) {
-      console.log('-- build stdout (MSBuild/make output) --')
-      console.log(stdout)
-      console.log('-- build stderr (gyp logs) --')
-      console.log(logLines.join('\n'))
-    }
-    const lastLine = logLines[logLines.length - 1]
-    assert.strictEqual(err, null)
-    assert.strictEqual(lastLine, 'gyp info ok', 'should end in ok')
-    assert.strictEqual(runHello(), 'world')
   })
 
   it('addon works with renamed host executable', async function () {


### PR DESCRIPTION
The non-ASCII addon test passes a downloaded SDK version directory through `--nodedir`. On Windows this makes node-gyp look for `Release/node.lib`, while the downloaded library is stored in `<arch>/node.lib`, causing `LNK1104`.

Python 3.15 enables UTF-8 mode by default, allowing the `Latīna` fixture to pass the encoding guard on cp1252 Windows and exposing this existing path mismatch. Older Python versions with UTF-8 mode disabled skip the test when the fixture cannot print U+012B.

Link the cache root through the non-ASCII path and pass it with `--devdir`, so node-gyp resolves `<version>/<arch>/node.lib`. Keep `Latīna` and the existing symlink error handling, and clean up the temporary directory in `finally`.

Related to #3369 and nodejs/gyp-next#357.

##### Validation

- `npm run lint` passed.
- `NODE_OPTIONS=--dns-result-order=ipv4first npm test`: 114 passing, 6 pending. IPv4-first is needed for localhost resolution in the local container.
- Local addon tests with the encoding-name selection overridden to `cp1252`: 3 passing, no skips, including actual build/load through `Latīna`. Verified `EEXIST`, `EPERM`, other symlink errors, and temporary-directory cleanup with fault injection.
- [Windows validation](https://github.com/gengjiawen/node-gyp/actions/runs/34447540393) on Node.js 24 with Python 3.14 (`PYTHONUTF8=1`) and Python 3.15 (default mode): each had 3 addon tests passing, no skips. This run used revision `5fc9412`; the final revision keeps the same successful build path and adds explanatory comments and the original symlink error handling.

##### Checklist

- [x] Lint and tests pass as described above.
- [x] The existing regression test is updated.
- [x] Commit message follows the commit guidelines.
